### PR TITLE
Extract worker threads to src/gui/workers.py

### DIFF
--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -19,118 +19,41 @@ from PyQt6.QtGui import QColor, QFont, QCursor, QPixmap, QIcon, QPalette
 from PyQt6.QtCore import QUrl
 from PyQt6.QtGui import QDesktopServices
 
+from src.gui.coach_mark import CoachMarkStep, TutorialTour
+from src.gui.config_tab import ConfigTab
+from src.gui.enhancements_tab import EnhancementsTab
 from src.gui.filter_header import FilterHeaderView
+from src.gui.log_tab import LogTab
 from src.gui.markdown_renderer import markdown_to_html as _md_to_html
 from src.gui.string_table_model import (
     StringTableModel, COL_STAR, COL_CUSTOM, COL_STATUS,
     status_color,
 )
-from src.utils.applied_file_validator import validate_applied_file as _validate_applied_file_impl
-from src.utils.entry_filter import filter_entry_indices as _filter_entry_indices_impl
-
-
-class AnimatedProgressDialog(QProgressDialog):
-    """Reusable progress dialog that toggles between indeterminate and determinate.
-
-    Starts indeterminate (range 0-0, auto-animating). Call `set_progress(completed,
-    total, message)` to switch to determinate; pass total=0 to drop back to
-    indeterminate for phases with an unknown extent. The phase message shows
-    in the label above the bar. In determinate mode the bar displays the
-    percent-complete (default Qt ``%p%`` format); indeterminate mode hides
-    the bar text since there's no meaningful percentage to show.
-    """
-
-    def __init__(self, message: str, parent=None, title: str = "Processing"):
-        super().__init__(message, None, 0, 0, parent)
-        self.setWindowTitle(title)
-        self.setModal(True)
-        self.setMinimumWidth(400)
-        self._bar = self.findChild(QProgressBar)
-        if self._bar is not None:
-            # Start indeterminate — bar text hidden until set_progress flips
-            # to determinate and a real percentage exists to display.
-            self._bar.setTextVisible(False)
-        self.show()
-
-    def set_progress(self, completed: int, total: int, message: str = "") -> None:
-        """Drive the bar from a ProgressSink. total=0 ⇒ indeterminate.
-
-        Determinate mode applies a two-tone gradient QSS and shows ``%p%``
-        inside the bar. Indeterminate mode clears the QSS so Fusion's
-        animated busy indicator still works, and hides the bar text.
-        Phase messages go to the label above the bar in both modes.
-        """
-        if total <= 0:
-            if self.maximum() != 0 or self.minimum() != 0:
-                self.setRange(0, 0)
-            if self._bar is not None:
-                self._bar.setTextVisible(False)
-                self._bar.setStyleSheet("")
-        else:
-            if self.maximum() != total:
-                self.setRange(0, total)
-            self.setValue(min(completed, total))
-            if self._bar is not None:
-                # Reset format to the Qt default so %p% resolves even if
-                # something upstream had set a custom format string.
-                self._bar.setFormat("%p%")
-                self._bar.setTextVisible(True)
-                from src.gui.theme import get_progress_groove_color, get_progress_chunk_color
-                chunk = QColor(get_progress_chunk_color())
-                light = chunk.lighter(135).name()
-                dark  = chunk.darker(125).name()
-                mid   = chunk.name()
-                self._bar.setStyleSheet(
-                    "QProgressBar {"
-                    f" background-color: {get_progress_groove_color()};"
-                    " border: 1px solid rgba(0,0,0,0.25);"
-                    " border-radius: 3px;"
-                    " text-align: center;"
-                    "}"
-                    "QProgressBar::chunk {"
-                    " background: qlineargradient("
-                    "  x1:0, y1:0, x2:0, y2:1,"
-                    f"  stop:0 {light},"
-                    f"  stop:0.5 {mid},"
-                    f"  stop:1 {dark}"
-                    " );"
-                    " border-radius: 2px;"
-                    "}"
-                )
-        if message:
-            self.setLabelText(message)
-
+from src.gui.theme import (
+    BRAND_FONT_FAMILY, get_button_color, get_button_text_color,
+    get_tagline_color, get_title_color,
+)
+from src.gui.workers import (
+    AnimatedProgressDialog,
+    DataForgeExtractWorker,
+    EnhancementsGeneratorWorker,
+    FileLoaderWorker,
+    P4kExtractWorker,
+    SelectAllDelegate,
+    StartupSyncWorker,
+)
+from src.merger.ini_merger import merge_sources_by_hierarchy
 from src.models.string_model import StringEntry
 from src.parser.ini_parser import load_source_files, load_sources_from_settings, parse_ini_file
-from src.utils.settings import AppSettings
-from src.merger.ini_merger import merge_sources_by_hierarchy
-from src.utils.version import get_version
-from src.utils.perf import timed
 from src.utils.app_updater import AppUpdateCheckWorker
-from src.gui.config_tab import ConfigTab
-from src.gui.theme import get_button_color, get_button_text_color, get_title_color, get_tagline_color, BRAND_FONT_FAMILY
-from src.gui.enhancements_tab import EnhancementsTab
-from src.gui.log_tab import LogTab
-from src.gui.coach_mark import CoachMarkStep, TutorialTour
+from src.utils.applied_file_validator import validate_applied_file as _validate_applied_file_impl
+from src.utils.entry_filter import filter_entry_indices as _filter_entry_indices_impl
+from src.utils.perf import timed
+from src.utils.resource_path import get_resource_path
+from src.utils.settings import AppSettings
+from src.utils.version import get_version
 
 logger = logging.getLogger(__name__)
