### PR TITLE
Standalone PR-B: portable-mode path routing + migrator skip

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -43,39 +43,62 @@ def main():
     """Application entry point."""
     logger.info(f"Starting Smart Citizen v{get_version()}")
 
-    # Move HKCU\Software\Osiris DevWorks\SC Localization Editor → Smart Citizen
-    # on first launch after 0.9.2 (idempotent via marker). Must run FIRST —
-    # every subsequent AppSettings call reads QSettings under the new node,
-    # so if the legacy settings haven't been copied over yet the app sees
-    # an empty registry and loses the user's saved paths / theme / etc.
-    AppSettings.migrate_registry_appname()
+    # Portable mode: swap the JSON backend in BEFORE any AppSettings
+    # accessor runs. No-op in registry mode (the default). Must run
+    # before the migrators below — they all read/write the active
+    # backend, and we want the JSON file to be the target in portable
+    # mode (or the migrators to skip entirely, which the early-return
+    # block right after handles).
+    AppSettings.setup_portable_backend_if_needed()
 
-    # Rename Documents\SC Localization Editor\ → Documents\Smart Citizen\ on
-    # first run after the 0.9.0 rebrand (idempotent). Must run before any
-    # path-resolving setting is touched.
-    AppSettings.migrate_docs_folder_rename()
+    # Skip all registry migrators in portable mode — they migrate
+    # state in HKEY_CURRENT_USER, which a portable build never reads.
+    # Filesystem migrators (`migrate_docs_folder_rename`,
+    # `migrate_data_to_documents`, `migrate_game_path_to_channel_layout`)
+    # also skip because portable mode starts fresh under
+    # `<exe-dir>/data/` — there's no legacy Documents\Smart Citizen tree
+    # to drain.
+    from src.utils import build_mode
+    if not build_mode.IS_PORTABLE:
+        # Move HKCU\Software\Osiris DevWorks\SC Localization Editor → Smart Citizen
+        # on first launch after 0.9.2 (idempotent via marker). Must run FIRST —
+        # every subsequent AppSettings call reads QSettings under the new node,
+        # so if the legacy settings haven't been copied over yet the app sees
+        # an empty registry and loses the user's saved paths / theme / etc.
+        AppSettings.migrate_registry_appname()
 
-    # Migrate legacy settings to new data source format
-    AppSettings.migrate_legacy_settings()
+        # Rename Documents\SC Localization Editor\ → Documents\Smart Citizen\ on
+        # first run after the 0.9.0 rebrand (idempotent). Must run before any
+        # path-resolving setting is touched.
+        AppSettings.migrate_docs_folder_rename()
 
-    # One-shot prune of the four URL-based sources (contracts/components/
-    # ships/commodities) retired in 0.7.0 when the app switched to local
-    # Data.p4k extraction. They've been silently 404-ing for ~10 versions
-    # and produced zero-key rows in the Merge Preview. Marker-gated so it
-    # runs exactly once per user.
-    AppSettings.migrate_remove_retired_url_sources()
+        # Migrate legacy settings to new data source format
+        AppSettings.migrate_legacy_settings()
 
-    # Migrate global source from any remote URL to local P4K cache path (v0.6.0+)
-    AppSettings.migrate_global_to_p4k_local()
+        # One-shot prune of the four URL-based sources (contracts/components/
+        # ships/commodities) retired in 0.7.0 when the app switched to local
+        # Data.p4k extraction. They've been silently 404-ing for ~10 versions
+        # and produced zero-key rows in the Merge Preview. Marker-gated so it
+        # runs exactly once per user.
+        AppSettings.migrate_remove_retired_url_sources()
 
-    # Split the pre-0.9.3 single-channel layout into channel-aware directories
-    # (registry: GAME_INSTALL_PATH → SC_INSTALL_ROOT + ACTIVE_CHANNEL;
-    # filesystem: Documents\Smart Citizen\{base.ini,cache,backups,user.ini,...}
-    # → Documents\Smart Citizen\LIVE\{...}). One-shot, marker-gated.
-    AppSettings.migrate_game_path_to_channel_layout()
+        # Migrate global source from any remote URL to local P4K cache path (v0.6.0+)
+        AppSettings.migrate_global_to_p4k_local()
 
