### PR TITLE
Add configurable data folder option

### DIFF
--- a/ABOUT.md
+++ b/ABOUT.md
@@ -67,7 +67,7 @@ Smart Citizen also bundles upstream tooling from:
 ### 🛡️ Data Management
 - **Automatic Backups**: Timestamped backups created before applying changes to your game (up to 5 per channel)
 - **Registry Persistence**: All paths and preferences saved securely in Windows Registry
-- **Documents Storage**: Your custom edits stored under `Documents\Smart Citizen\<channel>\` (one isolated subtree per Star Citizen channel) for safe persistence across sessions
+- **Configurable Data Storage**: Your custom edits are stored under `<data folder>\<channel>\` (default `Documents\Smart Citizen`, one isolated subtree per Star Citizen channel) for safe persistence across sessions
 - **In-App Log Viewer**: Real-time application log with level filter, auto-scroll, and an Export button for bug reports
 - **Auto-Update Notifier**: Smart Citizen checks GitHub Releases periodically and surfaces a non-blocking notification when a newer installer is available
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,7 +71,7 @@ Entry point: `src/main.py`. The app has two main layers:
 - `string_model.py` — `StringEntry` dataclass with category extraction from key prefixes.
 - `ini_parser.py` — Line-by-line INI parsing (splits on first `=`), source loading via `load_sources_from_settings()`, and `load_overrides(target_path)` for reading `user.ini` back as a `dict[str, str]`.
 - `ini_merger.py` — Merge engine: `merge_sources_by_hierarchy(sources_dict, hierarchy, user_overrides)`. Sources merge sequentially; user overrides always win.
-- `settings.py` — `AppSettings` class wrapping QSettings (Windows Registry). All user data stored under `Documents\Smart Citizen\{active_channel}\`. Critical: Registry is the single source of truth for all paths and preferences. Also owns canonical paths (`get_user_data_dir()`, `get_cache_dir()`, `get_user_ini_path()`, `get_backups_dir()`) and handles automatic migrations: legacy `overrides.ini` → `user.ini`, `AppData\Roaming\...` → `Documents\...`, and the 0.9.3+ flat layout → per-channel layout (`migrate_game_path_to_channel_layout()`).
+- `settings.py` — `AppSettings` class wrapping QSettings (Windows Registry). User data lives under the configured data root (default `Documents\Smart Citizen\`) plus `{active_channel}\`. Critical: Registry is the single source of truth for all paths and preferences. Also owns canonical paths (`get_user_data_dir()`, `get_cache_dir()`, `get_user_ini_path()`, `get_backups_dir()`) and handles automatic migrations: legacy `overrides.ini` → `user.ini`, `AppData\Roaming\...` → the configured data root, and the 0.9.3+ flat layout → per-channel layout (`migrate_game_path_to_channel_layout()`).
 - `updater.py` — Per-source GitHub downloads. Drives the auto-update workers that refresh each cached source INI (`base.ini`, `contracts.ini`, etc.) from its configured GitHub URL.
 - `app_updater.py` — *Separate* from `updater.py`. Polls `GET /repos/Osiris-DevWorks/smart-citizen/releases/latest` and compares `tag_name` to the local `VERSION.TXT` to surface a "new installer available" prompt. Runs on a `QThread`; `MainWindow` caps auto-checks to once per 6 hours via a registry timestamp to stay under GitHub's 60-req/hr unauthenticated limit.
 - `pak_extractor.py` — P4K extraction pipeline: `unp4k.exe` (extracts Game2.dcb) → `unforge.exe` (converts to entity XMLs). After unforge writes the full DataForge tree to a temp dir, `_copy_filtered_records()` copies only the subtrees in `DATAFORGE_KEEP_SUBPATHS` (the ones the generator actually reads) to the persistent cache — halves cache file count and cuts copy/rmtree wall time. Adding a new read path in the generator requires adding it to `DATAFORGE_KEEP_SUBPATHS`; `tests/test_pak_extraction.py::TestDataForgeKeepList` locks the contract.
@@ -124,13 +124,13 @@ Favorites prepend a configurable prefix (default `*`) to `custom_value`. The pre
 | What | Where |
 |------|-------|
 | Settings | Windows Registry: `HKEY_CURRENT_USER\Software\Osiris DevWorks\Smart Citizen` |
-| User data root | `Documents\Smart Citizen\` (resolved via registry for OneDrive support) |
-| **Per-channel data** | `Documents\Smart Citizen\{LIVE|PTU|EPTU|HOTFIX|TECH-PREVIEW}\` — 0.9.3+ nests user.ini / cache / backups / dataforge under the active channel so each SC channel is isolated. Migrator: `AppSettings.migrate_game_path_to_channel_layout()`. |
-| User overrides | `Documents\Smart Citizen\{active_channel}\user.ini` (legacy `overrides.ini`, auto-migrated) |
-| Cached sources | `Documents\Smart Citizen\{active_channel}\cache\` (`base.ini`, `contracts.ini`, etc.) |
-| DataForge cache | `Documents\Smart Citizen\{active_channel}\cache\dataforge\` (entity XMLs from Data.p4k) |
-| Enhancement INIs | `Documents\Smart Citizen\{active_channel}\cache\` (`ships_desc_enhancements.ini`, `components_desc_enhancements.ini`, `ship_weapons_desc_enhancements.ini`, `fps_weapons_desc_enhancements.ini`, `mission_rewards_enhancements.ini`, `commodity_crafting_enhancements.ini`) |
-| Backups | `Documents\Smart Citizen\{active_channel}\backups\` (max 5, oldest auto-deleted) |
+| User data root | Configurable via `user_data_dir` (alias `UserDataDir` is also read); defaults to `Documents\Smart Citizen\` |
+| **Per-channel data** | `{user_data_root}\{LIVE|PTU|EPTU|HOTFIX|TECH-PREVIEW}\` — 0.9.3+ nests user.ini / cache / backups / dataforge under the active channel so each SC channel is isolated. Migrator: `AppSettings.migrate_game_path_to_channel_layout()`. |
+| User overrides | `{user_data_root}\{active_channel}\user.ini` (legacy `overrides.ini`, auto-migrated) |
+| Cached sources | `{user_data_root}\{active_channel}\cache\` (`base.ini`, `contracts.ini`, etc.) |
+| DataForge cache | `{user_data_root}\{active_channel}\cache\dataforge\` (entity XMLs from Data.p4k) |
+| Enhancement INIs | `{user_data_root}\{active_channel}\cache\` (`ships_desc_enhancements.ini`, `components_desc_enhancements.ini`, `ship_weapons_desc_enhancements.ini`, `fps_weapons_desc_enhancements.ini`, `mission_rewards_enhancements.ini`, `commodity_crafting_enhancements.ini`) |
+| Backups | `{user_data_root}\{active_channel}\backups\` (max 5, oldest auto-deleted) |
 | Game file | `{sc_install_root}\{active_channel}\data\Localization\english\global.ini` — resolved via `AppSettings.get_global_ini_path()` |
 | P4K tools | `assets/unp4k/` (`unp4k.exe`, `unforge.exe`) |
 | DataForge patches | `patches/` (JSON files mirroring DataForge layout; applied post-extraction) |
@@ -179,11 +179,11 @@ Discord notification is automatic via GitHub Actions (`scripts/discord_notify.py
 ## Debugging
 
 - **Registry**: `regedit` → `HKEY_CURRENT_USER\Software\Osiris DevWorks\Smart Citizen` (live tree). Pre-0.9 installs leave a parallel `Osiris DevWorks\SC Localization Editor` tree that the in-app migrator drains on next launch.