-
-
-def get_resource_path(relative_path):
-    """Get absolute path to resource, works for dev and for PyInstaller."""
-    try:
-        # PyInstaller creates a temp folder and stores path in _MEIPASS
-        base_path = sys._MEIPASS
-    except Exception:
-        # If not running as PyInstaller bundle, use the project root
-        base_path = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-
-    return os.path.join(base_path, relative_path)
-
-
-def _resolve_patches_dir() -> Path:
-    """Return the path to the bundled DataForge patches directory."""
-    return Path(get_resource_path("patches"))
 
 
 # Preview-pane token translation — turns the raw loc-string format the game
@@ -283,308 +206,6 @@ def _render_preview_html(key: str, raw: str, stamp: str | None = None) -> str:
         "</div>"
     )
 
-
-class FileLoaderWorker(QThread):
-    """Worker thread for loading INI files without blocking UI.
-
-    Loads configured sources from settings and emits the merged entries plus
-    pre-computed sort keys so the main thread doesn't need to re-parse base.ini.
-    """
-
-    # (entries, default_values dict, pre-computed group sort keys)
-    finished = pyqtSignal(list, dict, list)
-    error = pyqtSignal(str)
-    progress = pyqtSignal(str)
-    progress_pct = pyqtSignal(int, int, str)  # (completed, total, message)
-
-    # 3 phase boundaries: sources read → entries built → sort keys computed.
-    _PHASE_TOTAL = 3
-
-    def run(self):
-        from src.gui.string_table_model import _group_sort_key
-        try:
-            logger.info("FileLoaderWorker starting...")
-            self.progress_pct.emit(0, self._PHASE_TOTAL, "Reading source files...")
-            self.progress.emit("Reading source files...")
-
-            sources_dict, hierarchy, enhancements_key_categories = load_sources_from_settings()
-            logger.info(f"Loaded from settings: sources={list(sources_dict.keys())}, hierarchy={hierarchy}")
-
-            if not (sources_dict and hierarchy):
-                raise ValueError("No sources configured")
-
-            self.progress_pct.emit(1, self._PHASE_TOTAL, "Creating StringEntry objects...")
-            self.progress.emit("Creating StringEntry objects...")
-            entries = load_source_files(sources_dict, hierarchy, enhancements_key_categories=enhancements_key_categories)
-            logger.info(f"load_source_files returned {len(entries)} entries")
-
-            default_values = dict(sources_dict.get("global", {}))
-
-            self.progress_pct.emit(2, self._PHASE_TOTAL, "Computing sort keys...")
-            self.progress.emit("Computing sort keys...")
-            sort_keys = [_group_sort_key(e.key) for e in entries]
-
-            self.progress_pct.emit(3, self._PHASE_TOTAL, "Ready")
-            logger.info("FileLoaderWorker finished successfully")
-            self.finished.emit(entries, default_values, sort_keys)
-        except Exception as e:
-            logger.exception(f"Error loading files: {e}")
-            self.error.emit(str(e))
-
-
-class StartupSyncWorker(QThread):
-    """Worker thread that syncs all enabled remote sources on startup.
-
-    Uses conditional GET (If-Modified-Since) so only changed files are downloaded.
-    Emits source_starting before each download, source_synced after, source_error on
-    failure. Always emits finished so loading proceeds even when sources fail.
-    """
-
-    source_starting = pyqtSignal(str)        # source_name (about to sync)
-    source_synced = pyqtSignal(str, bool)    # (source_name, was_updated)
-    source_error = pyqtSignal(str, str)      # (source_name, error_message)
-    finished = pyqtSignal()
-
-    def run(self):
-        from src.utils.updater import download_file_if_changed
-        from src.utils.settings import AppSettings
-
-        cache_dir = AppSettings.get_cache_dir()
-        cache_mapping = {
-            AppSettings.SOURCE_GLOBAL:      "base.ini",
-        }
-
-        for source_name in [
-            AppSettings.SOURCE_GLOBAL,
-        ]:
-            if not AppSettings.is_source_enabled(source_name):
-                continue
-            if not AppSettings.get_source_auto_update(source_name):
-                continue
-
-            source_url = AppSettings.get_source_path(source_name)
-            if not source_url or not source_url.startswith("http"):
-                continue
-
-            self.source_starting.emit(source_name)
-            cache_file = cache_dir / cache_mapping.get(source_name, f"{source_name}.ini")
-            try:
-                updated = download_file_if_changed(source_url, cache_file)
-                self.source_synced.emit(source_name, updated)
-            except Exception as e:
-                logger.warning(f"Startup sync failed for {source_name}: {e}")
-                self.source_error.emit(source_name, str(e))
-
-        self.finished.emit()
-
-
-class EnhancementsGeneratorWorker(QThread):
-    """Worker thread for generating enhancements INI files via generate_enhancements_ini.py."""
-
-    progress = pyqtSignal(str)
-    progress_pct = pyqtSignal(int, int, str)  # (completed, total, message)
-    finished = pyqtSignal(bool)
-    error = pyqtSignal(str)
-
-    def __init__(self, categories: set[str] | None = None):
-        super().__init__()
-        self.categories = categories
-
-    def run(self):
-        import importlib.util
-        import sys as sys_module
-        from src.utils.dataforge_patcher import apply_patches
-        try:
-            if getattr(sys, 'frozen', False):
-                script_path = Path(sys._MEIPASS) / 'scripts' / 'generate_enhancements_ini.py'
-            else:
-                script_path = Path(__file__).parent.parent.parent / 'scripts' / 'generate_enhancements_ini.py'
-
-            if not script_path.exists():
-                raise FileNotFoundError(f"Enhancements generator script not found: {script_path}")
-
-            base_ini  = AppSettings.get_cache_dir() / 'base.ini'
-            forge_dir = AppSettings.get_dataforge_cache_dir()
-
-            # Re-apply DataForge patches before generation. apply_patches is
-            # idempotent: already-patched files are a cheap no-op, so running
-            # this every regen picks up newly-added patches without forcing
-            # the user through a full re-extract. Bar stays indeterminate
-            # here — ``mod.main()`` below takes over with determinate ticks
-            # once its ProgressSink is wired up.
-            self.progress_pct.emit(0, 0, "Applying DataForge patches…")
-            self.progress.emit("Applying DataForge patches…")
-            patch_report = apply_patches(
-                _resolve_patches_dir(), forge_dir,
-                progress_callback=self.progress.emit,
-            )
-            logger.info(f"DataForge patches: {patch_report.summary_line()}")
-            if patch_report.errors:
-                for err in patch_report.errors:
-                    logger.warning(f"  patch error: {err}")
-
-            self.progress.emit("Loading enhancements generator...")
-
-            module_name = "generate_enhancements_ini_worker"
-            if module_name in sys_module.modules:
-                del sys_module.modules[module_name]
-
-            spec = importlib.util.spec_from_file_location(module_name, script_path)
-            mod = importlib.util.module_from_spec(spec)
-            sys_module.modules[module_name] = mod
-            spec.loader.exec_module(mod)
-
-            self.progress.emit("Generating enhancements (may take a few minutes on first run)...")
-            logger.info("Enhancements generation worker: calling mod.main()")
-
-            cat_desc = ", ".join(sorted(self.categories)) if self.categories else "all"
-            logger.info(f"Enhancements generation: base_ini={base_ini}, forge_dir={forge_dir}, categories={cat_desc}")
-
-            # Bridge the script's ProgressSink callback into a Qt-safe signal.
-            # PyQt signal emits are thread-safe across QThread boundaries, so
-            # this is safe to call from lookup-pool workers.
-            def _on_progress(completed: int, total: int, message: str) -> None:
-                self.progress_pct.emit(completed, total, message)
-
-            mod.main(base_ini, forge_dir, categories=self.categories,
-                     progress_callback=_on_progress,
-                     patches_dir=_resolve_patches_dir())
-            logger.info("Enhancements generation worker: mod.main() completed successfully")
-
-            self.finished.emit(True)
-        except Exception as e:
-            logger.exception(f"Enhancements generation failed: {e}")
-            self.error.emit(str(e))
-            self.finished.emit(False)
-
-
-class P4kExtractWorker(QThread):
-    """Worker thread for extracting global.ini from Data.p4k via unp4k.exe."""
-
-    progress = pyqtSignal(str)   # status message
-    progress_pct = pyqtSignal(int, int, str)  # (completed, total, message)
-    finished = pyqtSignal(bool)  # True = success
-    error = pyqtSignal(str)      # error message (emitted before finished(False))
-
-    def __init__(self, p4k_path, output_path, unp4k_exe):
-        super().__init__()
-        self._p4k = p4k_path
-        self._out = output_path
-        self._exe = unp4k_exe
-
-    def run(self):
-        from src.utils.pak_extractor import extract_global_ini
-        try:
-            extract_global_ini(
-                self._p4k, self._out, self._exe,
-                progress_callback=self.progress.emit,
-                progress_pct_callback=lambda c, t, m: self.progress_pct.emit(c, t, m),
-            )
-            self.finished.emit(True)
-        except Exception as e:
-            logger.exception(f"P4K extraction failed: {e}")
-            self.error.emit(str(e))
-            self.finished.emit(False)
-
-
-class DataForgeExtractWorker(QThread):
-    """Worker thread for extracting DataForge entity XMLs from Data.p4k."""
-
-    progress = pyqtSignal(str)
-    progress_pct = pyqtSignal(int, int, str)  # (completed, total, message)
-    finished = pyqtSignal(bool)
-    error = pyqtSignal(str)
-
-    def __init__(self, p4k_path, unp4k_exe, unforge_exe, cache_dir):
-        super().__init__()
-        self._p4k       = p4k_path
-        self._unp4k_exe = unp4k_exe
-        self._unforge_exe = unforge_exe
-        self._cache_dir = cache_dir
-
-    def run(self):
-        from src.utils.pak_extractor import extract_dataforge
-        from src.utils.dataforge_patcher import apply_patches
-        try:
-            extract_dataforge(
-                self._p4k,
-                self._unp4k_exe,
-                self._unforge_exe,
-                self._cache_dir,
-                progress_callback=self.progress.emit,
-                progress_pct_callback=lambda c, t, m: self.progress_pct.emit(c, t, m),
-            )
-            # Apply declarative patches over known CIG data bugs so downstream
-            # consumers (enhancement generator, future tooling) see corrected
-            # data. Patch failures are recorded in the report but don't block
-            # the pipeline.
-            #
-            # Flip the progress bar back to indeterminate (range 0-0, auto-
-            # animating) so the user can see we're still working — after
-            # extract_dataforge completes, the bar sits at its final 3/3
-            # "Done" determinate state, which would look like the dialog is
-            # about to close. The patches phase has no useful per-file
-            # progress, so indeterminate is the honest signal.
-            self.progress_pct.emit(0, 0, "Applying DataForge patches…")
-            self.progress.emit("Applying DataForge patches…")
-            patch_root = _resolve_patches_dir()
-            report = apply_patches(patch_root, self._cache_dir,
-                                   progress_callback=self.progress.emit)
-            logger.info(f"DataForge patches: {report.summary_line()}")
-            if report.errors:
-                for err in report.errors:
-                    logger.warning(f"  patch error: {err}")
-            self.finished.emit(True)
-        except Exception as e:
-            logger.exception(f"DataForge extraction failed: {e}")
-            self.error.emit(str(e))
-            self.finished.emit(False)
-
-
-class SelectAllDelegate(QStyledItemDelegate):
-    """Custom delegate for the Custom Value column.
-
-    - Selects all text when the editor opens so typing overwrites but Esc keeps it.
-    - Extends the editor's right-click menu with <EM3>/<EM4> wrap actions so
-      authors can apply Star Citizen emphasis tags around the selected text.
-    """
-
-    def createEditor(self, parent, option, index):
-        from PyQt6.QtWidgets import QLineEdit
-        editor = super().createEditor(parent, option, index)
-        if hasattr(editor, 'selectAll'):
-            editor.selectAll()
-        if isinstance(editor, QLineEdit):
-            editor.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
-            editor.customContextMenuRequested.connect(
-                lambda pos, ed=editor: SelectAllDelegate._show_editor_menu(ed, pos)
-            )
-        return editor
-
-    @staticmethod
-    def _show_editor_menu(editor, pos):
-        menu = editor.createStandardContextMenu()
-        menu.addSeparator()
-        has_sel = editor.hasSelectedText()
-        em3 = menu.addAction("Underline")
-        em3.setEnabled(has_sel)
-        em3.triggered.connect(lambda: SelectAllDelegate._wrap_selection(editor, "EM3"))
-        em4 = menu.addAction("Highlight")
-        em4.setEnabled(has_sel)
-        em4.triggered.connect(lambda: SelectAllDelegate._wrap_selection(editor, "EM4"))
-        menu.exec(editor.mapToGlobal(pos))
-
-    @staticmethod
-    def _wrap_selection(editor, tag: str):
-        sel = editor.selectedText()
-        if not sel:
-            return
-        # QLineEdit.insert replaces the current selection. Place the caret
-        # just inside the closing tag so successive edits stay near the text.
-        wrapped = f"<{tag}>{sel}</{tag}>"
-        start = editor.selectionStart()
-        editor.insert(wrapped)
-        editor.setCursorPosition(start + len(f"<{tag}>") + len(sel))
 
 
 class MainWindow(QMainWindow):