-    # Move user data files from old AppData location to Documents (idempotent)
-    AppSettings.migrate_data_to_documents()
+        # Split the pre-0.9.3 single-channel layout into channel-aware directories
+        # (registry: GAME_INSTALL_PATH → SC_INSTALL_ROOT + ACTIVE_CHANNEL;
+        # filesystem: Documents\Smart Citizen\{base.ini,cache,backups,user.ini,...}
+        # → Documents\Smart Citizen\LIVE\{...}). One-shot, marker-gated.
+        AppSettings.migrate_game_path_to_channel_layout()
+
+        # Move user data files from old AppData location to Documents (idempotent)
+        AppSettings.migrate_data_to_documents()
+    else:
+        # Portable mode also seeds defaults — the migrator does both
+        # ("seed defaults if no settings exist" + "migrate legacy"); we
+        # need the seed half. Check the marker explicitly to skip the
+        # registry-cleanup half.
+        AppSettings.migrate_legacy_settings()
 
     # Always keep user source path in sync with canonical user.ini location
     AppSettings.set_source_path(AppSettings.SOURCE_USER, str(AppSettings.get_user_ini_path()))

--- a/src/utils/build_mode.py
+++ b/src/utils/build_mode.py
@@ -1,0 +1,29 @@
+"""Build-time mode flags.
+
+PR-B in the standalone-build series. PR-C's build script
+(`build_exe.py --portable`) overwrites this module with one that has
+``IS_PORTABLE = True`` before PyInstaller bundles it. Default ships
+False, so the un-built repo and the standard PyInstaller build both
+behave identically (registry mode).
+
+Portable mode changes two things at runtime:
+
+  1. ``AppSettings._backend`` is set to a ``JsonSettings`` rooted at
+     ``<user_data_dir>/config.json`` (PR-A's hook) instead of using
+     ``QSettings`` against the Windows registry.
+  2. ``AppSettings.get_user_data_dir()`` returns ``<exe-dir>/data/``
+     (or ``<repo-root>/portable_data/`` when running unfrozen) so all
+     cache / backups / user.ini live alongside the binary instead of
+     under ``Documents\\Smart Citizen``.
+
+Migrators that read the legacy registry tree are no-ops in portable
+mode — there's no registry to migrate from.
+
+Tests can flip ``IS_PORTABLE`` via ``monkeypatch.setattr`` to exercise
+either branch without rebuilding. Production code should only ever
+read ``IS_PORTABLE`` (never write to it outside the build script).
+"""
+
+# Default ships False — registry mode. The portable build's overwrite
+# of this file changes only this constant.
+IS_PORTABLE: bool = False

--- a/src/utils/settings.py
+++ b/src/utils/settings.py
@@ -1004,7 +1004,13 @@ class AppSettings:
     def get_user_data_dir() -> Path:
         r"""Get the user data directory.
 
-        Resolution order:
+        Portable mode (build_mode.IS_PORTABLE = True): always returns
+        the ``data/`` directory next to the running binary. Registry
+        override and Documents fallback are skipped — portability is
+        the whole point. ``<exe-dir>/data/`` when frozen,
+        ``<repo-root>/portable_data/`` when running from source.
+
+        Registry mode (default) resolution order:
           1. Registry override ``USER_DATA_DIR`` — set by users who want the
              cache/user.ini off a OneDrive-synced Documents folder (extraction
              and rmtree are much slower under OneDrive's sync hooks).
@@ -1015,6 +1021,13 @@ class AppSettings:
         Returns:
             Path to the resolved directory (created if needed).
         """
+        # Portable build: always next to the binary, no overrides.
+        from src.utils import build_mode
+        if build_mode.IS_PORTABLE:
+            data_dir = AppSettings._portable_data_dir()
+            data_dir.mkdir(parents=True, exist_ok=True)
+            return data_dir
+
         override = AppSettings._get_user_data_dir_override()
         if override:
             override_path = Path(os.path.expandvars(override)).expanduser().resolve()
@@ -1029,6 +1042,50 @@ class AppSettings:
         data_dir = AppSettings._resolve_docs_base() / "Smart Citizen"
         data_dir.mkdir(parents=True, exist_ok=True)
         return data_dir