-- **User data path**: If `Documents` is redirected (OneDrive), Registry stores the resolved path under `UserDataDir`; delete that value to reset and auto-detect on next run.
+- **User data path**: If `Documents` is redirected (OneDrive), Registry stores the override under `user_data_dir` (legacy/manual alias `UserDataDir` is also honored); delete that value to reset and auto-detect on next run.
 - **Threading hangs**: Check `worker.quit()` + `worker.wait()` are called in finished slots. Use Log Tab to watch for blockages.
 - **File encoding**: Parser expects UTF-8; BOM or other encodings fail silently. Ensure cache files are UTF-8 no-BOM.
 - **GitHub API rate limit**: Unauthenticated, 60 requests/hour per IP. Check updater logs if auto-update stalls.
-- **Overrides not loading**: Verify `Documents\Smart Citizen\{active_channel}\user.ini` exists with `key=value` format (no sections). If you find a legacy `Documents\SC Localization Editor\overrides.ini`, both the rename (`overrides.ini` → `user.ini`) and the channel-nesting migration are handled lazily by `AppSettings` — launching the app once should drain them.
+- **Overrides not loading**: Verify `{user_data_root}\{active_channel}\user.ini` exists with `key=value` format (no sections). If you find a legacy `Documents\SC Localization Editor\overrides.ini`, both the rename (`overrides.ini` → `user.ini`) and the channel-nesting migration are handled lazily by `AppSettings` — launching the app once should drain them.
 - **Performance**: Use `@timed` decorator on slow functions and check elapsed times in DEBUG logs.
 - **Test isolation**: Each test should not depend on Registry state; mock `AppSettings` or use conftest fixtures.
 