--- a/src/gui/workers.py
+++ b/src/gui/workers.py
@@ -1,0 +1,402 @@
+"""Background worker threads and shared GUI helpers for the main window.
+
+Extracted from main_window.py so each worker can be reasoned about in
+isolation, and so the file size of main_window.py stays manageable.
+
+Contents:
+- AnimatedProgressDialog — reusable indeterminate↔determinate progress dialog
+- FileLoaderWorker        — loads sources, builds StringEntry list, sort keys
+- StartupSyncWorker       — refreshes URL-backed sources on startup
+- EnhancementsGeneratorWorker — runs scripts/generate_enhancements_ini.py
+- P4kExtractWorker        — unp4k extraction of global.ini
+- DataForgeExtractWorker  — unp4k + unforge + patch pipeline
+- SelectAllDelegate       — Custom Value cell delegate (auto-select, EM3/EM4 wrap)
+"""
+
+import logging
+import sys
+from pathlib import Path
+
+from PyQt6.QtCore import Qt, QThread, pyqtSignal
+from PyQt6.QtGui import QColor
+from PyQt6.QtWidgets import QProgressBar, QProgressDialog, QStyledItemDelegate
+
+from src.parser.ini_parser import load_source_files, load_sources_from_settings
+from src.utils.resource_path import resolve_patches_dir
+from src.utils.settings import AppSettings
+
+logger = logging.getLogger(__name__)
+
+
+class AnimatedProgressDialog(QProgressDialog):
+    """Reusable progress dialog that toggles between indeterminate and determinate.
+
+    Starts indeterminate (range 0-0, auto-animating). Call `set_progress(completed,
+    total, message)` to switch to determinate; pass total=0 to drop back to
+    indeterminate for phases with an unknown extent. The phase message shows
+    in the label above the bar. In determinate mode the bar displays the
+    percent-complete (default Qt ``%p%`` format); indeterminate mode hides
+    the bar text since there's no meaningful percentage to show.
+    """
+
+    def __init__(self, message: str, parent=None, title: str = "Processing"):
+        super().__init__(message, None, 0, 0, parent)
+        self.setWindowTitle(title)
+        self.setModal(True)
+        self.setMinimumWidth(400)
+        self._bar = self.findChild(QProgressBar)
+        if self._bar is not None:
+            # Start indeterminate — bar text hidden until set_progress flips
+            # to determinate and a real percentage exists to display.
+            self._bar.setTextVisible(False)
+        self.show()
+
+    def set_progress(self, completed: int, total: int, message: str = "") -> None:
+        """Drive the bar from a ProgressSink. total=0 ⇒ indeterminate.
+
+        Determinate mode applies a two-tone gradient QSS and shows ``%p%``
+        inside the bar. Indeterminate mode clears the QSS so Fusion's
+        animated busy indicator still works, and hides the bar text.
+        Phase messages go to the label above the bar in both modes.
+        """
+        if total <= 0:
+            if self.maximum() != 0 or self.minimum() != 0:
+                self.setRange(0, 0)
+            if self._bar is not None:
+                self._bar.setTextVisible(False)
+                self._bar.setStyleSheet("")
+        else:
+            if self.maximum() != total:
+                self.setRange(0, total)
+            self.setValue(min(completed, total))
+            if self._bar is not None:
+                # Reset format to the Qt default so %p% resolves even if
+                # something upstream had set a custom format string.
+                self._bar.setFormat("%p%")
+                self._bar.setTextVisible(True)
+                from src.gui.theme import get_progress_chunk_color, get_progress_groove_color
+                chunk = QColor(get_progress_chunk_color())
+                light = chunk.lighter(135).name()
+                dark  = chunk.darker(125).name()
+                mid   = chunk.name()
+                self._bar.setStyleSheet(
+                    "QProgressBar {"
+                    f" background-color: {get_progress_groove_color()};"
+                    " border: 1px solid rgba(0,0,0,0.25);"
+                    " border-radius: 3px;"
+                    " text-align: center;"
+                    "}"
+                    "QProgressBar::chunk {"
+                    " background: qlineargradient("
+                    "  x1:0, y1:0, x2:0, y2:1,"
+                    f"  stop:0 {light},"
+                    f"  stop:0.5 {mid},"
+                    f"  stop:1 {dark}"
+                    " );"
+                    " border-radius: 2px;"
+                    "}"
+                )
+        if message:
+            self.setLabelText(message)
+
+
+class FileLoaderWorker(QThread):
+    """Worker thread for loading INI files without blocking UI.
+
+    Loads configured sources from settings and emits the merged entries plus
+    pre-computed sort keys so the main thread doesn't need to re-parse base.ini.
+    """
+
+    # (entries, default_values dict, pre-computed group sort keys)
+    finished = pyqtSignal(list, dict, list)
+    error = pyqtSignal(str)
+    progress = pyqtSignal(str)
+    progress_pct = pyqtSignal(int, int, str)  # (completed, total, message)
+
+    # 3 phase boundaries: sources read → entries built → sort keys computed.
+    _PHASE_TOTAL = 3
+
+    def run(self):
+        from src.gui.string_table_model import _group_sort_key
+        try:
+            logger.info("FileLoaderWorker starting...")
+            self.progress_pct.emit(0, self._PHASE_TOTAL, "Reading source files...")
+            self.progress.emit("Reading source files...")
+
+            sources_dict, hierarchy, enhancements_key_categories = load_sources_from_settings()
+            logger.info(f"Loaded from settings: sources={list(sources_dict.keys())}, hierarchy={hierarchy}")
+
+            if not (sources_dict and hierarchy):
+                raise ValueError("No sources configured")
+
+            self.progress_pct.emit(1, self._PHASE_TOTAL, "Creating StringEntry objects...")
+            self.progress.emit("Creating StringEntry objects...")
+            entries = load_source_files(sources_dict, hierarchy, enhancements_key_categories=enhancements_key_categories)
+            logger.info(f"load_source_files returned {len(entries)} entries")
+
+            default_values = dict(sources_dict.get("global", {}))
+
+            self.progress_pct.emit(2, self._PHASE_TOTAL, "Computing sort keys...")
+            self.progress.emit("Computing sort keys...")
+            sort_keys = [_group_sort_key(e.key) for e in entries]
+
+            self.progress_pct.emit(3, self._PHASE_TOTAL, "Ready")
+            logger.info("FileLoaderWorker finished successfully")
+            self.finished.emit(entries, default_values, sort_keys)
+        except Exception as e:
+            logger.exception(f"Error loading files: {e}")
+            self.error.emit(str(e))
+
+
+class StartupSyncWorker(QThread):
+    """Worker thread that syncs all enabled remote sources on startup.
+
+    Uses conditional GET (If-Modified-Since) so only changed files are downloaded.
+    Emits source_starting before each download, source_synced after, source_error on
+    failure. Always emits finished so loading proceeds even when sources fail.
+    """
+
+    source_starting = pyqtSignal(str)        # source_name (about to sync)
+    source_synced = pyqtSignal(str, bool)    # (source_name, was_updated)
+    source_error = pyqtSignal(str, str)      # (source_name, error_message)
+    finished = pyqtSignal()
+
+    def run(self):
+        from src.utils.updater import download_file_if_changed
+
+        cache_dir = AppSettings.get_cache_dir()
+        cache_mapping = {
+            AppSettings.SOURCE_GLOBAL:      "base.ini",
+        }
+
+        for source_name in [
+            AppSettings.SOURCE_GLOBAL,
+        ]:
+            if not AppSettings.is_source_enabled(source_name):
+                continue
+            if not AppSettings.get_source_auto_update(source_name):
+                continue
+
+            source_url = AppSettings.get_source_path(source_name)
+            if not source_url or not source_url.startswith("http"):
+                continue
+
+            self.source_starting.emit(source_name)
+            cache_file = cache_dir / cache_mapping.get(source_name, f"{source_name}.ini")
+            try:
+                updated = download_file_if_changed(source_url, cache_file)
+                self.source_synced.emit(source_name, updated)
+            except Exception as e:
+                logger.warning(f"Startup sync failed for {source_name}: {e}")
+                self.source_error.emit(source_name, str(e))
+
+        self.finished.emit()
+
+
+class EnhancementsGeneratorWorker(QThread):
+    """Worker thread for generating enhancements INI files via generate_enhancements_ini.py."""
+
+    progress = pyqtSignal(str)
+    progress_pct = pyqtSignal(int, int, str)  # (completed, total, message)
+    finished = pyqtSignal(bool)
+    error = pyqtSignal(str)
+
+    def __init__(self, categories: set[str] | None = None):
+        super().__init__()
+        self.categories = categories
+
+    def run(self):
+        import importlib.util
+        import sys as sys_module
+        from src.utils.dataforge_patcher import apply_patches
+        try:
+            if getattr(sys, 'frozen', False):
+                script_path = Path(sys._MEIPASS) / 'scripts' / 'generate_enhancements_ini.py'
+            else:
+                script_path = Path(__file__).parent.parent.parent / 'scripts' / 'generate_enhancements_ini.py'
+
+            if not script_path.exists():
+                raise FileNotFoundError(f"Enhancements generator script not found: {script_path}")
+
+            base_ini  = AppSettings.get_cache_dir() / 'base.ini'
+            forge_dir = AppSettings.get_dataforge_cache_dir()
+
+            # Re-apply DataForge patches before generation. apply_patches is
+            # idempotent: already-patched files are a cheap no-op, so running
+            # this every regen picks up newly-added patches without forcing
+            # the user through a full re-extract. Bar stays indeterminate
+            # here — ``mod.main()`` below takes over with determinate ticks
+            # once its ProgressSink is wired up.
+            self.progress_pct.emit(0, 0, "Applying DataForge patches…")
+            self.progress.emit("Applying DataForge patches…")
+            patch_report = apply_patches(
+                resolve_patches_dir(), forge_dir,
+                progress_callback=self.progress.emit,
+            )
+            logger.info(f"DataForge patches: {patch_report.summary_line()}")
+            if patch_report.errors:
+                for err in patch_report.errors:
+                    logger.warning(f"  patch error: {err}")
+
+            self.progress.emit("Loading enhancements generator...")
+
+            module_name = "generate_enhancements_ini_worker"
+            if module_name in sys_module.modules:
+                del sys_module.modules[module_name]
+
+            spec = importlib.util.spec_from_file_location(module_name, script_path)
+            mod = importlib.util.module_from_spec(spec)
+            sys_module.modules[module_name] = mod
+            spec.loader.exec_module(mod)
+
+            self.progress.emit("Generating enhancements (may take a few minutes on first run)...")
+            logger.info("Enhancements generation worker: calling mod.main()")
+
+            cat_desc = ", ".join(sorted(self.categories)) if self.categories else "all"
+            logger.info(f"Enhancements generation: base_ini={base_ini}, forge_dir={forge_dir}, categories={cat_desc}")
+
+            # Bridge the script's ProgressSink callback into a Qt-safe signal.
+            # PyQt signal emits are thread-safe across QThread boundaries, so
+            # this is safe to call from lookup-pool workers.
+            def _on_progress(completed: int, total: int, message: str) -> None:
+                self.progress_pct.emit(completed, total, message)
+
+            mod.main(base_ini, forge_dir, categories=self.categories,
+                     progress_callback=_on_progress,
+                     patches_dir=resolve_patches_dir())
+            logger.info("Enhancements generation worker: mod.main() completed successfully")
+
+            self.finished.emit(True)
+        except Exception as e:
+            logger.exception(f"Enhancements generation failed: {e}")
+            self.error.emit(str(e))
+            self.finished.emit(False)
+
+
+class P4kExtractWorker(QThread):
+    """Worker thread for extracting global.ini from Data.p4k via unp4k.exe."""
+
+    progress = pyqtSignal(str)   # status message
+    progress_pct = pyqtSignal(int, int, str)  # (completed, total, message)
+    finished = pyqtSignal(bool)  # True = success
+    error = pyqtSignal(str)      # error message (emitted before finished(False))
+
+    def __init__(self, p4k_path, output_path, unp4k_exe):
+        super().__init__()
+        self._p4k = p4k_path
+        self._out = output_path
+        self._exe = unp4k_exe
+
+    def run(self):
+        from src.utils.pak_extractor import extract_global_ini
+        try:
+            extract_global_ini(
+                self._p4k, self._out, self._exe,
+                progress_callback=self.progress.emit,
+                progress_pct_callback=lambda c, t, m: self.progress_pct.emit(c, t, m),
+            )
+            self.finished.emit(True)
+        except Exception as e:
+            logger.exception(f"P4K extraction failed: {e}")
+            self.error.emit(str(e))
+            self.finished.emit(False)
+
+
+class DataForgeExtractWorker(QThread):
+    """Worker thread for extracting DataForge entity XMLs from Data.p4k."""
+
+    progress = pyqtSignal(str)
+    progress_pct = pyqtSignal(int, int, str)  # (completed, total, message)
+    finished = pyqtSignal(bool)
+    error = pyqtSignal(str)
+
+    def __init__(self, p4k_path, unp4k_exe, unforge_exe, cache_dir):
+        super().__init__()
+        self._p4k       = p4k_path
+        self._unp4k_exe = unp4k_exe
+        self._unforge_exe = unforge_exe
+        self._cache_dir = cache_dir
+
+    def run(self):
+        from src.utils.pak_extractor import extract_dataforge
+        from src.utils.dataforge_patcher import apply_patches
+        try:
+            extract_dataforge(
+                self._p4k,
+                self._unp4k_exe,
+                self._unforge_exe,
+                self._cache_dir,
+                progress_callback=self.progress.emit,
+                progress_pct_callback=lambda c, t, m: self.progress_pct.emit(c, t, m),
+            )
+            # Apply declarative patches over known CIG data bugs so downstream
+            # consumers (enhancement generator, future tooling) see corrected
+            # data. Patch failures are recorded in the report but don't block
+            # the pipeline.
+            #
+            # Flip the progress bar back to indeterminate (range 0-0, auto-
+            # animating) so the user can see we're still working — after
+            # extract_dataforge completes, the bar sits at its final 3/3
+            # "Done" determinate state, which would look like the dialog is
+            # about to close. The patches phase has no useful per-file
+            # progress, so indeterminate is the honest signal.
+            self.progress_pct.emit(0, 0, "Applying DataForge patches…")
+            self.progress.emit("Applying DataForge patches…")
+            patch_root = resolve_patches_dir()
+            report = apply_patches(patch_root, self._cache_dir,
+                                   progress_callback=self.progress.emit)
+            logger.info(f"DataForge patches: {report.summary_line()}")
+            if report.errors:
+                for err in report.errors:
+                    logger.warning(f"  patch error: {err}")
+            self.finished.emit(True)
+        except Exception as e:
+            logger.exception(f"DataForge extraction failed: {e}")
+            self.error.emit(str(e))
+            self.finished.emit(False)
+
+
+class SelectAllDelegate(QStyledItemDelegate):
+    """Custom delegate for the Custom Value column.
+
+    - Selects all text when the editor opens so typing overwrites but Esc keeps it.
+    - Extends the editor's right-click menu with <EM3>/<EM4> wrap actions so
+      authors can apply Star Citizen emphasis tags around the selected text.
+    """
+
+    def createEditor(self, parent, option, index):
+        from PyQt6.QtWidgets import QLineEdit
+        editor = super().createEditor(parent, option, index)
+        if hasattr(editor, 'selectAll'):
+            editor.selectAll()
+        if isinstance(editor, QLineEdit):
+            editor.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
+            editor.customContextMenuRequested.connect(
+                lambda pos, ed=editor: SelectAllDelegate._show_editor_menu(ed, pos)
+            )
+        return editor
+
+    @staticmethod
+    def _show_editor_menu(editor, pos):
+        menu = editor.createStandardContextMenu()
+        menu.addSeparator()
+        has_sel = editor.hasSelectedText()
+        em3 = menu.addAction("Underline")
+        em3.setEnabled(has_sel)
+        em3.triggered.connect(lambda: SelectAllDelegate._wrap_selection(editor, "EM3"))
+        em4 = menu.addAction("Highlight")
+        em4.setEnabled(has_sel)
+        em4.triggered.connect(lambda: SelectAllDelegate._wrap_selection(editor, "EM4"))
+        menu.exec(editor.mapToGlobal(pos))
+
+    @staticmethod
+    def _wrap_selection(editor, tag: str):
+        sel = editor.selectedText()
+        if not sel:
+            return
+        # QLineEdit.insert replaces the current selection. Place the caret
+        # just inside the closing tag so successive edits stay near the text.
+        wrapped = f"<{tag}>{sel}</{tag}>"
+        start = editor.selectionStart()
+        editor.insert(wrapped)
+        editor.setCursorPosition(start + len(f"<{tag}>") + len(sel))