+
+    @staticmethod
+    def _portable_data_dir() -> Path:
+        """Resolve the portable-mode data root.
+
+        Frozen (PyInstaller): ``<exe-dir>/data/`` — true portable, no
+        machine state outside the .exe's folder. ``sys.executable``
+        points at the bundled .exe, not the Python interpreter.
+
+        Unfrozen (dev / tests): ``<repo-root>/portable_data/`` so a
+        developer running ``python src/main.py`` with a monkeypatched
+        IS_PORTABLE = True can exercise the portable code path without
+        accidentally polluting Documents\\Smart Citizen.
+        """
+        import sys
+        if getattr(sys, "frozen", False):
+            return Path(sys.executable).resolve().parent / "data"
+        # src/utils/settings.py → src/utils → src → repo root
+        repo_root = Path(__file__).resolve().parent.parent.parent
+        return repo_root / "portable_data"
+
+    @staticmethod
+    def setup_portable_backend_if_needed() -> None:
+        """Wire the JSON settings backend on portable startup.
+
+        Called from main.py once at startup, BEFORE any AppSettings
+        accessor that depends on get_user_data_dir() (which the JSON
+        backend file path is derived from). No-op in registry mode —
+        the existing QSettings default keeps working.
+
+        Idempotent: safe to call multiple times. Subsequent calls are
+        a no-op once `_backend` is set.
+        """
+        from src.utils import build_mode
+        if not build_mode.IS_PORTABLE:
+            return
+        if AppSettings._backend is not None:
+            return
+        from src.utils.json_settings import JsonSettings
+        # Lives next to all the other portable data so the whole
+        # standalone install is one folder the user can copy/move.
+        config_path = AppSettings._portable_data_dir() / "config.json"
+        AppSettings._backend = JsonSettings(config_path)
+        logger.info("Portable mode active — settings backend: %s", config_path)
 
     @staticmethod
     def set_user_data_dir(path: "str | Path | None") -> None:

--- a/tests/test_portable_mode.py
+++ b/tests/test_portable_mode.py
@@ -1,0 +1,203 @@
+"""Tests for portable-mode path routing.
+
+PR-B in the standalone-build series. Verifies that flipping
+``build_mode.IS_PORTABLE`` redirects ``AppSettings.get_user_data_dir()``
+to the next-to-binary location and switches the settings backend to
+``JsonSettings``. Tests use ``monkeypatch`` to flip the constant
+without rebuilding — production code paths set it at build time
+(PR-C) but the tests need to exercise both branches in one run.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+from utils import build_mode  # noqa: E402
+# Import via the `src.X` path that production code uses, so `isinstance`
+# checks against AppSettings._backend (set inside production via
+# `from src.utils.json_settings import JsonSettings`) actually match.
+# The bare `from utils.X` alternative would create a separate class
+# object in sys.modules — the same ImportPath-Inconsistency-Bug we hit
+# in PR #6's tests.
+from src.utils.json_settings import JsonSettings  # noqa: E402
+from src.utils.settings import AppSettings  # noqa: E402
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture(autouse=True)
+def reset_appsettings_backend():
+    """Each test starts with a clean ``AppSettings._backend``.
+
+    Without this, a test that sets the JSON backend would leak state
+    into subsequent tests (and into the registry-mode tests in the
+    rest of the suite). Defensive — also prevents state leakage from
+    the other test files in this run.
+    """
+    saved = AppSettings._backend
+    AppSettings._backend = None
+    yield
+    AppSettings._backend = saved
+
+
+# ── build_mode default ────────────────────────────────────────────────────────
+class TestBuildModeDefault:
+    def test_default_ships_registry_mode(self):
+        """Ship default is False — protects against an accidental
+        portable-only release that would silently switch every
+        production user to the JSON backend."""
+        assert build_mode.IS_PORTABLE is False
+
+
+# ── _portable_data_dir resolution ─────────────────────────────────────────────
+class TestPortableDataDir:
+    def test_unfrozen_uses_repo_root_portable_data(self, monkeypatch):
+        """Dev mode (no PyInstaller bundle): data lives at
+        ``<repo-root>/portable_data/`` so a developer flipping
+        IS_PORTABLE=True doesn't touch their real Documents tree."""
+        # Make sure sys.frozen isn't set (the test process should never
+        # have it, but be defensive against pytest plugins that might).
+        monkeypatch.delattr(sys, "frozen", raising=False)
+
+        result = AppSettings._portable_data_dir()
+
+        assert result.name == "portable_data"
+        assert result.is_absolute()
+
+    def test_frozen_uses_exe_dir_data(self, monkeypatch, tmp_path):
+        """Frozen build: ``<exe-dir>/data/``. Simulated by setting
+        sys.frozen + sys.executable since we can't actually build a
+        PyInstaller bundle in tests."""
+        fake_exe = tmp_path / "SmartCitizen-Portable.exe"
+        fake_exe.write_bytes(b"")  # so resolve() works
+        monkeypatch.setattr(sys, "frozen", True, raising=False)
+        monkeypatch.setattr(sys, "executable", str(fake_exe))
+
+        result = AppSettings._portable_data_dir()
+
+        assert result == tmp_path.resolve() / "data"
+
+
+# ── get_user_data_dir routing ─────────────────────────────────────────────────
+class TestGetUserDataDirRouting:
+    def test_registry_mode_uses_documents_path(self, monkeypatch):
+        """When IS_PORTABLE is False, get_user_data_dir() goes through
+        the registry-override → Documents → ~/Documents resolution
+        (existing behavior, unchanged)."""
+        monkeypatch.setattr("src.utils.build_mode.IS_PORTABLE", False)
+
+        result = AppSettings.get_user_data_dir()
+
+        # Registry mode should land in something under the user's
+        # home / Documents-like tree. Just check it's NOT the portable
+        # path — the actual resolution depends on the test machine's
+        # registry state, which we don't want to assert on here.
+        assert result.name != "portable_data"
+        assert "data" not in result.parts[-2:] or result.parts[-1] != "data"
+
+    def test_portable_mode_routes_to_portable_data(self, monkeypatch):
+        """When IS_PORTABLE is True, get_user_data_dir() returns
+        _portable_data_dir() — bypasses USER_DATA_DIR override and
+        Documents resolution entirely."""
+        monkeypatch.setattr("src.utils.build_mode.IS_PORTABLE", True)
+
+        result = AppSettings.get_user_data_dir()
+
+        assert result == AppSettings._portable_data_dir()
+
+    def test_portable_mode_creates_directory(self, monkeypatch, tmp_path):
+        """get_user_data_dir() promises to create the directory if
+        missing — should hold in portable mode too. Simulate frozen
+        mode pointed at a clean tmp_path so we control the target."""
+        fake_exe = tmp_path / "SmartCitizen-Portable.exe"
+        fake_exe.write_bytes(b"")
+        monkeypatch.setattr(sys, "frozen", True, raising=False)
+        monkeypatch.setattr(sys, "executable", str(fake_exe))
+        monkeypatch.setattr("src.utils.build_mode.IS_PORTABLE", True)
+
+        target = tmp_path.resolve() / "data"
+        assert not target.exists()
+
+        result = AppSettings.get_user_data_dir()
+
+        assert result == target
+        assert target.exists()
+
+
+# ── setup_portable_backend_if_needed ──────────────────────────────────────────
+class TestSetupPortableBackend:
+    def test_noop_in_registry_mode(self, monkeypatch):
+        """No-op in registry mode — _backend stays None so settings()
+        keeps returning a fresh QSettings."""
+        monkeypatch.setattr("src.utils.build_mode.IS_PORTABLE", False)
+        AppSettings._backend = None
+
+        AppSettings.setup_portable_backend_if_needed()
+
+        assert AppSettings._backend is None
+
+    def test_installs_json_backend_in_portable_mode(self, monkeypatch, tmp_path):
+        """Portable mode swaps in a JsonSettings rooted at the portable
+        data dir."""
+        fake_exe = tmp_path / "SmartCitizen-Portable.exe"
+        fake_exe.write_bytes(b"")
+        monkeypatch.setattr(sys, "frozen", True, raising=False)
+        monkeypatch.setattr(sys, "executable", str(fake_exe))
+        monkeypatch.setattr("src.utils.build_mode.IS_PORTABLE", True)
+        AppSettings._backend = None
+
+        AppSettings.setup_portable_backend_if_needed()
+
+        assert isinstance(AppSettings._backend, JsonSettings)
+        assert AppSettings._backend.file_path() == tmp_path.resolve() / "data" / "config.json"
+
+    def test_idempotent_when_backend_already_set(self, monkeypatch, tmp_path):
+        """Calling setup twice shouldn't replace an existing backend
+        — that would lose any in-memory state and leak the file
+        handle on the previous instance."""
+        fake_exe = tmp_path / "SmartCitizen-Portable.exe"
+        fake_exe.write_bytes(b"")
+        monkeypatch.setattr(sys, "frozen", True, raising=False)
+        monkeypatch.setattr(sys, "executable", str(fake_exe))
+        monkeypatch.setattr("src.utils.build_mode.IS_PORTABLE", True)
+
+        AppSettings.setup_portable_backend_if_needed()
+        first_backend = AppSettings._backend
+
+        AppSettings.setup_portable_backend_if_needed()
+        second_backend = AppSettings._backend
+
+        assert first_backend is second_backend
+
+
+# ── End-to-end: settings round-trip through portable backend ─────────────────
+class TestPortableModeRoundTrip:
+    def test_appsettings_methods_use_json_backend_when_portable(self, monkeypatch, tmp_path):
+        """Sanity check that the existing AppSettings get_*/set_*
+        methods route through the JSON backend cleanly when portable
+        mode is active. If they fall through to a fresh QSettings
+        instead, the settings would silently end up in the user's
+        registry — a data-leak bug we want to catch in CI."""
+        fake_exe = tmp_path / "SmartCitizen-Portable.exe"
+        fake_exe.write_bytes(b"")
+        monkeypatch.setattr(sys, "frozen", True, raising=False)
+        monkeypatch.setattr(sys, "executable", str(fake_exe))
+        monkeypatch.setattr("src.utils.build_mode.IS_PORTABLE", True)
+        AppSettings._backend = None
+        AppSettings.setup_portable_backend_if_needed()
+
+        # Round-trip via a real AppSettings public method.
+        AppSettings.set_theme("dark")
+        assert AppSettings.get_theme() == "dark"
+
+        # Confirm it actually landed in the JSON file, not the registry.
+        config_path = tmp_path.resolve() / "data" / "config.json"
+        assert config_path.exists()
+        import json
+        with config_path.open() as f:
+            data = json.load(f)
+        assert data.get("theme") == "dark"


