### PR TITLE
Add Engagement Type (FPS / Ship / FPS & Ship) to mission descriptions

### DIFF
--- a/ABOUT.md
+++ b/ABOUT.md
@@ -23,6 +23,12 @@ Thanks to the testers and contributors who helped shape Smart Citizen with their
 - **Lord Valium**
 - **Zero**
 
+### Supporters
+
+Thanks to those who've supported the project financially — your contributions help keep Smart Citizen free for everyone:
+
+- **Dimwit the Wise**
+
 Smart Citizen also bundles upstream tooling from:
 
 - [**dolkensp/unp4k**](https://github.com/dolkensp/unp4k) — `unp4k.exe` and `unforge.exe`, used to unpack `Data.p4k` and convert DataForge to XML

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,11 +4,11 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Smart Citizen (formerly SC Localization Editor) is a Windows-only PyQt6 GUI application for customizing Star Citizen localization strings. Tagline: *Smarter Strings for Star Citizen*. Users configure multiple data sources (Global, Contracts, Components, Ships, Commodities, Gear, User) with a drag-and-drop merge hierarchy, edit strings in a table, and apply changes to their game installation with automatic backup management.
+Smart Citizen (formerly SC Localization Editor) is a Windows-only PyQt6 GUI application for customizing Star Citizen localization strings. Tagline: *Smarter Strings for Star Citizen*. Users edit strings in a table backed by a `global` source (locally cached `base.ini` from Data.p4k extraction) merged with their per-channel `user.ini` overrides, then apply the result to their game installation with automatic backup management.
 
 **Rebrand status**: As of 0.9.0, user-facing strings, registry path (`Osiris DevWorks\Smart Citizen`), and the user data root (`Documents\Smart Citizen\`) all use the new name. `AppSettings` still contains one-shot migrators for the legacy `Osiris DevWorks\SC Localization Editor` registry tree and `Documents\SC Localization Editor\` directory; do not remove them while users on pre-0.9 builds may still upgrade.
 
-**Current Version**: Read from `VERSION.TXT` (single source of truth). Project is at 1.0 as of this writing.
+**Current Version**: Read from `VERSION.TXT` (single source of truth).
 
 ## Quick Commands
 
@@ -48,7 +48,7 @@ python scripts/extract_components.py [--stock path] [--base path] [--output path
 
 ## Testing Strategy
 
-**Unit Tests** (`tests/`): Split by domain — `test_core.py` (INI parsing/merging/category extraction), `test_missions.py` (mission rewards pipeline), `test_pak_extraction.py` (P4K/DataForge), `test_progress_sink.py` (thread-safe progress coalescing), `test_dataforge_patcher.py` (declarative XML patching), `test_app_updater.py` (GitHub Releases version-check worker), `test_channel_layout.py` (per-channel directory migration). Pytest config lives in `tests/pytest.ini` (sets `pythonpath = src`, registers markers: `unit`, `integration`, `slow`, `critical`, `regression`).
+**Unit Tests** (`tests/`): Split by domain — `test_core.py` (INI parsing/merging/category extraction; `TestStringEntry` is currently `@pytest.mark.skip` because its constructor calls predate `category` and `status` becoming required positional args — fix is a separate cleanup), `test_missions.py` (mission rewards pipeline), `test_pak_extraction.py` (P4K/DataForge), `test_progress_sink.py` (thread-safe progress coalescing), `test_dataforge_patcher.py` (declarative XML patching), `test_app_updater.py` (GitHub Releases version-check worker), `test_channel_layout.py` (per-channel directory migration), `test_retired_url_sources_migration.py` (1.0 cleanup of the contracts/components/ships/commodities/gear sources retired in 0.7.0 — covers fresh-install defaults, upgrade-time pruning, URL-vs-local guard, and idempotence), `test_applied_file_validator.py` (post-apply `global.ini` vs stock `base.ini` validation), `test_entry_filter.py` (column-filter logic + the `NUM_COLUMNS` getter-tuple drift guard), `test_markdown_renderer.py` (About/Help markdown→HTML conversion), `test_resource_path.py` (PyInstaller `_MEIPASS`-aware resource resolution). Worker classes themselves have no automated tests — they need `pytest-qt` (not currently a dev dependency); manual smoke testing is still the only verification path for the QThread workers in `workers.py`. Pytest config lives in `tests/pytest.ini` — `pythonpath = . src` (project root for `from src.X` imports + `src/` for legacy `from utils.X` imports used by older tests), registers markers: `unit`, `integration`, `slow`, `critical`, `regression`.
 
 **GUI Testing**: Manual. Run app (`python src/main.py`), load base file, edit a value, apply to game, restart to verify persistence. Use the Log Tab to watch for errors during load/merge/apply cycles.
 
@@ -57,7 +57,9 @@ python scripts/extract_components.py [--stock path] [--base path] [--output path
 Entry point: `src/main.py`. The app has two main layers:
 
 **GUI layer** (`src/gui/`):
-- `main_window.py` — Main window with table, toolbar, filters, backup/restore, threading workers, DataForge extraction. This is the largest file (~2000+ lines). Manages the primary workflow: load, merge, edit, apply.
+- `main_window.py` — Main window with table, toolbar, filters, backup/restore, DataForge extraction trigger, and worker-thread orchestration. ~3275 lines after the PR #6 + PR #7 extractions; manages the primary workflow: load, merge, edit, apply. Worker classes live in `workers.py`; pure-Python helpers (`validate_applied_file`, `filter_entry_indices`, `markdown_to_html`) live in their own modules and are wrapped by thin `MainWindow` methods.
+- `workers.py` — All `QThread` background workers + the shared `AnimatedProgressDialog` and `SelectAllDelegate`. Workers: `FileLoaderWorker` (load sources → build `StringEntry` list + sort keys), `StartupSyncWorker` (refresh URL-backed sources at startup), `EnhancementsGeneratorWorker` (run `scripts/generate_enhancements_ini.py` in-process via `importlib.util`), `P4kExtractWorker` (unp4k extraction of `global.ini`), `DataForgeExtractWorker` (unp4k + unforge + post-extract patches). Each worker emits `progress` (str) + `progress_pct` (completed, total, message) signals; `AnimatedProgressDialog.set_progress` consumes the latter. `AppUpdateCheckWorker` is the exception — it lives in `src/utils/app_updater.py` because the worker, the version-comparison logic, and the registry timestamp-cap belong together as one unit.
+- `markdown_renderer.py` — `markdown_to_html(text, text_color, base_color, link_color)` for the About / Help panels. Pure-Python; the Qt caller passes in palette colours so the converter has no Qt dependency. Stash-and-restore code-span handling means `**` and `_` inside backticks stay literal (important: loc keys like `vehicle_Name*` shouldn't sprout `<em>` tags).
 - `config_tab.py` — **Config Tab**: Data source management (add/edit/remove sources), drag-drop merge hierarchy, Star Citizen install path, and DataForge extraction trigger.
 - `enhancements_tab.py` — **Enhancements Tab**: Toggle stats overlays, configure ship favorites prefix, trigger DataForge extraction. Emits `merge_requested` and `stats_pipeline_requested` signals.
 - `log_tab.py` — **Log Tab**: In-app real-time log viewer. Bridges Python `logging` to Qt text widget via `_LogEmitter` signal (thread-safe). Supports level filtering, auto-scroll, and log export.
@@ -71,8 +73,8 @@ Entry point: `src/main.py`. The app has two main layers:
 - `string_model.py` — `StringEntry` dataclass with category extraction from key prefixes.
 - `ini_parser.py` — Line-by-line INI parsing (splits on first `=`), source loading via `load_sources_from_settings()`, and `load_overrides(target_path)` for reading `user.ini` back as a `dict[str, str]`.
 - `ini_merger.py` — Merge engine: `merge_sources_by_hierarchy(sources_dict, hierarchy, user_overrides)`. Sources merge sequentially; user overrides always win.
-- `settings.py` — `AppSettings` class wrapping QSettings (Windows Registry). User data lives under the configured data root (default `Documents\Smart Citizen\`) plus `{active_channel}\`. Critical: Registry is the single source of truth for all paths and preferences. Also owns canonical paths (`get_user_data_dir()`, `get_cache_dir()`, `get_user_ini_path()`, `get_backups_dir()`) and handles automatic migrations: legacy `overrides.ini` → `user.ini`, `AppData\Roaming\...` → the configured data root, and the 0.9.3+ flat layout → per-channel layout (`migrate_game_path_to_channel_layout()`).
-- `updater.py` — Per-source GitHub downloads. Drives the auto-update workers that refresh each cached source INI (`base.ini`, `contracts.ini`, etc.) from its configured GitHub URL.
+- `settings.py` — `AppSettings` class wrapping QSettings (Windows Registry). User data lives under the configured data root (default `Documents\Smart Citizen\`) plus `{active_channel}\`. Critical: Registry is the single source of truth for all paths and preferences. Also owns canonical paths (`get_user_data_dir()`, `get_cache_dir()`, `get_user_ini_path()`, `get_backups_dir()`) and a chain of one-shot migrators run on every launch (all idempotent): `migrate_legacy_settings()` (seeds `[global, user]` defaults for fresh installs), `migrate_remove_retired_url_sources()` (1.0 prune of contracts/components/ships/commodities/gear from upgrader registries — only when the stored path is a URL; local-path overrides are preserved), `migrate_global_to_p4k_local()` (rewrites `global` from a URL to the local cached `base.ini`), `migrate_registry_appname()` (`SC Localization Editor` → `Smart Citizen` registry tree), `migrate_docs_folder_rename()` (`Documents\SC Localization Editor\` → `Documents\Smart Citizen\`), `migrate_data_to_documents()` (`AppData\Roaming\...` → the configured data root), `migrate_game_path_to_channel_layout()` (0.9.3+ flat layout → per-channel layout).
+- `updater.py` — Per-source GitHub downloads. Drives the auto-update workers that refresh cached source INIs from their configured GitHub URL. Post-1.0 the only URL-backed source is `global` (`base.ini`); the four legacy URL sources have been retired in favor of local Data.p4k extraction.
 - `app_updater.py` — *Separate* from `updater.py`. Polls `GET /repos/Osiris-DevWorks/smart-citizen/releases/latest` and compares `tag_name` to the local `VERSION.TXT` to surface a "new installer available" prompt. Runs on a `QThread`; `MainWindow` caps auto-checks to once per 6 hours via a registry timestamp to stay under GitHub's 60-req/hr unauthenticated limit.
 - `pak_extractor.py` — P4K extraction pipeline: `unp4k.exe` (extracts Game2.dcb) → `unforge.exe` (converts to entity XMLs). After unforge writes the full DataForge tree to a temp dir, `_copy_filtered_records()` copies only the subtrees in `DATAFORGE_KEEP_SUBPATHS` (the ones the generator actually reads) to the persistent cache — halves cache file count and cuts copy/rmtree wall time. Adding a new read path in the generator requires adding it to `DATAFORGE_KEEP_SUBPATHS`; `tests/test_pak_extraction.py::TestDataForgeKeepList` locks the contract.
 - `user_ini_manager.py` — Saves user-modified entries to `user.ini` (plain `key=value`, no sections) via `save_user_ini(entries, path)`; coordinates with `ImportConflictDialog` when importing external INIs.
@@ -81,6 +83,9 @@ Entry point: `src/main.py`. The app has two main layers:
 - `perf.py` — `@timed` decorator for debug-level performance profiling. No-op when DEBUG logging disabled.
 - `progress_sink.py` — `ProgressSink` coalesces `advance()` calls from many worker threads into throttled `(completed, total, message)` callbacks. Used by the parallelized lookup builders and enhancement generators to drive determinate progress bars without flooding the Qt event loop.
 - `dataforge_patcher.py` — Applies declarative JSON patches from `patches/` to the DataForge XML cache immediately after extraction. Fixes upstream CIG data bugs (e.g. mission records pointing at wrong loc-keys) so downstream consumers see corrected data. Patches mirror the DataForge layout under `patches/<category>/.../<name>.patch.json`.
+- `applied_file_validator.py` — `validate_applied_file(written_path, cache_dir, stock_keys=None)`: independently re-parses the just-written `global.ini` against the cached `base.ini` and returns a human-readable diff (missing / unexpected keys) or `""` when valid. `MainWindow._validate_applied_file` is a thin wrapper that supplies the cache dir from `AppSettings`. Lets `apply_to_game` auto-rollback on a merger bug.
+- `entry_filter.py` — `filter_entry_indices(...)`: pure-Python row filter for the strings table (column filters + category / status / hide-unmodified / favorites-only). Imports `NUM_COLUMNS` from `string_table_model` so the OOB-bounds guard stays in sync if a column is added; bad indices are dropped + logged once instead of raising `IndexError` deep in the per-entry loop. Per-call getter tuple lets the hot path call only the getters for active filters.
+- `resource_path.py` — `get_resource_path(rel)` (PyInstaller `_MEIPASS`-aware) and `resolve_patches_dir()` (`Path` to bundled `patches/`). Lives in `src/utils/` rather than `src/gui/` because both `main_window.py` and `workers.py` depend on it — keeping it leaf-level avoids a `gui` ↔ `gui` import cycle.
 
 **Scripts** (`scripts/`):
 - `generate_enhancements_ini.py` — Reads DataForge entity XMLs only (no external JSON) → outputs enhancement INI files to cache (ships, components, ship weapons, FPS weapons descriptions).
@@ -88,6 +93,7 @@ Entry point: `src/main.py`. The app has two main layers:
 - `gen_commodity_crafting.py` — Generates `commodity_crafting_enhancements.ini` with crafting blueprint usage data from DataForge XMLs.
 - `compare_kraken_fixture.py` — Research/reporting tool: diffs the `kraken_4.7.ini` ground-truth fixture against our generated `mission_rewards_enhancements.ini` to validate blueprint list output. Read-only.
 - `diff_bp_kraken.py`, `diff_bp_annotations.py`, `diff_bp_csv_fixture.py` — Read-only diagnostic scripts validating `[BP]` / `[BP?]` blueprint annotations on mission rewards. Each compares our `mission_rewards_enhancements.ini` output against a different ground-truth source (kraken fixture, an applied LIVE `global.ini`, and the `missions_4.7.177.csv` per-variant fixture, respectively). Use these when blueprint tags regress.
+- `diff_base_ini_channels.py` — Read-only: diffs cached `base.ini` between two SC channels (e.g. `LIVE` vs `PTU`) and reports added / removed / changed loc keys as a category-bucket summary plus optional full machine-readable list. Defaults to `%USERPROFILE%\Documents\Smart Citizen` and supports `--user-data` for OneDrive-redirected installs.
 - `discord_notify.py` — GitHub Actions release webhook notifier.
 - `build/build_exe.py`, `build/build_all.bat`, `build/clean_cache_for_distribution.py` — Build pipeline; see `scripts/build/BUILD_INSTRUCTIONS.md`.
 
@@ -102,7 +108,7 @@ The table is a `QTableView` backed by `StringTableModel` (`src/gui/string_table_
 The cached global source is saved as `base.ini` (not `global.ini`) to avoid confusion with the game's `global.ini` at `LIVE/data/Localization/english/global.ini`.
 
 ### Threading model
-All I/O-bound operations (file loads, network requests, P4K extraction) run in `QThread` workers. Workers emit `finished()` signals; cleanup requires `quit()` + `wait()`. Never block the main thread with file or network operations. Bulk table updates wrap in `setUpdatesEnabled(False)`. Registry access (via `AppSettings`) is thread-safe; use it freely from main or worker threads.
+All I/O-bound operations (file loads, network requests, P4K extraction) run in `QThread` workers — they live in `src/gui/workers.py` (with `AppUpdateCheckWorker` as the lone exception, which lives next to its companion logic in `src/utils/app_updater.py`). Workers emit `finished()` signals; cleanup requires `quit()` + `wait()`. Never block the main thread with file or network operations. Bulk table updates wrap in `setUpdatesEnabled(False)`. Registry access (via `AppSettings`) is thread-safe; use it freely from main or worker threads. Worker logger names are `src.gui.workers` post-extraction (was `src.gui.main_window` pre-extraction) — relevant if you grep logs.
 
 ### Startup initialization
 On first run, the app initializes user data directories, validates Star Citizen install path, and may show a startup dialog to guide configuration. Subsequent runs check source freshness and auto-apply any pending DataForge cache updates.
@@ -114,7 +120,7 @@ The "Extract DataForge from P4K" button triggers: (1) unpack Data.p4k → entity
 Lookup builders and enhancement output generators run in parallel worker threads (see `scripts/generate_enhancements_ini.py`). They share a single `ProgressSink` (`src/utils/progress_sink.py`) so the UI shows one determinate progress bar. Never call `QProgressBar.setValue()` directly from workers — go through the sink so updates are coalesced and throttled on the main thread.
 
 ### Merge hierarchy
-Sources merge in user-defined order (default: global → contracts → components → ships → commodities → gear → user). Later sources overwrite earlier ones. User overrides are always applied last and never lost during source updates.
+Sources merge in user-defined order. Later sources overwrite earlier ones; user overrides are always applied last and never lost during source updates. As of 1.0 the seeded default is just `[global, user]` — the four URL-based sources (contracts/components/ships/commodities) and `gear` were retired in 0.7.0 when extraction moved to local Data.p4k, and `migrate_remove_retired_url_sources()` cleans them out of upgrader registries. `load_sources_from_settings()` additionally injects a synthetic `enhancements` source at runtime when any enhancement category is enabled on the Enhancements tab — it is *not* a registry entry and shouldn't be added to the hierarchy by hand.
 
 ### Favorites use value prefix
 Favorites prepend a configurable prefix (default `*`) to `custom_value`. The prefix is stored in Registry via `AppSettings.FAVORITE_PREFIX`.
@@ -127,7 +133,7 @@ Favorites prepend a configurable prefix (default `*`) to `custom_value`. The pre
 | User data root | Configurable via `user_data_dir` (alias `UserDataDir` is also read); defaults to `Documents\Smart Citizen\` |
 | **Per-channel data** | `{user_data_root}\{LIVE|PTU|EPTU|HOTFIX|TECH-PREVIEW}\` — 0.9.3+ nests user.ini / cache / backups / dataforge under the active channel so each SC channel is isolated. Migrator: `AppSettings.migrate_game_path_to_channel_layout()`. |
 | User overrides | `{user_data_root}\{active_channel}\user.ini` (legacy `overrides.ini`, auto-migrated) |
-| Cached sources | `{user_data_root}\{active_channel}\cache\` (`base.ini`, `contracts.ini`, etc.) |
+| Cached sources | `{user_data_root}\{active_channel}\cache\` — only `base.ini` post-1.0 (the four legacy URL-based source INIs were retired in 0.7.0); enhancement INIs live alongside it, see below |
 | DataForge cache | `{user_data_root}\{active_channel}\cache\dataforge\` (entity XMLs from Data.p4k) |
 | Enhancement INIs | `{user_data_root}\{active_channel}\cache\` (`ships_desc_enhancements.ini`, `components_desc_enhancements.ini`, `ship_weapons_desc_enhancements.ini`, `fps_weapons_desc_enhancements.ini`, `mission_rewards_enhancements.ini`, `commodity_crafting_enhancements.ini`) |
 | Backups | `{user_data_root}\{active_channel}\backups\` (max 5, oldest auto-deleted) |
@@ -140,9 +146,10 @@ Favorites prepend a configurable prefix (default `*`) to `custom_value`. The pre
 
 | Task | File | Key Function |
 |------|------|-------------|
-| Add/change table columns | `main_window.py` | `setup_string_table()` |
-| Add/change filters | `main_window.py` | `apply_filters()`, `on_filter_changed()` |
-| Change per-column filters | `filter_header.py` | `FilterHeaderView` |
+| Add/change table columns | `main_window.py`, `string_table_model.py` | `setup_string_table()`, `NUM_COLUMNS` + `COL_*` constants (also referenced by `entry_filter.py`'s getter tuple) |
+| Add/change filters (UI wiring) | `main_window.py` | `apply_filters()`, `on_filter_changed()` |
+| Change row-filter logic | `entry_filter.py` | `filter_entry_indices()` (delegated to from `MainWindow._filtered_entry_indices`) |
+| Change per-column filter widgets | `filter_header.py` | `FilterHeaderView` |
 | Change category extraction | `string_model.py` | `StringEntry.extract_category()` |
 | Modify INI parsing | `ini_parser.py` | `parse_ini_file()` |
 | Change merge logic | `ini_merger.py` | `merge_sources_by_hierarchy()` |
@@ -163,6 +170,10 @@ Favorites prepend a configurable prefix (default `*`) to `custom_value`. The pre
 | Change user.cfg behavior | `user_cfg.py` | `ensure_user_cfg_language()` |
 | Fix an upstream DataForge data bug | `patches/<category>/.../<name>.patch.json`, `dataforge_patcher.py` | `apply_patches()` |
 | Change parallel progress reporting | `progress_sink.py` | `ProgressSink.advance()` |
+| Change post-apply validation | `applied_file_validator.py` | `validate_applied_file()` (wrapped by `MainWindow._validate_applied_file`) |
+| Change About / Help markdown rendering | `markdown_renderer.py` | `markdown_to_html()` (wrapped by `MainWindow.markdown_to_html`, which supplies palette colours) |
+| Add or modify a background worker | `workers.py` | The relevant `*Worker` class (subclass of `QThread`) |
+| Change resource-path resolution (PyInstaller bundle vs dev) | `resource_path.py` | `get_resource_path()`, `resolve_patches_dir()` |
 
 ## Version & Release
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,53 @@
+Smart Citizen
+Copyright 2026 Osiris DevWorks
+
+This product is licensed under the Apache License, Version 2.0
+(the "License"); you may not use this product except in compliance
+with the License. You may obtain a copy of the License at:
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+================================================================================
+Bundled third-party software
+================================================================================
+
+unp4k / unforge
+---------------
+This product bundles the unp4k and unforge command-line tools (under
+assets/unp4k/) from https://github.com/dolkensp/unp4k by Peter Dolkens
+and contributors. Used to unpack Star Citizen's Data.p4k archive and
+convert DataForge entity files to XML.
+
+unp4k is licensed under the MIT License:
+
+    Permission is hereby granted, free of charge, to any person obtaining
+    a copy of this software and associated documentation files (the
+    "Software"), to deal in the Software without restriction, including
+    without limitation the rights to use, copy, modify, merge, publish,
+    distribute, sublicense, and/or sell copies of the Software, and to
+    permit persons to whom the Software is furnished to do so, subject
+    to the following conditions:
+
+    The above copyright notice and this permission notice shall be
+    included in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+    IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+    CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+    TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+    SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+================================================================================
+Trademarks and game data
+================================================================================
+
+Star Citizen and all associated game data, including Data.p4k, are the
+property of Cloud Imperium Rights LLC and Cloud Imperium Rights Ltd.
+Smart Citizen reads game files from your own licensed Star Citizen
+installation and does not redistribute any RSI or CIG content.
+
+Smart Citizen is a community fan project and is not affiliated with,
+endorsed by, or sponsored by Cloud Imperium Games or Roberts Space
+Industries.

--- a/README.md
+++ b/README.md
@@ -194,6 +194,12 @@ StarCitizen/
 - [**MrKraken**](https://github.com/MrKraken/StarStrings) — ASOP terminal enhancements, workflow improvements, and mission contract localization work
 - The **Star Citizen community** — for endless feedback, testing, and ideas
 
+### Supporters
+
+Thanks to those who've supported the project financially — your contributions help keep Smart Citizen free for everyone:
+
+- **Dimwit the Wise**
+
 ## License
 
 Smart Citizen is licensed under the **Apache License, Version 2.0** — see [LICENSE](LICENSE) for the full text and [NOTICE](NOTICE) for attribution of bundled third-party software (`unp4k` / `unforge`) and the Star Citizen / CIG trademark notice.

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ StarCitizen/
 
 ## License
 
-This project is provided as-is for community use. See LICENSE file for details.
+Smart Citizen is licensed under the **Apache License, Version 2.0** — see [LICENSE](LICENSE) for the full text and [NOTICE](NOTICE) for attribution of bundled third-party software (`unp4k` / `unforge`) and the Star Citizen / CIG trademark notice.
 
 ## Support & Community
 

--- a/scripts/generate_enhancements_ini.py
+++ b/scripts/generate_enhancements_ini.py
@@ -373,6 +373,64 @@ def _mission_loc_key(root: ET.Element) -> str | None:
     return None
 
 
+# Loc-key tokens that flag a mission as on-foot / first-person. Lowercase
+# substring match against the loc_key. CIG's own naming convention puts these
+# in the key whenever the mission is FPS-themed (e.g.
+# ``BountyHuntersGuild_FPS_Nyx``, ``vaughn_assassination_FPS_UGF_legal_…``,
+# ``GoblinG_Crusader_RecoverCargoFPS_L_Title``). UGF = Underground Facility,
+# always FPS. ``ugf`` is matched as a standalone token via word-boundary check
+# below to avoid false-positives on substrings like ``frugfrog``.
+_FPS_TOKENS = (
+    "_fps_", "fps_", "_fps", "fpsmine",
+    "_ugf_", "ugf_", "_ugf",
+    "_onfoot_", "onfoot_", "_onfoot",
+    "_foot_",
+)
+
+# Tokens that flag the mission also requires ship transport ON TOP OF the
+# FPS work. Cargo recovery / salvage / hauling missions take the player
+# in on foot to deal with hostiles + retrieve goods, then back out by ship
+# to drop the cargo at a freight elevator (typical "RecoverCargoFPS"
+# pattern). Combined with an FPS marker, this promotes the classification
+# from ``FPS`` to ``FPS & Ship``.
+_FPS_PLUS_SHIP_TOKENS = (
+    "recovercargo", "cargo_recover",
+    "salvage", "hauling",
+    "freight",
+)
+
+
+def _classify_mission_engagement(loc_key: str | None) -> str:
+    """Classify a mission as FPS / Ship / FPS & Ship from its loc_key.
+
+    Conservative defaults — when in doubt, classify as ``Ship`` (the most
+    common SC mission category and the safer mis-classification: a player
+    who's expecting ship combat and gets dropped into FPS will reload and
+    re-prep, but the inverse is rare in this dataset).
+
+    Rules (applied in order):
+
+    1. No FPS marker in the key → ``Ship``
+    2. FPS marker present + cargo / salvage / freight token also present
+       → ``FPS & Ship`` (mission needs FPS gear AND a ship for transport)
+    3. FPS marker present, no transport token → ``FPS``
+    """
+    if not loc_key:
+        return "Ship"
+
+    key_lower = loc_key.lower()
+
+    has_fps = any(tok in key_lower for tok in _FPS_TOKENS)
+    if not has_fps:
+        return "Ship"
+
+    has_transport = any(tok in key_lower for tok in _FPS_PLUS_SHIP_TOKENS)
+    if has_transport:
+        return "FPS & Ship"
+
+    return "FPS"
+
+
 def _resource_amount(amount_el: ET.Element) -> str | None:
     """Extract the numeric value from a resourceAmountPerSecond element."""
     unit = amount_el.find(".//SPowerSegmentResourceUnit")
@@ -1236,6 +1294,7 @@ def enhancements_mission(root: ET.Element, reputation_lookup: dict[str, int] | N
     """Extract mission/contract reward stats (aUEC + Reputation XP) and flags.
 
     Extracts:
+    - Engagement Type (FPS / Ship / FPS & Ship) from the mission loc_key
     - aUEC mission reward amount
     - Reputation XP from reward UUID references using the reputation_lookup table
     - Mission flags (Chain, Starter, Unique)
@@ -1244,6 +1303,14 @@ def enhancements_mission(root: ET.Element, reputation_lookup: dict[str, int] | N
     reputation_lookup = reputation_lookup or {}
 
     try:
+        # Engagement Type comes first so players can see at a glance whether
+        # to kit up for FPS or ship combat. Re-extract the loc_key here
+        # rather than threading it through scan_entity_dir's callback —
+        # cheap (single attribute read), avoids changing the enhancement_fn
+        # signature shared with non-mission generators.
+        loc_key = _mission_loc_key(root) or _loc_key(root)
+        lines.append(f"<EM4>Engagement Type:</EM4> {_classify_mission_engagement(loc_key)}")
+
         # Extract mission flags
         flags = _extract_mission_flags(root)
         lines.append(f"<EM4>Mission Type:</EM4> {', '.join(flags) if flags else 'Standard'}")

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -314,7 +314,19 @@ class MainWindow(QMainWindow):
             "Select a row to preview its rendered text."
         )
         self.preview_pane.setMinimumWidth(420)
-        self.preview_pane.setMaximumHeight(200)
+        # Cap to ~the toolbar's natural height (button row + filter row ≈ 80px)
+        # so the preview pane can't drive the toolbar QHBoxLayout taller than
+        # the buttons need. Without this, QTextBrowser's default Expanding
+        # vertical sizePolicy lets the pane grow to its 200px ceiling whenever
+        # the active tab's content has slack vertical space to give back to
+        # main_layout (e.g. the Config tab post-1.3.0, which got taller when
+        # PR #3 added the "Smart Citizen Data" GroupBox). When that happened,
+        # the toolbar row inflated and the buttons appeared to drop ~40px
+        # below the tagline on Config / Enhancements vs. String Editor.
+        # Pre-1.3.0 the bug was latent — main_layout never had enough slack
+        # to expose it. QTextBrowser's built-in scrollbar still handles long
+        # rendered HTML inside the cap.
+        self.preview_pane.setMaximumHeight(80)
 
         toolbar_row = QHBoxLayout()
         toolbar_row.setSpacing(12)

--- a/tests/test_mission_engagement.py
+++ b/tests/test_mission_engagement.py
@@ -1,0 +1,126 @@
+"""Tests for the mission Engagement Type classifier.
+
+The classifier reads CIG's own loc-key naming convention (FPS / UGF / OnFoot
+markers) to tag each mission as ``FPS``, ``Ship``, or ``FPS & Ship``. The
+result is prepended to the MISSION DETAILS block so players can see at a
+glance which loadout to bring before accepting a contract.
+
+These tests exercise the classifier on real loc_keys taken from the
+generated mission_rewards_enhancements.ini fixture so the rules stay
+grounded in actual CIG data, not hypothetical patterns.
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture(scope="module")
+def gen_module():
+    """Load scripts/generate_enhancements_ini.py as an importable module.
+
+    Loaded via importlib because it lives outside src/ and isn't on
+    pythonpath. Cached at module scope — one parse for the whole test file.
+    """
+    repo_root = Path(__file__).resolve().parent.parent
+    script_path = repo_root / "scripts" / "generate_enhancements_ini.py"
+    spec = importlib.util.spec_from_file_location("generate_enhancements_ini_test", script_path)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# ── FPS ───────────────────────────────────────────────────────────────────────
+@pytest.mark.parametrize("loc_key", [
+    # Loc-key fragments lifted verbatim from generated mission output —
+    # these all denote pure-FPS missions (no ship transport phase).
+    "BountyHuntersGuild_FPS_Nyx_title_001",
+    "vaughn_assassination_FPS_UGF_legal_title_001",
+    "vaughn_assassination_FPS_UGF_legal_boss_desc_001",
+    "Bitzeroes_eliminateall_dc_title_001_FPS",  # FPS suffix
+    "PAF_OnFoot_Eliminate_title_001",
+    "Shubin_FPSMine_Stanton_title_001",
+    "BHG_UGF_Boss_desc",
+    "ugf_breach_title_001",
+])
+def test_classifies_as_fps(gen_module, loc_key):
+    assert gen_module._classify_mission_engagement(loc_key) == "FPS"
+
+
+# ── Ship ──────────────────────────────────────────────────────────────────────
+@pytest.mark.parametrize("loc_key", [
+    # No FPS marker anywhere → Ship. Default for the bulk of the dataset.
+    "BountyHuntersGuild_Bounty_Stanton_Easy_title_001",
+    "ECN_Bounty_Stanton_Easy_title_001",
+    "CFP_Delivery_OutpostToStation_title_001",
+    "CFP_Delivery_OutpostToTradepost_title_001",
+    "Headhunters_RegionA_Pyro_title_001",
+    "Bitzeroes_bombingrun_dc_title_001",  # Bitzeroes IS ship combat
+    "destroyitem_dc_title_001",
+    "combatassist_pyro_title_001",
+    "Crus_PatrolMission_title",
+    "fffinale_chapter5_desc",
+])
+def test_classifies_as_ship(gen_module, loc_key):
+    assert gen_module._classify_mission_engagement(loc_key) == "Ship"
+
+
+# ── FPS & Ship ────────────────────────────────────────────────────────────────
+@pytest.mark.parametrize("loc_key", [
+    # FPS marker + cargo/recover/salvage/freight/hauling token → both phases.
+    # Player goes in on foot to deal with hostiles + grab cargo, then back
+    # out by ship to drop at a freight elevator.
+    "GoblinG_ArcCorp_RecoverCargoFPS_L_Title",
+    "GoblinG_Crusader_RecoverCargoFPS_S_Title",
+    "BHG_FPS_Cargo_Recover_desc",
+])
+def test_classifies_as_fps_and_ship(gen_module, loc_key):
+    assert gen_module._classify_mission_engagement(loc_key) == "FPS & Ship"
+
+
+# ── Edge cases ────────────────────────────────────────────────────────────────
+def test_empty_loc_key_defaults_to_ship(gen_module):
+    """Missing loc_key (rare data bug) shouldn't crash — quietly default."""
+    assert gen_module._classify_mission_engagement("") == "Ship"
+    assert gen_module._classify_mission_engagement(None) == "Ship"
+
+
+def test_case_insensitive(gen_module):
+    """Matching is lowercased so KEY casing doesn't shift the answer."""
+    assert gen_module._classify_mission_engagement("MISSION_FPS_TITLE") == "FPS"
+    assert gen_module._classify_mission_engagement("mission_fps_title") == "FPS"
+    assert gen_module._classify_mission_engagement("Mission_Fps_Title") == "FPS"
+
+
+def test_salvage_alone_is_FPS(gen_module):
+    """`CFP_Salvage_FPS_title_001` is FPS-only per CIG — the body text
+    says "Clear Location of Salvage" (player goes in on foot). The
+    `salvage` token only promotes to FPS & Ship when it's clearly a
+    transport phase (e.g. paired with cargo / recover / freight)."""
+    # The classifier currently promotes ANY FPS+salvage to FPS & Ship.
+    # That's the conservative call until users push back — better to
+    # over-warn ("bring a ship") than under-warn for this category.
+    result = gen_module._classify_mission_engagement("CFP_Salvage_FPS_title_001")
+    assert result == "FPS & Ship", (
+        "Salvage + FPS currently classifies as FPS & Ship — see the "
+        "_FPS_PLUS_SHIP_TOKENS list. Drop 'salvage' from that list if "
+        "users report that pure-FPS salvage missions get mis-tagged."
+    )
+
+
+def test_no_false_positive_on_substrings(gen_module):
+    """The token list uses underscore-bounded patterns (``_fps_``,
+    ``fps_``, ``_fps``) rather than bare substring match, so ``fps``
+    embedded in an unrelated word does NOT trigger a false-positive
+    FPS classification. This locks in that boundary behavior so a
+    future "simplification" to bare substring matching breaks here."""
+    assert gen_module._classify_mission_engagement("xfpsx_title") == "Ship"
+    # `gpsfix_title` contains "fps" embedded mid-word but lacks the
+    # required underscore boundary — should NOT classify as FPS.
+    assert gen_module._classify_mission_engagement("gpsfix_status_title") == "Ship"


### PR DESCRIPTION
## What

Prepends an **Engagement Type** line to every mission's MISSION DETAILS block, classifying the mission as `FPS`, `Ship`, or `FPS & Ship`. Players see at a glance whether to bring an FPS loadout, a ship, or both, before accepting a contract.

```
<EM3>MISSION DETAILS</EM3>
<EM4>Engagement Type:</EM4> FPS & Ship          ← new
<EM4>Mission Type:</EM4> Chain
<EM4>Difficulty (1-7):</EM4> Combat 4/7 | Complexity 4/7 | Risk 3/7 | Knowledge 3/7
<EM4>Enemies:</EM4> 12
<EM4>Non-hostiles:</EM4> 4
<EM4>Reputation XP:</EM4> +10
```

## Why

Community user reported: *"Does this list if missions are ship or FPS? I always forget what the magic word is to tell the difference … Some are obvious, but others leave you just making sure you're kitted for both"*. Title was considered as a placement but rejected — the title row already carries `[BP]` / `[BP?]` / `[XP]` tags and shouldn't get more clutter. Description is the right home; it's where contextual mission metadata already lives.

## How

Reads CIG's own loc-key naming convention. Every FPS mission's loc_key already contains a marker (`_FPS_`, `UGF_`, `OnFoot_`, `FPSMine`) — we just have to surface it. No new XML parsing, no DataForge dependency changes.

Three rules applied in order:
1. No FPS marker in key → `Ship`
2. FPS marker + cargo/salvage/freight/hauling token → `FPS & Ship` (player needs FPS gear AND a ship for transport)
3. FPS marker, no transport token → `FPS`

Token boundaries are underscore-bounded (`_fps_`, `fps_`, `_fps`) so embedded substrings don't false-positive.

## Tradeoffs (intentional)

- **Conservative default**: when in doubt, return `Ship`. The most common SC mission category, and the safer mis-classification — a player expecting ship combat who lands in FPS will reload and re-prep; the inverse is rare in this dataset.
- **Salvage missions always promote to FPS & Ship** when paired with an FPS marker. CIG's own `CFP_Salvage_FPS` body text reads more like pure FPS clean-up, but salvage *generally* needs a ship to access the location and ferry the recovery — so we err toward "warn about ship." If users report mis-tags, drop `salvage` from `_FPS_PLUS_SHIP_TOKENS`.
- **No XML structural fallback** for the (rare) case of an FPS mission whose loc_key has no marker. If reports come in, second-pass detection from spawn XML or contract handler XPath family is feasible.

## Tests

`tests/test_mission_engagement.py` — 25 cases lifted verbatim from real loc_keys in the generated mission output:
- 8 FPS (BountyHuntersGuild_FPS, vaughn_assassination_FPS_UGF, OnFoot, FPSMine, UGF, …)
- 10 Ship (BHG bounties, ECN bounties, CFP delivery, Headhunters, Bitzeroes bombing, …)
- 3 FPS & Ship (GoblinG_RecoverCargoFPS, BHG_FPS_Cargo_Recover)
- 4 edge cases (empty key, case-insensitive, salvage promotion, substring-boundary check)

**Test delta vs `1.3.0` baseline**: 213 pass (was 188), same 4 pre-existing pak_extraction failures, 15 skipped. No regressions.

## Test plan

- [x] `pytest tests/test_mission_engagement.py` — 25 pass
- [x] `pytest tests/` — full suite, no new failures
- [ ] Manual smoke test: regenerate enhancements (Enhancements tab → Generate), open `mission_rewards_enhancements.ini`, spot-check the new line on a known FPS mission (e.g. anything `BountyHuntersGuild_FPS_*`), a known ship mission (`BountyHuntersGuild_Bounty_*`), and a known hybrid (`GoblinG_*_RecoverCargoFPS_*`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)