--- a/src/utils/resource_path.py
+++ b/src/utils/resource_path.py
@@ -1,0 +1,34 @@
+"""Resource-path helpers shared by the GUI and the worker thread modules.
+
+PyInstaller bundles the project tree under ``sys._MEIPASS`` at runtime; outside
+the bundle, resources are read from the project root. Both the main window
+(asset images, ABOUT.md, HELP.md, tutorial.json) and the worker threads
+(DataForge patch files) need to resolve paths against the same base, so the
+helpers live here in one place.
+"""
+
+import os
+import sys
+from pathlib import Path
+
+
+def get_resource_path(relative_path: str) -> str:
+    """Return the absolute path for a bundled resource.
+
+    Works for both development runs (``python src/main.py``) and frozen
+    PyInstaller builds (``sys._MEIPASS`` is set).
+    """
+    try:
+        # PyInstaller creates a temp folder and stores path in _MEIPASS
+        base_path = sys._MEIPASS  # type: ignore[attr-defined]
+    except AttributeError:
+        # Not running as a PyInstaller bundle — anchor at the project root
+        # (this file lives at <root>/src/utils/resource_path.py).
+        base_path = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+    return os.path.join(base_path, relative_path)
+
+
+def resolve_patches_dir() -> Path:
+    """Return the path to the bundled DataForge patches directory."""
+    return Path(get_resource_path("patches"))