### PR DESCRIPTION
## What

Second of three PRs landing the standalone (portable) build option. Builds on **#16 (PR-A)**: wires the `IS_PORTABLE` flag, routes `get_user_data_dir()` to `<exe-dir>/data/` in portable mode, and skips the registry-specific migrators when portable.

**Behavior unchanged in registry mode** (the default ship state). PR-C provides the build flag that flips `IS_PORTABLE = True` at bundle time.

## Files

- **`src/utils/build_mode.py` (new, ~25 lines)** — `IS_PORTABLE` constant, defaults `False`. PR-C's build script overwrites this file at bundle time.
- **`src/utils/settings.py` (~50 net lines)** —
  - `AppSettings.get_user_data_dir()` checks `IS_PORTABLE` first; portable mode skips the registry-override and Documents-resolution paths entirely
  - `AppSettings._portable_data_dir()` — `<exe-dir>/data/` when frozen, `<repo-root>/portable_data/` when running unfrozen (so dev-mode flag-flipping doesn't pollute Documents)
  - `AppSettings.setup_portable_backend_if_needed()` — wires `JsonSettings` rooted at `<portable_data>/config.json` on portable startup. Idempotent. No-op in registry mode.
- **`src/main.py`** — Calls `setup_portable_backend_if_needed()` FIRST (must precede any AppSettings accessor). Wraps the migrator chain in `if not IS_PORTABLE` — they're all registry / pre-existing-Documents-tree migrators that don't apply to a portable build. `migrate_legacy_settings()` still runs in portable mode since it doubles as "seed defaults if no settings exist."

## Tests

`tests/test_portable_mode.py` — **10 cases**:

| Area | Cases |
|---|---|
| `build_mode.IS_PORTABLE` defaults False | 1 |
| `_portable_data_dir`: unfrozen → `<repo>/portable_data`, frozen → `<exe-dir>/data` | 2 |
| `get_user_data_dir` routing: registry mode unchanged, portable mode redirected, dir created | 3 |
| `setup_portable_backend_if_needed`: no-op in registry, installs JsonSettings in portable, idempotent | 3 |
| **End-to-end**: `AppSettings.set_theme()/get_theme()` round-trips through JSON file, NOT registry | 1 |

The end-to-end test is the most important guardrail — it catches the failure mode where AppSettings's existing `get_*/set_*` methods would silently fall through to a fresh `QSettings` instance instead of the portable JSON backend (data leak into the user's registry).

**Test delta**: 228 pass (+10 new), 4 pre-existing pak_extraction failures unchanged, 15 skipped. Zero regressions in PR-A's 218.

## Notes

- Tests use `from src.utils.X` imports (matching production) so `isinstance(_, JsonSettings)` checks match the same class object — same import-path consistency lesson from PR #6.
- `_portable_data_dir` resolves dynamically per-call (no caching) — a test using `monkeypatch.setattr(sys, "executable", ...)` gets honored without import-time freezing of the path.

## Sequencing

- **PR-A** (#16) — backend abstraction + JsonSettings
- **PR-B** (this) — path routing + migrator skip
- **PR-C** (next) — `build_exe.py --portable` flag, output naming, optional portable-zip distribution, CI matrix to build both flavors

**This PR's base is `feature/standalone-pr-a-storage-backend` (not `1.3.0`)** — it depends on #16's `_backend` hook. GitHub will rebase automatically once #16 merges, but if reviewing standalone, click "merge base" to compare against `1.3.0` directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)