--- a/HELP.md
+++ b/HELP.md
@@ -15,7 +15,7 @@ When extraction finishes, the extracted `base.ini` is loaded into the table auto
 - Double-click any **Custom Value** cell to edit text.
 - **Default Value** — original text from `Data.p4k`-extracted `base.ini`.
 - **Current Value** — the effective value before your override (base + any imported INI layers).
-- **Custom Value** — your personal edit. Saved automatically on every change and persisted to `Documents\Smart Citizen\<channel>\user.ini` (each Star Citizen channel — LIVE, PTU, EPTU, HOTFIX, TECH-PREVIEW — has its own isolated overrides).
+- **Custom Value** — your personal edit. Saved automatically on every change and persisted to `<data folder>\<channel>\user.ini` (the data folder defaults to `Documents\Smart Citizen`, and each Star Citizen channel — LIVE, PTU, EPTU, HOTFIX, TECH-PREVIEW — has its own isolated overrides).
 - Edits are highlighted with a **Modified** status (green).
 
 ## 3. Preview Pane
@@ -57,7 +57,7 @@ Use the **Category** filter to focus on one domain:
 
 ## 7. Apply Changes to Game
 
-Click **Apply to Game** to write your edits to the game installation. A timestamped backup of the current `global.ini` is created in `Documents\Smart Citizen\<channel>\backups\` before anything is overwritten.
+Click **Apply to Game** to write your edits to the game installation. A timestamped backup of the current `global.ini` is created in `<data folder>\<channel>\backups\` before anything is overwritten.
 
 ## 8. Restore a Backup
 
@@ -65,7 +65,7 @@ Click **Restore Backup** to revert to a previous version. Smart Citizen keeps up
 
 ## 9. Clear Localization
 
-Click **Clear Localization** to delete the custom `global.ini` from the game directory, reverting the game to its default (vanilla) text. Your saved overrides in `Documents\Smart Citizen\<channel>\user.ini` are untouched and can be re-applied anytime.
+Click **Clear Localization** to delete the custom `global.ini` from the game directory, reverting the game to its default (vanilla) text. Your saved overrides in `<data folder>\<channel>\user.ini` are untouched and can be re-applied anytime.
 
 ## 10. Import INI
 
@@ -73,7 +73,7 @@ Use **Import INI** in the **Config** tab to fold an existing INI file into your 
 
 ## 11. After Game Updates
 
-When Star Citizen updates, your edits are preserved in `Documents\Smart Citizen\<channel>\user.ini`. Re-run **Extract from Data.p4k** to pull fresh stock strings from the patched game — the table reloads automatically and your customizations re-apply on top.
+When Star Citizen updates, your edits are preserved in `<data folder>\<channel>\user.ini`. Re-run **Extract from Data.p4k** to pull fresh stock strings from the patched game — the table reloads automatically and your customizations re-apply on top.
 
 ## Enhancements Tab
 
@@ -86,6 +86,7 @@ When Star Citizen updates, your edits are preserved in `Documents\Smart Citizen\
 
 - **Appearance** — pick the app theme (see below).
 - **Star Citizen Installation** — path to your LIVE directory; auto-detected at install time, editable here.
+- **Smart Citizen Data** — folder for `user.ini`, caches, DataForge extraction, generated enhancement INIs, and backups. Defaults to `Documents\Smart Citizen`; move it off OneDrive if extraction or cache cleanup is slow.
 - **Base Localization (P4K Extraction)** — click **Extract from Data.p4k** to unpack stock localization plus DataForge entity data directly from your installed game. This is the sole source for base strings and enhancement data.
 - **Import INI** — fold an existing INI file into your overrides via the conflict-resolution dialog.
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Download the **`SmartCitizen-{VERSION}-Setup.exe`** installer and run it. The ap
 ## Usage
 
 ### First Run