--- a/tests/test_resource_path.py
+++ b/tests/test_resource_path.py
@@ -1,0 +1,63 @@
+"""Tests for src.utils.resource_path — get_resource_path / resolve_patches_dir."""
+
+import os.path as _osp
+import sys
+from pathlib import Path
+
+import pytest
+
+from utils.resource_path import get_resource_path, resolve_patches_dir
+
+pytestmark = pytest.mark.unit
+
+
+class TestGetResourcePath:
+    def test_unfrozen_returns_path_under_project_root(self):
+        """Outside a PyInstaller bundle, the path is rooted at the project dir."""
+        result = get_resource_path("patches")
+        assert Path(result).name == "patches"
+        assert Path(result).is_absolute()
+
+    def test_unfrozen_no_meipass_set(self):
+        """Sanity check: tests should not run inside a frozen build."""
+        assert not hasattr(sys, "_MEIPASS"), (
+            "_MEIPASS should not be set in the test process (would mean tests "
+            "are running inside a frozen build)"
+        )
+
+    def test_frozen_uses_meipass(self, monkeypatch, tmp_path):
+        """When _MEIPASS is set, get_resource_path uses it as the base."""
+        monkeypatch.setattr(sys, "_MEIPASS", str(tmp_path), raising=False)
+        result = get_resource_path("patches")
+        assert result == str(tmp_path / "patches")
+
+    def test_nested_relative_path(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(sys, "_MEIPASS", str(tmp_path), raising=False)
+        result = get_resource_path("assets/fonts")
+        # os.path.join preserves the slash style from the relative arg —
+        # normalise both sides before comparing.
+        assert _osp.normpath(result) == _osp.normpath(str(tmp_path / "assets" / "fonts"))
+
+    def test_meipass_cleanup_doesnt_leak_between_tests(self, monkeypatch, tmp_path):
+        """Confirm monkeypatch's setattr(_, raising=False) reverts cleanly."""
+        monkeypatch.setattr(sys, "_MEIPASS", str(tmp_path), raising=False)
+        assert hasattr(sys, "_MEIPASS")
+        monkeypatch.undo()
+        assert not hasattr(sys, "_MEIPASS")
+
+
+class TestResolvePatchesDir:
+    def test_returns_path_instance(self):
+        result = resolve_patches_dir()
+        assert isinstance(result, Path)
+
+    def test_name_is_patches(self):
+        assert resolve_patches_dir().name == "patches"
+
+    def test_is_absolute(self):
+        assert resolve_patches_dir().is_absolute()
+
+    def test_uses_meipass_when_frozen(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(sys, "_MEIPASS", str(tmp_path), raising=False)
+        result = resolve_patches_dir()
+        assert result == tmp_path / "patches"


### PR DESCRIPTION
## Summary

Lifts the `QThread` workers, the shared progress dialog, and the cell-edit delegate out of `main_window.py` so each can be reasoned about (and later tested) in isolation. **Net: `main_window.py` drops from 3900 to 3521 lines** (-379).

This is PR-A in the series distilling the useful refactors from #5 — independent of #6.

### New: `src/gui/workers.py` (402 lines)

- `AnimatedProgressDialog` — indeterminate↔determinate progress dialog
- `FileLoaderWorker` — load sources, build StringEntry list, sort keys
- `StartupSyncWorker` — refresh URL-backed sources on startup
- `EnhancementsGeneratorWorker` — run `scripts/generate_enhancements_ini.py`
- `P4kExtractWorker` — unp4k extraction of `global.ini`
- `DataForgeExtractWorker` — unp4k + unforge + patch pipeline
- `SelectAllDelegate` — Custom Value cell delegate (auto-select + EM3/EM4 wrap actions)

### New: `src/utils/resource_path.py` (34 lines)

- `get_resource_path(rel)` — PyInstaller-aware bundled-resource resolver
- `resolve_patches_dir()` — `Path` → bundled DataForge patches dir

Lives in `src/utils/` rather than `src/gui/` because the workers and the main window both depend on it; keeping it leaf-level avoids `workers.py` importing from `main_window.py` or vice versa.

### Behavior preserved exactly

Same class bodies, same signal contracts, same in-method imports. Only renames:
- `get_resource_path`: argument was untyped, now `str` (was already a `str` at every call site).
- `_resolve_patches_dir` → `resolve_patches_dir` — dropped the leading underscore since it's no longer module-private.

### `main_window.py` changes

- Removed the 7 extracted classes and the two resource-path helpers.
- Consolidated the mid-file imports — there were two import blocks before, with `AnimatedProgressDialog` between them — now one alphabetised block at the top.
- New imports: `workers` (the 7 names) and `resource_path.get_resource_path`.

`AppUpdateCheckWorker` stays in `src/utils/app_updater.py` — unchanged. This PR only reorganises what was already in `main_window.py`.

### New tests

`tests/test_resource_path.py` — 9 tests covering `get_resource_path` (unfrozen / frozen via `_MEIPASS` / nested paths / monkeypatch hygiene) and `resolve_patches_dir`. Pure-function tests — no Qt required.

Worker tests are out of scope: they need `pytest-qt` (not currently a dev dependency); adding it is a separate decision.

### Test result

124 pass (was 115 baseline), 4 `test_pak_extraction.py::TestDataForgeCache` failures unchanged (unrelated pre-existing `dataforge_cache_dir` str/Path bug, separate fix). `test_core.py` still doesn't collect on this branch — that's #6's fix.

### Relationship to other PRs

- **#6** (helper extractions) — independent. Both PRs touch `main_window.py` but in different sections (helpers around lines 1500/3400/3700; workers around lines 30 and 280-580). Either can merge first; the loser will need a one-line conflict resolution at the top imports block.
- **PR-C** (bug fixes) — sequenced after both #6 and #A.

### Attribution

Module sources adapted from jonigirl's work in #5. The `resource_path` extraction, the import consolidation in `main_window.py`, and the test coverage are this PR's additions. (#5's `workers.py` also moves `AppUpdateCheckerWorker` and adds `tools_manager`-gated branches — neither is taken here.)

## Test plan

- [x] `pytest tests/` — 124 pass, 4 unrelated pre-existing pak_extraction failures
- [x] `python -c "from src.gui.main_window import MainWindow"` resolves
- [x] `python -c "from src.gui.workers import AnimatedProgressDialog, FileLoaderWorker, StartupSyncWorker, EnhancementsGeneratorWorker, P4kExtractWorker, DataForgeExtractWorker, SelectAllDelegate"` resolves
- [ ] Manual smoke test: launch app and exercise each worker once (file load, source sync, enhancements regen, P4K extract, DataForge extract). Open + double-click a Custom Value cell to confirm the delegate auto-selects and the EM3/EM4 menu items work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)