### PR TITLE
Add Export Loc-Pack toolbar button (zips applied global.ini)

### DIFF
--- a/ABOUT.md
+++ b/ABOUT.md
@@ -23,6 +23,12 @@ Thanks to the testers and contributors who helped shape Smart Citizen with their
 - **Lord Valium**
 - **Zero**
 
+### Supporters
+
+Thanks to those who've supported the project financially — your contributions help keep Smart Citizen free for everyone:
+
+- **Dimwit the Wise**
+
 Smart Citizen also bundles upstream tooling from:
 
 - [**dolkensp/unp4k**](https://github.com/dolkensp/unp4k) — `unp4k.exe` and `unforge.exe`, used to unpack `Data.p4k` and convert DataForge to XML

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,11 +4,11 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Smart Citizen (formerly SC Localization Editor) is a Windows-only PyQt6 GUI application for customizing Star Citizen localization strings. Tagline: *Smarter Strings for Star Citizen*. Users configure multiple data sources (Global, Contracts, Components, Ships, Commodities, Gear, User) with a drag-and-drop merge hierarchy, edit strings in a table, and apply changes to their game installation with automatic backup management.
+Smart Citizen (formerly SC Localization Editor) is a Windows-only PyQt6 GUI application for customizing Star Citizen localization strings. Tagline: *Smarter Strings for Star Citizen*. Users edit strings in a table backed by a `global` source (locally cached `base.ini` from Data.p4k extraction) merged with their per-channel `user.ini` overrides, then apply the result to their game installation with automatic backup management.
 
 **Rebrand status**: As of 0.9.0, user-facing strings, registry path (`Osiris DevWorks\Smart Citizen`), and the user data root (`Documents\Smart Citizen\`) all use the new name. `AppSettings` still contains one-shot migrators for the legacy `Osiris DevWorks\SC Localization Editor` registry tree and `Documents\SC Localization Editor\` directory; do not remove them while users on pre-0.9 builds may still upgrade.
 
-**Current Version**: Read from `VERSION.TXT` (single source of truth). Project is at 1.0 as of this writing.
+**Current Version**: Read from `VERSION.TXT` (single source of truth).
 
 ## Quick Commands
 
@@ -48,7 +48,7 @@ python scripts/extract_components.py [--stock path] [--base path] [--output path
 
 ## Testing Strategy
 
-**Unit Tests** (`tests/`): Split by domain — `test_core.py` (INI parsing/merging/category extraction), `test_missions.py` (mission rewards pipeline), `test_pak_extraction.py` (P4K/DataForge), `test_progress_sink.py` (thread-safe progress coalescing), `test_dataforge_patcher.py` (declarative XML patching), `test_app_updater.py` (GitHub Releases version-check worker), `test_channel_layout.py` (per-channel directory migration). Pytest config lives in `tests/pytest.ini` (sets `pythonpath = src`, registers markers: `unit`, `integration`, `slow`, `critical`, `regression`).
+**Unit Tests** (`tests/`): Split by domain — `test_core.py` (INI parsing/merging/category extraction; `TestStringEntry` is currently `@pytest.mark.skip` because its constructor calls predate `category` and `status` becoming required positional args — fix is a separate cleanup), `test_missions.py` (mission rewards pipeline), `test_pak_extraction.py` (P4K/DataForge), `test_progress_sink.py` (thread-safe progress coalescing), `test_dataforge_patcher.py` (declarative XML patching), `test_app_updater.py` (GitHub Releases version-check worker), `test_channel_layout.py` (per-channel directory migration), `test_retired_url_sources_migration.py` (1.0 cleanup of the contracts/components/ships/commodities/gear sources retired in 0.7.0 — covers fresh-install defaults, upgrade-time pruning, URL-vs-local guard, and idempotence), `test_applied_file_validator.py` (post-apply `global.ini` vs stock `base.ini` validation), `test_entry_filter.py` (column-filter logic + the `NUM_COLUMNS` getter-tuple drift guard), `test_markdown_renderer.py` (About/Help markdown→HTML conversion), `test_resource_path.py` (PyInstaller `_MEIPASS`-aware resource resolution). Worker classes themselves have no automated tests — they need `pytest-qt` (not currently a dev dependency); manual smoke testing is still the only verification path for the QThread workers in `workers.py`. Pytest config lives in `tests/pytest.ini` — `pythonpath = . src` (project root for `from src.X` imports + `src/` for legacy `from utils.X` imports used by older tests), registers markers: `unit`, `integration`, `slow`, `critical`, `regression`.
 
 **GUI Testing**: Manual. Run app (`python src/main.py`), load base file, edit a value, apply to game, restart to verify persistence. Use the Log Tab to watch for errors during load/merge/apply cycles.
 
@@ -57,7 +57,9 @@ python scripts/extract_components.py [--stock path] [--base path] [--output path
 Entry point: `src/main.py`. The app has two main layers:
 
 **GUI layer** (`src/gui/`):
-- `main_window.py` — Main window with table, toolbar, filters, backup/restore, threading workers, DataForge extraction. This is the largest file (~2000+ lines). Manages the primary workflow: load, merge, edit, apply.
+- `main_window.py` — Main window with table, toolbar, filters, backup/restore, DataForge extraction trigger, and worker-thread orchestration. ~3275 lines after the PR #6 + PR #7 extractions; manages the primary workflow: load, merge, edit, apply. Worker classes live in `workers.py`; pure-Python helpers (`validate_applied_file`, `filter_entry_indices`, `markdown_to_html`) live in their own modules and are wrapped by thin `MainWindow` methods.
+- `workers.py` — All `QThread` background workers + the shared `AnimatedProgressDialog` and `SelectAllDelegate`. Workers: `FileLoaderWorker` (load sources → build `StringEntry` list + sort keys), `StartupSyncWorker` (refresh URL-backed sources at startup), `EnhancementsGeneratorWorker` (run `scripts/generate_enhancements_ini.py` in-process via `importlib.util`), `P4kExtractWorker` (unp4k extraction of `global.ini`), `DataForgeExtractWorker` (unp4k + unforge + post-extract patches). Each worker emits `progress` (str) + `progress_pct` (completed, total, message) signals; `AnimatedProgressDialog.set_progress` consumes the latter. `AppUpdateCheckWorker` is the exception — it lives in `src/utils/app_updater.py` because the worker, the version-comparison logic, and the registry timestamp-cap belong together as one unit.
+- `markdown_renderer.py` — `markdown_to_html(text, text_color, base_color, link_color)` for the About / Help panels. Pure-Python; the Qt caller passes in palette colours so the converter has no Qt dependency. Stash-and-restore code-span handling means `**` and `_` inside backticks stay literal (important: loc keys like `vehicle_Name*` shouldn't sprout `<em>` tags).
 - `config_tab.py` — **Config Tab**: Data source management (add/edit/remove sources), drag-drop merge hierarchy, Star Citizen install path, and DataForge extraction trigger.
 - `enhancements_tab.py` — **Enhancements Tab**: Toggle stats overlays, configure ship favorites prefix, trigger DataForge extraction. Emits `merge_requested` and `stats_pipeline_requested` signals.
 - `log_tab.py` — **Log Tab**: In-app real-time log viewer. Bridges Python `logging` to Qt text widget via `_LogEmitter` signal (thread-safe). Supports level filtering, auto-scroll, and log export.
@@ -71,8 +73,8 @@ Entry point: `src/main.py`. The app has two main layers:
 - `string_model.py` — `StringEntry` dataclass with category extraction from key prefixes.
 - `ini_parser.py` — Line-by-line INI parsing (splits on first `=`), source loading via `load_sources_from_settings()`, and `load_overrides(target_path)` for reading `user.ini` back as a `dict[str, str]`.
 - `ini_merger.py` — Merge engine: `merge_sources_by_hierarchy(sources_dict, hierarchy, user_overrides)`. Sources merge sequentially; user overrides always win.
-- `settings.py` — `AppSettings` class wrapping QSettings (Windows Registry). User data lives under the configured data root (default `Documents\Smart Citizen\`) plus `{active_channel}\`. Critical: Registry is the single source of truth for all paths and preferences. Also owns canonical paths (`get_user_data_dir()`, `get_cache_dir()`, `get_user_ini_path()`, `get_backups_dir()`) and handles automatic migrations: legacy `overrides.ini` → `user.ini`, `AppData\Roaming\...` → the configured data root, and the 0.9.3+ flat layout → per-channel layout (`migrate_game_path_to_channel_layout()`).
-- `updater.py` — Per-source GitHub downloads. Drives the auto-update workers that refresh each cached source INI (`base.ini`, `contracts.ini`, etc.) from its configured GitHub URL.
+- `settings.py` — `AppSettings` class wrapping QSettings (Windows Registry). User data lives under the configured data root (default `Documents\Smart Citizen\`) plus `{active_channel}\`. Critical: Registry is the single source of truth for all paths and preferences. Also owns canonical paths (`get_user_data_dir()`, `get_cache_dir()`, `get_user_ini_path()`, `get_backups_dir()`) and a chain of one-shot migrators run on every launch (all idempotent): `migrate_legacy_settings()` (seeds `[global, user]` defaults for fresh installs), `migrate_remove_retired_url_sources()` (1.0 prune of contracts/components/ships/commodities/gear from upgrader registries — only when the stored path is a URL; local-path overrides are preserved), `migrate_global_to_p4k_local()` (rewrites `global` from a URL to the local cached `base.ini`), `migrate_registry_appname()` (`SC Localization Editor` → `Smart Citizen` registry tree), `migrate_docs_folder_rename()` (`Documents\SC Localization Editor\` → `Documents\Smart Citizen\`), `migrate_data_to_documents()` (`AppData\Roaming\...` → the configured data root), `migrate_game_path_to_channel_layout()` (0.9.3+ flat layout → per-channel layout).
+- `updater.py` — Per-source GitHub downloads. Drives the auto-update workers that refresh cached source INIs from their configured GitHub URL. Post-1.0 the only URL-backed source is `global` (`base.ini`); the four legacy URL sources have been retired in favor of local Data.p4k extraction.
 - `app_updater.py` — *Separate* from `updater.py`. Polls `GET /repos/Osiris-DevWorks/smart-citizen/releases/latest` and compares `tag_name` to the local `VERSION.TXT` to surface a "new installer available" prompt. Runs on a `QThread`; `MainWindow` caps auto-checks to once per 6 hours via a registry timestamp to stay under GitHub's 60-req/hr unauthenticated limit.
 - `pak_extractor.py` — P4K extraction pipeline: `unp4k.exe` (extracts Game2.dcb) → `unforge.exe` (converts to entity XMLs). After unforge writes the full DataForge tree to a temp dir, `_copy_filtered_records()` copies only the subtrees in `DATAFORGE_KEEP_SUBPATHS` (the ones the generator actually reads) to the persistent cache — halves cache file count and cuts copy/rmtree wall time. Adding a new read path in the generator requires adding it to `DATAFORGE_KEEP_SUBPATHS`; `tests/test_pak_extraction.py::TestDataForgeKeepList` locks the contract.
 - `user_ini_manager.py` — Saves user-modified entries to `user.ini` (plain `key=value`, no sections) via `save_user_ini(entries, path)`; coordinates with `ImportConflictDialog` when importing external INIs.
@@ -81,6 +83,9 @@ Entry point: `src/main.py`. The app has two main layers:
 - `perf.py` — `@timed` decorator for debug-level performance profiling. No-op when DEBUG logging disabled.
 - `progress_sink.py` — `ProgressSink` coalesces `advance()` calls from many worker threads into throttled `(completed, total, message)` callbacks. Used by the parallelized lookup builders and enhancement generators to drive determinate progress bars without flooding the Qt event loop.
 - `dataforge_patcher.py` — Applies declarative JSON patches from `patches/` to the DataForge XML cache immediately after extraction. Fixes upstream CIG data bugs (e.g. mission records pointing at wrong loc-keys) so downstream consumers see corrected data. Patches mirror the DataForge layout under `patches/<category>/.../<name>.patch.json`.
+- `applied_file_validator.py` — `validate_applied_file(written_path, cache_dir, stock_keys=None)`: independently re-parses the just-written `global.ini` against the cached `base.ini` and returns a human-readable diff (missing / unexpected keys) or `""` when valid. `MainWindow._validate_applied_file` is a thin wrapper that supplies the cache dir from `AppSettings`. Lets `apply_to_game` auto-rollback on a merger bug.
+- `entry_filter.py` — `filter_entry_indices(...)`: pure-Python row filter for the strings table (column filters + category / status / hide-unmodified / favorites-only). Imports `NUM_COLUMNS` from `string_table_model` so the OOB-bounds guard stays in sync if a column is added; bad indices are dropped + logged once instead of raising `IndexError` deep in the per-entry loop. Per-call getter tuple lets the hot path call only the getters for active filters.
+- `resource_path.py` — `get_resource_path(rel)` (PyInstaller `_MEIPASS`-aware) and `resolve_patches_dir()` (`Path` to bundled `patches/`). Lives in `src/utils/` rather than `src/gui/` because both `main_window.py` and `workers.py` depend on it — keeping it leaf-level avoids a `gui` ↔ `gui` import cycle.
 
 **Scripts** (`scripts/`):
 - `generate_enhancements_ini.py` — Reads DataForge entity XMLs only (no external JSON) → outputs enhancement INI files to cache (ships, components, ship weapons, FPS weapons descriptions).
@@ -88,6 +93,7 @@ Entry point: `src/main.py`. The app has two main layers:
 - `gen_commodity_crafting.py` — Generates `commodity_crafting_enhancements.ini` with crafting blueprint usage data from DataForge XMLs.
 - `compare_kraken_fixture.py` — Research/reporting tool: diffs the `kraken_4.7.ini` ground-truth fixture against our generated `mission_rewards_enhancements.ini` to validate blueprint list output. Read-only.
 - `diff_bp_kraken.py`, `diff_bp_annotations.py`, `diff_bp_csv_fixture.py` — Read-only diagnostic scripts validating `[BP]` / `[BP?]` blueprint annotations on mission rewards. Each compares our `mission_rewards_enhancements.ini` output against a different ground-truth source (kraken fixture, an applied LIVE `global.ini`, and the `missions_4.7.177.csv` per-variant fixture, respectively). Use these when blueprint tags regress.
+- `diff_base_ini_channels.py` — Read-only: diffs cached `base.ini` between two SC channels (e.g. `LIVE` vs `PTU`) and reports added / removed / changed loc keys as a category-bucket summary plus optional full machine-readable list. Defaults to `%USERPROFILE%\Documents\Smart Citizen` and supports `--user-data` for OneDrive-redirected installs.
 - `discord_notify.py` — GitHub Actions release webhook notifier.
 - `build/build_exe.py`, `build/build_all.bat`, `build/clean_cache_for_distribution.py` — Build pipeline; see `scripts/build/BUILD_INSTRUCTIONS.md`.
 
@@ -102,7 +108,7 @@ The table is a `QTableView` backed by `StringTableModel` (`src/gui/string_table_
 The cached global source is saved as `base.ini` (not `global.ini`) to avoid confusion with the game's `global.ini` at `LIVE/data/Localization/english/global.ini`.
 
 ### Threading model
-All I/O-bound operations (file loads, network requests, P4K extraction) run in `QThread` workers. Workers emit `finished()` signals; cleanup requires `quit()` + `wait()`. Never block the main thread with file or network operations. Bulk table updates wrap in `setUpdatesEnabled(False)`. Registry access (via `AppSettings`) is thread-safe; use it freely from main or worker threads.
+All I/O-bound operations (file loads, network requests, P4K extraction) run in `QThread` workers — they live in `src/gui/workers.py` (with `AppUpdateCheckWorker` as the lone exception, which lives next to its companion logic in `src/utils/app_updater.py`). Workers emit `finished()` signals; cleanup requires `quit()` + `wait()`. Never block the main thread with file or network operations. Bulk table updates wrap in `setUpdatesEnabled(False)`. Registry access (via `AppSettings`) is thread-safe; use it freely from main or worker threads. Worker logger names are `src.gui.workers` post-extraction (was `src.gui.main_window` pre-extraction) — relevant if you grep logs.
 
 ### Startup initialization
 On first run, the app initializes user data directories, validates Star Citizen install path, and may show a startup dialog to guide configuration. Subsequent runs check source freshness and auto-apply any pending DataForge cache updates.
@@ -114,7 +120,7 @@ The "Extract DataForge from P4K" button triggers: (1) unpack Data.p4k → entity
 Lookup builders and enhancement output generators run in parallel worker threads (see `scripts/generate_enhancements_ini.py`). They share a single `ProgressSink` (`src/utils/progress_sink.py`) so the UI shows one determinate progress bar. Never call `QProgressBar.setValue()` directly from workers — go through the sink so updates are coalesced and throttled on the main thread.
 
 ### Merge hierarchy
-Sources merge in user-defined order (default: global → contracts → components → ships → commodities → gear → user). Later sources overwrite earlier ones. User overrides are always applied last and never lost during source updates.
+Sources merge in user-defined order. Later sources overwrite earlier ones; user overrides are always applied last and never lost during source updates. As of 1.0 the seeded default is just `[global, user]` — the four URL-based sources (contracts/components/ships/commodities) and `gear` were retired in 0.7.0 when extraction moved to local Data.p4k, and `migrate_remove_retired_url_sources()` cleans them out of upgrader registries. `load_sources_from_settings()` additionally injects a synthetic `enhancements` source at runtime when any enhancement category is enabled on the Enhancements tab — it is *not* a registry entry and shouldn't be added to the hierarchy by hand.
 
 ### Favorites use value prefix
 Favorites prepend a configurable prefix (default `*`) to `custom_value`. The prefix is stored in Registry via `AppSettings.FAVORITE_PREFIX`.
@@ -127,7 +133,7 @@ Favorites prepend a configurable prefix (default `*`) to `custom_value`. The pre
 | User data root | Configurable via `user_data_dir` (alias `UserDataDir` is also read); defaults to `Documents\Smart Citizen\` |
 | **Per-channel data** | `{user_data_root}\{LIVE|PTU|EPTU|HOTFIX|TECH-PREVIEW}\` — 0.9.3+ nests user.ini / cache / backups / dataforge under the active channel so each SC channel is isolated. Migrator: `AppSettings.migrate_game_path_to_channel_layout()`. |
 | User overrides | `{user_data_root}\{active_channel}\user.ini` (legacy `overrides.ini`, auto-migrated) |
-| Cached sources | `{user_data_root}\{active_channel}\cache\` (`base.ini`, `contracts.ini`, etc.) |
+| Cached sources | `{user_data_root}\{active_channel}\cache\` — only `base.ini` post-1.0 (the four legacy URL-based source INIs were retired in 0.7.0); enhancement INIs live alongside it, see below |
 | DataForge cache | `{user_data_root}\{active_channel}\cache\dataforge\` (entity XMLs from Data.p4k) |
 | Enhancement INIs | `{user_data_root}\{active_channel}\cache\` (`ships_desc_enhancements.ini`, `components_desc_enhancements.ini`, `ship_weapons_desc_enhancements.ini`, `fps_weapons_desc_enhancements.ini`, `mission_rewards_enhancements.ini`, `commodity_crafting_enhancements.ini`) |
 | Backups | `{user_data_root}\{active_channel}\backups\` (max 5, oldest auto-deleted) |
@@ -140,9 +146,10 @@ Favorites prepend a configurable prefix (default `*`) to `custom_value`. The pre
 
 | Task | File | Key Function |
 |------|------|-------------|
-| Add/change table columns | `main_window.py` | `setup_string_table()` |
-| Add/change filters | `main_window.py` | `apply_filters()`, `on_filter_changed()` |
-| Change per-column filters | `filter_header.py` | `FilterHeaderView` |
+| Add/change table columns | `main_window.py`, `string_table_model.py` | `setup_string_table()`, `NUM_COLUMNS` + `COL_*` constants (also referenced by `entry_filter.py`'s getter tuple) |
+| Add/change filters (UI wiring) | `main_window.py` | `apply_filters()`, `on_filter_changed()` |
+| Change row-filter logic | `entry_filter.py` | `filter_entry_indices()` (delegated to from `MainWindow._filtered_entry_indices`) |
+| Change per-column filter widgets | `filter_header.py` | `FilterHeaderView` |
 | Change category extraction | `string_model.py` | `StringEntry.extract_category()` |
 | Modify INI parsing | `ini_parser.py` | `parse_ini_file()` |
 | Change merge logic | `ini_merger.py` | `merge_sources_by_hierarchy()` |
@@ -163,6 +170,10 @@ Favorites prepend a configurable prefix (default `*`) to `custom_value`. The pre
 | Change user.cfg behavior | `user_cfg.py` | `ensure_user_cfg_language()` |
 | Fix an upstream DataForge data bug | `patches/<category>/.../<name>.patch.json`, `dataforge_patcher.py` | `apply_patches()` |
 | Change parallel progress reporting | `progress_sink.py` | `ProgressSink.advance()` |
+| Change post-apply validation | `applied_file_validator.py` | `validate_applied_file()` (wrapped by `MainWindow._validate_applied_file`) |
+| Change About / Help markdown rendering | `markdown_renderer.py` | `markdown_to_html()` (wrapped by `MainWindow.markdown_to_html`, which supplies palette colours) |
+| Add or modify a background worker | `workers.py` | The relevant `*Worker` class (subclass of `QThread`) |
+| Change resource-path resolution (PyInstaller bundle vs dev) | `resource_path.py` | `get_resource_path()`, `resolve_patches_dir()` |
 
 ## Version & Release
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,53 @@
+Smart Citizen
+Copyright 2026 Osiris DevWorks
+
+This product is licensed under the Apache License, Version 2.0
+(the "License"); you may not use this product except in compliance
+with the License. You may obtain a copy of the License at:
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+================================================================================
+Bundled third-party software
+================================================================================
+
+unp4k / unforge
+---------------
+This product bundles the unp4k and unforge command-line tools (under
+assets/unp4k/) from https://github.com/dolkensp/unp4k by Peter Dolkens
+and contributors. Used to unpack Star Citizen's Data.p4k archive and
+convert DataForge entity files to XML.
+
+unp4k is licensed under the MIT License:
+
+    Permission is hereby granted, free of charge, to any person obtaining
+    a copy of this software and associated documentation files (the
+    "Software"), to deal in the Software without restriction, including
+    without limitation the rights to use, copy, modify, merge, publish,
+    distribute, sublicense, and/or sell copies of the Software, and to
+    permit persons to whom the Software is furnished to do so, subject
+    to the following conditions:
+
+    The above copyright notice and this permission notice shall be
+    included in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+    IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+    CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+    TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+    SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+================================================================================
+Trademarks and game data
+================================================================================
+
+Star Citizen and all associated game data, including Data.p4k, are the
+property of Cloud Imperium Rights LLC and Cloud Imperium Rights Ltd.
+Smart Citizen reads game files from your own licensed Star Citizen
+installation and does not redistribute any RSI or CIG content.
+
+Smart Citizen is a community fan project and is not affiliated with,
+endorsed by, or sponsored by Cloud Imperium Games or Roberts Space
+Industries.

--- a/README.md
+++ b/README.md
@@ -194,6 +194,12 @@ StarCitizen/
 - [**MrKraken**](https://github.com/MrKraken/StarStrings) — ASOP terminal enhancements, workflow improvements, and mission contract localization work
 - The **Star Citizen community** — for endless feedback, testing, and ideas
 
+### Supporters
+
+Thanks to those who've supported the project financially — your contributions help keep Smart Citizen free for everyone:
+
+- **Dimwit the Wise**
+
 ## License
 
 Smart Citizen is licensed under the **Apache License, Version 2.0** — see [LICENSE](LICENSE) for the full text and [NOTICE](NOTICE) for attribution of bundled third-party software (`unp4k` / `unforge`) and the Star Citizen / CIG trademark notice.

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ StarCitizen/
 
 ## License
 
-This project is provided as-is for community use. See LICENSE file for details.
+Smart Citizen is licensed under the **Apache License, Version 2.0** — see [LICENSE](LICENSE) for the full text and [NOTICE](NOTICE) for attribution of bundled third-party software (`unp4k` / `unforge`) and the Star Citizen / CIG trademark notice.
 
 ## Support & Community
 

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -314,7 +314,19 @@ class MainWindow(QMainWindow):
             "Select a row to preview its rendered text."
         )
         self.preview_pane.setMinimumWidth(420)
-        self.preview_pane.setMaximumHeight(200)
+        # Cap to ~the toolbar's natural height (button row + filter row ≈ 80px)
+        # so the preview pane can't drive the toolbar QHBoxLayout taller than
+        # the buttons need. Without this, QTextBrowser's default Expanding
+        # vertical sizePolicy lets the pane grow to its 200px ceiling whenever
+        # the active tab's content has slack vertical space to give back to
+        # main_layout (e.g. the Config tab post-1.3.0, which got taller when
+        # PR #3 added the "Smart Citizen Data" GroupBox). When that happened,
+        # the toolbar row inflated and the buttons appeared to drop ~40px
+        # below the tagline on Config / Enhancements vs. String Editor.
+        # Pre-1.3.0 the bug was latent — main_layout never had enough slack
+        # to expose it. QTextBrowser's built-in scrollbar still handles long
+        # rendered HTML inside the cap.
+        self.preview_pane.setMaximumHeight(80)
 
         toolbar_row = QHBoxLayout()
         toolbar_row.setSpacing(12)

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -445,6 +445,22 @@ class MainWindow(QMainWindow):
         self.clear_cache_btn.clicked.connect(self.clear_cache)
         button_layout.addWidget(self.clear_cache_btn)
 
+        # Export Loc-Pack — packages the currently-applied global.ini into a
+        # zip for sharing (org-wide loc-packs, Discord drops, etc.). Reads
+        # the already-written game file rather than re-merging in memory,
+        # which keeps the export aligned with what the user has actually
+        # validated in-game. Blue 'open' info-action role since it produces
+        # output without modifying game state.
+        self.export_locpack_btn = QPushButton("Export Loc-Pack")
+        self.export_locpack_btn.setStyleSheet(f"background-color: {get_button_color('open')}; color: {get_button_text_color()}; font-weight: bold; padding: 6px;")
+        self.export_locpack_btn.setToolTip(
+            "Package the currently-applied global.ini into a zip for sharing. "
+            "Click Apply to Game first if you haven't already — Export reads the "
+            "applied file, not the in-memory edits."
+        )
+        self.export_locpack_btn.clicked.connect(self.export_locpack)
+        button_layout.addWidget(self.export_locpack_btn)
+
         # Editor — toggles the side-docked String Editor for editing long
         # values comfortably. Shares the 'open' info-action role so it pairs
         # visually with Help/Tutorial as a panel-toggle.
@@ -1347,6 +1363,69 @@ class MainWindow(QMainWindow):
             return
 
         QDesktopServices.openUrl(QUrl.fromLocalFile(str(loc_dir)))
+
+    @pyqtSlot()
+    def export_locpack(self):
+        """Package the currently-applied global.ini into a shareable zip.
+
+        Reads the already-written game file rather than re-merging in
+        memory — keeps the export aligned with what the user has actually
+        validated in-game, and makes "Export" a no-side-effect action
+        (no implicit re-apply, no surprises).
+        """
+        from src.utils.locpack_exporter import default_locpack_filename, write_locpack_zip
+
+        if not AppSettings.get_game_install_path():
+            QMessageBox.warning(self, "Warning", "Please configure game install path in Config tab")
+            return
+
+        global_ini = AppSettings.get_global_ini_path()
+        if not global_ini.exists():
+            QMessageBox.information(
+                self, "Nothing to Export",
+                "No applied global.ini was found in the game's localization directory.\n\n"
+                "Click 'Apply to Game' first to write your customizations, then "
+                "Export Loc-Pack to package them for sharing."
+            )
+            return
+
+        channel = AppSettings.get_active_channel()
+        default_name = default_locpack_filename(channel)
+        # Suggest the user's Downloads folder as the default save location —
+        # most natural place for a "share this file" output.
+        downloads_dir = Path.home() / "Downloads"
+        if not downloads_dir.exists():
+            downloads_dir = Path.home()
+        default_path = str(downloads_dir / default_name)
+
+        out_path_str, _ = QFileDialog.getSaveFileName(
+            self,
+            "Export Loc-Pack",
+            default_path,
+            "Zip files (*.zip);;All files (*)",
+        )
+        if not out_path_str:
+            return  # user cancelled
+
+        out_path = Path(out_path_str)
+        try:
+            source_size = write_locpack_zip(global_ini, out_path)
+        except Exception as e:
+            logger.exception("Loc-pack export failed")
+            QMessageBox.critical(
+                self, "Export Failed",
+                f"Could not write the loc-pack zip:\n{e}"
+            )
+            return
+
+        zip_size = out_path.stat().st_size
+        QMessageBox.information(
+            self, "Export Complete",
+            f"Loc-pack written to:\n{out_path}\n\n"
+            f"Channel: {channel}\n"
+            f"Source size: {source_size:,} bytes\n"
+            f"Zip size: {zip_size:,} bytes"
+        )
 
     @pyqtSlot()
     @timed

--- a/src/utils/locpack_exporter.py
+++ b/src/utils/locpack_exporter.py
@@ -1,0 +1,80 @@
+"""Package an applied global.ini into a shareable zip.
+
+The "Export Loc-Pack" toolbar action reads the already-applied
+``global.ini`` from the game's localization directory and writes it
+into a zip suitable for sharing on Discord, an org website, etc. The
+zip contains a single ``global.ini`` at the root — recipients (whether
+or not they use Smart Citizen) drop it into their own
+``StarCitizen\\<channel>\\data\\Localization\\english\\global.ini``.
+
+This module owns the file I/O so the logic is testable without Qt.
+"""
+from __future__ import annotations
+
+import logging
+import zipfile
+from datetime import datetime
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+def default_locpack_filename(channel: str, today: datetime | None = None) -> str:
+    """Return a sensible default filename for the export dialog.
+
+    Format: ``SmartCitizen-LocPack-{channel}-{YYYYMMDD}.zip``. The channel
+    is included because loc-files are channel-specific (a PTU export should
+    not be applied to LIVE — different stock keys); the date helps the user
+    distinguish revisions when iterating.
+    """
+    when = today or datetime.now()
+    return f"SmartCitizen-LocPack-{channel}-{when.strftime('%Y%m%d')}.zip"
+
+
+def write_locpack_zip(source_global_ini: Path, output_zip_path: Path) -> int:
+    """Write ``source_global_ini`` into ``output_zip_path`` as ``global.ini``.
+
+    Args:
+        source_global_ini: Absolute path to the already-applied
+            ``global.ini`` in the game's localization directory.
+        output_zip_path: Absolute path the zip will be written to. Parent
+            directory must exist (caller's responsibility — typically the
+            QFileDialog already enforces this).
+
+    Returns:
+        Number of bytes written for the zipped ``global.ini`` entry
+        (uncompressed source size). Useful for status-bar feedback.
+
+    Raises:
+        FileNotFoundError: if ``source_global_ini`` doesn't exist. Callers
+            (the MainWindow handler) should surface a friendly "Apply to
+            Game first" message rather than letting this propagate.
+        OSError: any other I/O failure during the write.
+    """
+    if not source_global_ini.exists():
+        raise FileNotFoundError(
+            f"Applied global.ini not found at {source_global_ini}. "
+            "Click 'Apply to Game' first, then Export."
+        )
+
+    source_size = source_global_ini.stat().st_size
+
+    # ZIP_DEFLATED gives ~85% compression on typical loc-files (mostly
+    # repetitive English text); compresslevel=9 is the slowest of the
+    # deflate levels but a 4MB→600KB difference is invisible at this size
+    # and the user only runs this on demand. STORED would skip compression
+    # entirely and produce a 4MB+ zip — bad for Discord 25MB upload limit
+    # when org members add their own loc-pack art / READMEs in the future.
+    with zipfile.ZipFile(output_zip_path, mode="w", compression=zipfile.ZIP_DEFLATED, compresslevel=9) as zf:
+        # Use the bare filename inside the zip — recipients see "global.ini"
+        # at the root, no nested directories. Matches what they'd expect to
+        # drop straight into the game.
+        zf.write(source_global_ini, arcname="global.ini")
+
+    logger.info(
+        "Wrote loc-pack zip: %s (source %d bytes → zip %d bytes)",
+        output_zip_path,
+        source_size,
+        output_zip_path.stat().st_size,
+    )
+    return source_size

--- a/tests/test_locpack_exporter.py
+++ b/tests/test_locpack_exporter.py
@@ -1,0 +1,120 @@
+"""Tests for src.utils.locpack_exporter — zip packaging of applied global.ini."""
+from __future__ import annotations
+
+import sys
+import zipfile
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+from utils.locpack_exporter import default_locpack_filename, write_locpack_zip  # noqa: E402
+
+pytestmark = pytest.mark.unit
+
+
+# ── default_locpack_filename ──────────────────────────────────────────────────
+class TestDefaultLocpackFilename:
+    def test_uses_channel_and_today(self):
+        result = default_locpack_filename("LIVE", today=datetime(2026, 5, 9))
+        assert result == "SmartCitizen-LocPack-LIVE-20260509.zip"
+
+    def test_distinct_per_channel(self):
+        """Channel-specific because LIVE/PTU stock keys diverge — applying
+        a PTU export to LIVE could produce missing-key validation errors.
+        Filename surfaces the channel so the recipient can avoid that."""
+        live = default_locpack_filename("LIVE", today=datetime(2026, 1, 1))
+        ptu = default_locpack_filename("PTU", today=datetime(2026, 1, 1))
+        assert live != ptu
+        assert "LIVE" in live and "PTU" in ptu
+
+    def test_zip_suffix(self):
+        assert default_locpack_filename("LIVE").endswith(".zip")
+
+    def test_default_today_when_omitted(self):
+        """When `today` is None, uses datetime.now() — should still produce
+        a parseable YYYYMMDD substring."""
+        result = default_locpack_filename("LIVE")
+        # Format: SmartCitizen-LocPack-LIVE-YYYYMMDD.zip
+        date_part = result.split("-")[-1].replace(".zip", "")
+        assert len(date_part) == 8
+        assert date_part.isdigit()
+
+
+# ── write_locpack_zip ─────────────────────────────────────────────────────────
+class TestWriteLocpackZip:
+    def test_writes_global_ini_at_zip_root(self, tmp_path):
+        """Zip should contain `global.ini` at the root, no nested dirs —
+        recipients drop straight into the game's loc directory without
+        having to navigate sub-folders. Uses write_bytes (not write_text)
+        to bypass Windows newline translation — keeps the test focused on
+        zip structure, not on platform-specific line endings."""
+        src = tmp_path / "global.ini"
+        payload = b"vehicle_NameTestShip=Test Ship\n"
+        src.write_bytes(payload)
+        dst = tmp_path / "out.zip"
+
+        write_locpack_zip(src, dst)
+
+        with zipfile.ZipFile(dst) as zf:
+            assert zf.namelist() == ["global.ini"]
+            assert zf.read("global.ini") == payload
+
+    def test_returns_uncompressed_size(self, tmp_path):
+        """Return value is the source size in bytes — the GUI uses it for
+        status feedback ("Source size: 12,345 bytes"). Uses write_bytes
+        to control byte count exactly (write_text on Windows would
+        CRLF-expand and inflate the count)."""
+        src = tmp_path / "global.ini"
+        payload = b"key=value\n" * 100  # exactly 1000 bytes
+        src.write_bytes(payload)
+        dst = tmp_path / "out.zip"
+
+        result = write_locpack_zip(src, dst)
+
+        assert result == 1000
+
+    def test_overwrites_existing_zip(self, tmp_path):
+        """If the output path already exists, write_locpack_zip should
+        overwrite it (mode='w' on ZipFile). Avoids the user having to
+        manually delete an old export before re-running."""
+        src = tmp_path / "global.ini"
+        payload = b"new=content\n"
+        src.write_bytes(payload)
+        dst = tmp_path / "out.zip"
+        dst.write_bytes(b"stale junk that should not survive")
+
+        write_locpack_zip(src, dst)
+
+        with zipfile.ZipFile(dst) as zf:
+            assert zf.read("global.ini") == payload
+
+    def test_compressed_smaller_than_source(self, tmp_path):
+        """Sanity check that DEFLATE is actually being applied — not
+        STORED. Real loc-files are mostly repetitive English text (~85%
+        compression typical), so a 10KB highly-repetitive source should
+        compress significantly."""
+        src = tmp_path / "global.ini"
+        # Highly repetitive content — guarantees deflate gives a big win.
+        src.write_text("repeat_key=repeat_value\n" * 1000, encoding="utf-8")
+        dst = tmp_path / "out.zip"
+
+        write_locpack_zip(src, dst)
+
+        assert dst.stat().st_size < src.stat().st_size // 4, (
+            "Zip should be <25% of source size for highly repetitive input "
+            "— if not, ZIP_DEFLATED isn't being applied"
+        )
+
+    def test_missing_source_raises_filenotfounderror(self, tmp_path):
+        """The GUI handler converts this into a friendly "Apply to Game
+        first" message, but the raw exception type is part of the API
+        contract — locks it in. The literal apostrophes in the message
+        text mean we match against a quote-less substring."""
+        src = tmp_path / "does_not_exist.ini"
+        dst = tmp_path / "out.zip"
+
+        with pytest.raises(FileNotFoundError, match=r"Apply to Game"):
+            write_locpack_zip(src, dst)


### PR DESCRIPTION
## What

New **Export Loc-Pack** button on the toolbar (left of the Editor button — info-action blue palette since it produces output without modifying game state). Click → file-save dialog defaulting to `Downloads/SmartCitizen-LocPack-{channel}-{YYYYMMDD}.zip` → writes a zip containing the currently-applied `global.ini` at the root.

## Why

Community user reported building org-wide loc-packs (custom localizations with org member easter eggs) and currently has to manually grab `global.ini` from the game directory + zip it for sharing on Discord / their org website. One-click button automates that.

## Design choices

| Decision | Rationale |
|---|---|
| **Just `global.ini` in the zip** | Per user spec ("just the modified global.ini"). Recipients drop straight into game; no Smart Citizen install required on the recipient side. |
| **Reads the already-applied file** | Aligns export with what the user has actually validated in-game. No re-merge logic to maintain; "Export" stays a no-side-effect action. |
| **Requires Apply first** | If no applied `global.ini` exists, friendly QMessageBox guides user to Apply first. Avoids hidden semantics ("does Export auto-apply?"). |
| **Channel in filename** | LIVE / PTU / EPTU stock keys diverge — applying a PTU export to LIVE would produce missing-key validation errors. Filename surfaces channel so recipients avoid that. |
| **Default to Downloads/** | Most natural place for a "share this" output. Falls back to home dir if Downloads doesn't exist. |
| **DEFLATE level 9** | Typical loc-files are ~85% compressible. Keeps the zip well under Discord's 25MB upload limit even when the user grows the pack later (additional READMEs, art, etc.). |

## How

- **`src/utils/locpack_exporter.py`** — pure-Python helpers (no Qt deps, fully testable):
  - `default_locpack_filename(channel, today=None)`
  - `write_locpack_zip(source, dest)` → returns uncompressed source size for status feedback; raises `FileNotFoundError` if source is missing
- **`src/gui/main_window.py`** — `export_locpack()` `pyqtSlot` wires the toolbar button. Reads `AppSettings.get_global_ini_path()`, runs the file dialog, calls into the helper, surfaces results (or any failure) via `QMessageBox`.

## Tests

`tests/test_locpack_exporter.py` — 9 cases:
- Filename format: channel inclusion, date, `.zip` suffix, today-default fallback (4)
- Zip structure: single `global.ini` at root, no nested dirs (1)
- Return value matches uncompressed source size (1)
- Overwrites existing zip without prompting (1)
- DEFLATE actually applied — sanity check on compression ratio (1)
- `FileNotFoundError` API contract used by the GUI handler (1)

Tests use `write_bytes` throughout to bypass Windows newline auto-translation.

**Test delta**: 197 pass (+9 new), 4 pre-existing pak_extraction failures unchanged, 15 skipped.

## Test plan (manual — file dialog can't be auto-tested)

- [x] `pytest tests/test_locpack_exporter.py` — 9 pass
- [x] `pytest tests/` — full suite, no new failures
- [ ] Click Apply to Game (writes `global.ini` to game dir)
- [ ] Click Export Loc-Pack — dialog defaults to Downloads, suggested filename has the channel + today's date
- [ ] Save and verify the zip contains exactly one entry: `global.ini`
- [ ] Open Export without first Applying — confirm friendly "Nothing to Export" prompt explaining to Apply first

🤖 Generated with [Claude Code](https://claude.com/claude-code)