-1. The app creates `Documents\Smart Citizen\<channel>\` (one subdir per Star Citizen channel) for user data — cache, backups, `user.ini`.
+1. The app creates `<data folder>\<channel>\` for user data — cache, backups, `user.ini`. The default data folder is `Documents\Smart Citizen`, and it can be changed in the Config tab.
 2. Open the Config tab and click **Extract from Data.p4k** to unpack stock localization plus DataForge entity data from your installed game. When extraction finishes, sources merge by hierarchy and the strings load into the table automatically.
 3. The guided tutorial auto-runs the first time you launch a new version, walking you through the rest.
 
@@ -94,6 +94,7 @@ All settings are stored in Windows Registry under:
 The Config tab lets you set:
 - **Star Citizen install path** (the SC root folder containing `LIVE/`, `PTU/`, etc. — auto-detected at install time)
 - **Active channel** (LIVE / PTU / EPTU / HOTFIX / TECH-PREVIEW)
+- **Smart Citizen data folder** (where `user.ini`, cache, DataForge extraction, enhancement INIs, and backups live)
 - **Theme**
 - **Data sources**: enable/disable, drag-drop merge priority
 - **Import INI**: fold an external `.ini` into your overrides
@@ -102,7 +103,7 @@ The Enhancements tab lets you toggle each enhancement category (ship stats, weap
 
 ### Data Storage
 
-All per-user data lives under `Documents\Smart Citizen\<channel>\`, where `<channel>` is one of `LIVE`, `PTU`, `EPTU`, `HOTFIX`, `TECH-PREVIEW`:
+All per-user data lives under `<data folder>\<channel>\`, where `<data folder>` defaults to `Documents\Smart Citizen` and `<channel>` is one of `LIVE`, `PTU`, `EPTU`, `HOTFIX`, `TECH-PREVIEW`:
 
 - **Your edits**: `user.ini`
 - **Cached sources & extracted DataForge**: `cache\` (`base.ini`, `cache\dataforge\`, and the generated `*_enhancements.ini` files)

--- a/TESTPLAN.md
+++ b/TESTPLAN.md
@@ -16,6 +16,7 @@ Run against the built `dist/SmartCitizen-1.0.0-Setup.exe`.
 - [ ] **Upgrade 0.9.3 → 1.0** (reinstall) — no duplicate migrations, no data loss, no zombie uninstall entry
 - [ ] **OneDrive-redirected Documents** — installer's `IsDocsOnOneDrive` page fires; user redirects to local path; `USER_DATA_DIR` override written; app respects it
 - [ ] **OneDrive + override already set** — installer skips the redirect page (`HasDataDirOverride`)
+- [ ] **Config tab data folder override** — change Smart Citizen Data to a custom local path; app reloads, `user.ini`/cache/backups resolve under `<custom>\<channel>\`, and Reset returns to `Documents\Smart Citizen`
 - [ ] **Uninstall → reinstall** — preserves `backups/`, registry settings, and `user.ini` across the cycle
 - [ ] **Uninstall** does NOT delete `Documents\Smart Citizen\backups\`
 
@@ -28,7 +29,7 @@ For **each channel you have installed** (minimum: LIVE; ideally also PTU):
 - [ ] `Channel: {NAME}` shown in status bar; SC-version string carries suffix (e.g. `SC v4.7.176-PTU`)
 - [ ] Switching channels triggers the enhancement-categories prompt **every** switch (not just first)
 - [ ] Switching to an **un-extracted** channel prompts to extract, doesn't load stale data
-- [ ] `Documents\Smart Citizen\{channel}\` has its own `cache/`, `backups/`, `dataforge/`, `user.ini` — zero cross-contamination
+- [ ] `<data folder>\{channel}\` has its own `cache/`, `backups/`, `dataforge/`, `user.ini` — zero cross-contamination
 - [ ] **PTU DataForge extraction succeeds** (validates bundled `unforge.exe` v4.0.83 PTU DCB fix)
 - [ ] `⚠` hint appears when the stored active channel's P4K is missing
 

--- a/scripts/gen_commodity_crafting.py
+++ b/scripts/gen_commodity_crafting.py
@@ -6,13 +6,18 @@ import subprocess, re, os, sys
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from scripts.generate_enhancements_ini import DEFAULT_BASE_INI, parse_ini, write_ini, APP_CACHE_DIR
+from scripts.generate_enhancements_ini import (
+    DEFAULT_BASE_INI, DEFAULT_FORGE_DIR, parse_ini, write_ini, APP_CACHE_DIR,
+)
 
-forge_dir = Path("C:/Users/aabou/OneDrive/Documents/Smart Citizen/cache/dataforge/raw/libs/foundry/records")
-scitem_dir = forge_dir / "entities" / "scitem"
-bp_dir = forge_dir / "crafting" / "blueprints" / "crafting"
+base_ini = Path(sys.argv[1]) if len(sys.argv) > 1 else DEFAULT_BASE_INI
+dataforge_dir = Path(sys.argv[2]) if len(sys.argv) > 2 else DEFAULT_FORGE_DIR
+candidate_records_dir = dataforge_dir / "raw" / "libs" / "foundry" / "records"
+records_dir = candidate_records_dir if candidate_records_dir.exists() else dataforge_dir
+scitem_dir = records_dir / "entities" / "scitem"
+bp_dir = records_dir / "crafting" / "blueprints" / "crafting"
 
-loc = parse_ini(DEFAULT_BASE_INI)
+loc = parse_ini(base_ini)
 
 # Step 1: Resource UUID -> commodity name
 resource_uuids_all = set()
@@ -175,7 +180,8 @@ for commodity in sorted(commodity_items.keys()):
         stats_block = f"== Blueprint Data ==\\n{bp_block}"
         out[desc_key] = f"{base_desc}\\n\\n{stats_block}"
 
-output_path = APP_CACHE_DIR / "commodity_crafting_enhancements.ini"
+output_dir = base_ini.parent if base_ini.parent.exists() else APP_CACHE_DIR
+output_path = output_dir / "commodity_crafting_enhancements.ini"
 write_ini(output_path, out)
 print(f"Written {len(out)} entries to {output_path}")
 

--- a/scripts/generate_enhancements_ini.py
+++ b/scripts/generate_enhancements_ini.py
@@ -48,7 +48,19 @@ def _get_documents_dir() -> Path:
         return Path.home() / "Documents"
 
 
-APP_CACHE_DIR    = _get_documents_dir() / "Smart Citizen" / "cache"
+def _get_default_cache_dir() -> Path:
+    """Resolve the app's active cache directory for standalone CLI defaults."""
+    try:
+        if str(PROJECT_ROOT) not in sys.path:
+            sys.path.insert(0, str(PROJECT_ROOT))
+        from src.utils.settings import AppSettings
+        return AppSettings.get_cache_dir()
+    except (ImportError, OSError) as e:
+        logger.debug(f"Falling back to Documents cache default: {e}")
+        return _get_documents_dir() / "Smart Citizen" / "LIVE" / "cache"
+
+
+APP_CACHE_DIR    = _get_default_cache_dir()
 DEFAULT_BASE_INI = APP_CACHE_DIR / "base.ini"
 DEFAULT_FORGE_DIR = APP_CACHE_DIR / "dataforge"
 

--- a/src/gui/config_tab.py
+++ b/src/gui/config_tab.py
@@ -1,5 +1,6 @@
 """Configuration tab for Smart Citizen."""
 import logging
+import os
 from pathlib import Path
 from datetime import datetime
 
@@ -29,6 +30,9 @@ class ConfigTab(QWidget):
     # MainWindow owns the update-check worker and writes results back via
     # set_update_status() so this tab stays decoupled from the network path.
     check_updates_requested = pyqtSignal()
+    # Emitted after the Smart Citizen data folder override has been saved.
+    # MainWindow re-syncs source paths and reloads against the new location.
+    data_dir_changed = pyqtSignal(str)
 
     def __init__(self):
         super().__init__()
@@ -137,6 +141,44 @@ class ConfigTab(QWidget):
         self.channel_combo.currentIndexChanged.connect(self._on_channel_changed)
 
         layout.addWidget(game_group)
+
+        # ── Smart Citizen Data ───────────────────────────────────────────────
+        data_group = QGroupBox("Smart Citizen Data")
+        data_layout = QVBoxLayout(data_group)
+
+        data_desc = QLabel(
+            "Folder for user.ini, source cache, DataForge extraction, enhancement INIs, "
+            "and backups. Move this off OneDrive-synced Documents if extraction is slow "
+            "or cache cleanup fails."
+        )
+        data_desc.setProperty("role", "secondary")
+        data_desc.setStyleSheet("font-size: 11px; margin-bottom: 5px;")
+        data_desc.setWordWrap(True)
+        data_layout.addWidget(data_desc)
+
+        data_input_layout = QHBoxLayout()
+        self.data_dir_input = QLineEdit()
+        self.data_dir_input.setText(str(AppSettings.get_user_data_dir()))
+        self.data_dir_input.setToolTip(
+            "Smart Citizen's app data root. Each channel gets its own subfolder "
+            "inside this directory. Leave blank or click Reset to use Documents\\Smart Citizen."
+        )
+        self.data_dir_input.editingFinished.connect(self._save_data_dir)
+        data_input_layout.addWidget(self.data_dir_input)
+
+        data_browse_btn = QPushButton("Browse...")
+        data_browse_btn.setMaximumWidth(100)
+        data_browse_btn.clicked.connect(self._browse_data_dir)
+        data_input_layout.addWidget(data_browse_btn)
+
+        data_reset_btn = QPushButton("Reset")
+        data_reset_btn.setMaximumWidth(80)
+        data_reset_btn.setToolTip("Clear the custom data folder and use Documents\\Smart Citizen.")
+        data_reset_btn.clicked.connect(self._reset_data_dir)
+        data_input_layout.addWidget(data_reset_btn)
+
+        data_layout.addLayout(data_input_layout)
+        layout.addWidget(data_group)
 
         # ── P4K Extraction ───────────────────────────────────────────────────
         p4k_group = QGroupBox("Base Localization (P4K Extraction)")
@@ -266,6 +308,65 @@ class ConfigTab(QWidget):
         if path:
             self.game_path_input.setText(path)
             self._save_game_path()
+
+    # ── Smart Citizen data folder ────────────────────────────────────────────
+
+    def _save_data_dir(self):
+        """Persist the Smart Citizen data folder override."""
+        current_dir = AppSettings.get_user_data_dir()
+        raw_path = self.data_dir_input.text().strip()
+
+        try:
+            if raw_path:
+                target = Path(os.path.expandvars(raw_path)).expanduser().resolve()
+                if target.exists() and not target.is_dir():
+                    QMessageBox.warning(
+                        self,
+                        "Invalid Data Folder",
+                        f"The selected data folder is a file, not a directory:\n{target}",
+                    )
+                    self.data_dir_input.setText(str(current_dir))
+                    return
+                target.mkdir(parents=True, exist_ok=True)
+                AppSettings.set_user_data_dir(target)
+            else:
+                AppSettings.set_user_data_dir(None)
+
+            new_dir = AppSettings.get_user_data_dir()
+        except OSError as e:
+            logger.warning(f"Could not use Smart Citizen data folder {raw_path!r}: {e}")
+            QMessageBox.warning(
+                self,
+                "Invalid Data Folder",
+                f"Smart Citizen could not use that data folder:\n{e}",
+            )
+            self.data_dir_input.setText(str(current_dir))
+            return
+
+        self.data_dir_input.setText(str(new_dir))
+        if new_dir != current_dir:
+            logger.info(f"Smart Citizen data folder changed: {current_dir} → {new_dir}")
+            self._refresh_p4k_status()
+            self.data_dir_changed.emit(str(new_dir))
+
+    def _browse_data_dir(self):
+        start_dir = self.data_dir_input.text().strip() or str(AppSettings.get_user_data_dir())
+        path = QFileDialog.getExistingDirectory(
+            self, "Select Smart Citizen Data Folder", start_dir
+        )
+        if path:
+            self.data_dir_input.setText(path)
+            self._save_data_dir()
+
+    def _reset_data_dir(self):
+        current_dir = AppSettings.get_user_data_dir()
+        AppSettings.set_user_data_dir(None)
+        new_dir = AppSettings.get_user_data_dir()
+        self.data_dir_input.setText(str(new_dir))
+        if new_dir != current_dir:
+            logger.info(f"Smart Citizen data folder reset to default: {new_dir}")
+            self._refresh_p4k_status()
+            self.data_dir_changed.emit(str(new_dir))
 
     # ── Channel selector ─────────────────────────────────────────────────────
 

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -710,6 +710,7 @@ class MainWindow(QMainWindow):
         self.config_tab.import_ini_requested.connect(self._handle_import_ini)
         self.config_tab.channel_changed.connect(self._on_channel_changed)
         self.config_tab.check_updates_requested.connect(self._on_check_updates_clicked)
+        self.config_tab.data_dir_changed.connect(self._on_data_dir_changed)
         self._config_tab_index = self.tabs.addTab(self.config_tab, "Config")
 
         # Enhancements tab
@@ -2666,6 +2667,22 @@ class MainWindow(QMainWindow):
             return
         self._channel_indicator.setText(f"Channel: {AppSettings.get_active_channel()}")
 
+    def _sync_canonical_source_paths(self, context: str) -> None:
+        """Mirror canonical file-backed source paths into QSettings."""
+        for source_name, canonical in (
+            (AppSettings.SOURCE_GLOBAL, str(AppSettings.get_cache_dir() / "base.ini")),
+            (AppSettings.SOURCE_USER, str(AppSettings.get_user_ini_path())),
+        ):
+            stored = AppSettings.get_source_path(source_name)
+            if stored.startswith("http://") or stored.startswith("https://"):
+                continue
+            if stored != canonical:
+                AppSettings.set_source_path(source_name, canonical)
+                logger.info(
+                    f"Re-synced {source_name} source path {context}: "
+                    f"{stored or '(unset)'} → {canonical}"
+                )
+
     @pyqtSlot(str)
     def _on_channel_changed(self, channel: str) -> None:
         """Handle a channel switch from the Config tab.
@@ -2687,19 +2704,7 @@ class MainWindow(QMainWindow):
         # new values into those entries the same way main() does on startup.
         # Skip any source currently set to a URL to preserve custom remote
         # configs.
-        for source_name, canonical in (
-            (AppSettings.SOURCE_GLOBAL, str(AppSettings.get_cache_dir() / "base.ini")),
-            (AppSettings.SOURCE_USER, str(AppSettings.get_user_ini_path())),
-        ):
-            stored = AppSettings.get_source_path(source_name)
-            if stored.startswith("http://") or stored.startswith("https://"):
-                continue
-            if stored != canonical:
-                AppSettings.set_source_path(source_name, canonical)
-                logger.info(
-                    f"Re-synced {source_name} source path for channel {channel}: "
-                    f"{stored or '(unset)'} → {canonical}"
-                )
+        self._sync_canonical_source_paths(f"for channel {channel}")
 
         self._refresh_channel_indicator()
         self.config_tab._refresh_p4k_status()
@@ -2740,6 +2745,31 @@ class MainWindow(QMainWindow):
         self._maybe_prompt_dataforge_refresh()
 
         self.statusBar().showMessage(f"Switched to {channel} — reloading sources…")
+        self.perform_merge_and_reload()
+
+    @pyqtSlot(str)
+    def _on_data_dir_changed(self, data_dir: str) -> None:
+        """Reload the app against a newly selected Smart Citizen data folder."""
+        logger.info(f"MainWindow reacting to data folder change → {data_dir}")
+
+        AppSettings.ensure_user_ini_file()
+        self._sync_canonical_source_paths(f"for data folder {data_dir}")
+        self.config_tab._refresh_p4k_status()
+        if hasattr(self, "enhancements_tab"):
+            self.enhancements_tab.refresh_enhancements_status()
+
+        self._enhancements_prompted_on_startup = False
+
+        if self._check_p4k_freshness():
+            self.statusBar().showMessage(
+                f"Data folder changed to {data_dir} — extracting Data.p4k…"
+            )
+            return
+
+        self._maybe_prompt_dataforge_refresh()
+        self.statusBar().showMessage(
+            f"Data folder changed to {data_dir} — reloading sources…"
+        )
         self.perform_merge_and_reload()
 
     def _update_status_bar(self):

--- a/src/utils/settings.py
+++ b/src/utils/settings.py
@@ -114,6 +114,9 @@ class AppSettings:
     # Documents redirected to OneDrive can point this at a local path to
     # avoid slow extraction / rmtree races on OneDrive-synced folders.
     USER_DATA_DIR = "user_data_dir"
+    # Compatibility alias for older docs/manual registry edits. The installer
+    # and current app write ``user_data_dir``; read both so either spelling works.
+    USER_DATA_DIR_ALIASES = ("UserDataDir",)
 
     # Settings keys - Data sources (new)
     # Prefix: data_sources/{source_name}/
@@ -950,6 +953,38 @@ class AppSettings:
         settings.sync()
 
     @staticmethod
+    def _get_user_data_dir_override() -> str:
+        """Return the configured user-data directory override, if any.
+
+        Current builds store this as ``user_data_dir``. Some docs and manual
+        support notes referred to ``UserDataDir``; migrate that alias lazily
+        so users who followed those instructions don't fall back to Documents.
+        """
+        settings = AppSettings.settings()
+        raw = settings.value(AppSettings.USER_DATA_DIR, "", type=str)
+        if raw and str(raw).strip():
+            return str(raw).strip()
+
+        for alias in AppSettings.USER_DATA_DIR_ALIASES:
+            raw_alias = settings.value(alias, "", type=str)
+            if raw_alias and str(raw_alias).strip():
+                value = str(raw_alias).strip()
+                settings.setValue(AppSettings.USER_DATA_DIR, value)
+                settings.sync()
+                logger.info(
+                    f"Migrated user data directory setting {alias} → "
+                    f"{AppSettings.USER_DATA_DIR}: {value}"
+                )
+                return value
+
+        return ""
+
+    @staticmethod
+    def get_user_data_dir_override() -> str:
+        """Return the explicit user-data directory override, or ``""`` when unset."""
+        return AppSettings._get_user_data_dir_override()
+
+    @staticmethod
     def get_user_data_dir() -> Path:
         r"""Get the user data directory.
 
@@ -964,9 +999,9 @@ class AppSettings:
         Returns:
             Path to the resolved directory (created if needed).
         """
-        override = AppSettings.settings().value(AppSettings.USER_DATA_DIR, "", type=str)
+        override = AppSettings._get_user_data_dir_override()
         if override:
-            override_path = Path(override)
+            override_path = Path(os.path.expandvars(override)).expanduser().resolve()
             try:
                 override_path.mkdir(parents=True, exist_ok=True)
                 return override_path
@@ -984,15 +1019,21 @@ class AppSettings:
         r"""Override the user data directory. Pass ``None`` or an empty
         string to clear the override and revert to the Documents default.
 
-        Writes to the Osiris DevWorks\SC Localization Editor registry key
-        (same scope as every other AppSettings value), so it survives
-        reinstalls and is per-user.
+        Writes to the Osiris DevWorks\Smart Citizen registry key (same scope
+        as every other AppSettings value), so it survives reinstalls and is
+        per-user.
         """
+        settings = AppSettings.settings()
         if not path:
-            AppSettings.settings().remove(AppSettings.USER_DATA_DIR)
+            settings.remove(AppSettings.USER_DATA_DIR)
+            for alias in AppSettings.USER_DATA_DIR_ALIASES:
+                settings.remove(alias)
         else:
-            AppSettings.settings().setValue(AppSettings.USER_DATA_DIR, str(path))
-        AppSettings.settings().sync()
+            expanded = Path(os.path.expandvars(str(path))).expanduser().resolve()
+            settings.setValue(AppSettings.USER_DATA_DIR, str(expanded))
+            for alias in AppSettings.USER_DATA_DIR_ALIASES:
+                settings.remove(alias)
+        settings.sync()
 
     # ── Channel selection API ────────────────────────────────────────────────
 

--- a/tests/test_channel_layout.py
+++ b/tests/test_channel_layout.py
@@ -155,6 +155,46 @@ class TestChannelScopedPaths:
         assert ptu_cache.parent.name == "PTU"
 
 
+class TestUserDataDirOverride:
+    def test_user_data_dir_override_wins(self, isolated_qsettings, tmp_path):
+        custom_dir = tmp_path / "Custom Smart Citizen Data"
+
+        AppSettings.set_user_data_dir(custom_dir)
+
+        assert AppSettings.get_user_data_dir() == custom_dir
+        assert custom_dir.exists()
+
+    def test_user_data_dir_alias_is_honored(self, isolated_qsettings, tmp_path):
+        custom_dir = tmp_path / "Alias Smart Citizen Data"
+        AppSettings.settings().setValue("UserDataDir", str(custom_dir))
+
+        assert AppSettings.get_user_data_dir() == custom_dir
+        assert AppSettings.settings().value(AppSettings.USER_DATA_DIR, "") == str(custom_dir)
+
+    def test_channel_paths_nest_under_custom_user_data_dir(
+        self, isolated_qsettings, tmp_path
+    ):
+        custom_dir = tmp_path / "Custom Data"
+        AppSettings.set_user_data_dir(custom_dir)
+        AppSettings.set_active_channel("PTU")
+
+        assert AppSettings.get_cache_dir() == custom_dir / "PTU" / "cache"
+        assert AppSettings.get_user_ini_path() == custom_dir / "PTU" / "user.ini"
+
+    def test_clearing_user_data_dir_reverts_to_documents_default(
+        self, isolated_qsettings, tmp_path, monkeypatch
+    ):
+        docs_dir = tmp_path / "Documents"
+        monkeypatch.setattr(
+            AppSettings, "_resolve_docs_base", staticmethod(lambda: docs_dir)
+        )
+
+        AppSettings.set_user_data_dir(tmp_path / "Custom Data")
+        AppSettings.set_user_data_dir(None)
+
+        assert AppSettings.get_user_data_dir() == docs_dir / "Smart Citizen"
+
+
 # ─────────────────────────────────────────────────────────────────────────────
 # SC install root + channel install path + p4k path
 # ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Allow users to change the Smart Citizen data root from the Config tab and reload against the selected folder without manual editing of the registry. Folder was not saving and being used and kept defaulting to the My Documents path.

Honor the documented UserDataDir alias, keep source paths synchronized with the active data folder, and update enhancement script defaults and documentation.