### PR TITLE
Fix release.yml gate step (re-attempt v1.3.0 release)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,17 +95,23 @@ jobs:
             "skip=false" | Out-File -Append $env:GITHUB_OUTPUT
             exit 0
           }
-          # gh release view returns non-zero (and exits the step) if the
-          # release doesn't exist. Catch that and proceed; if it returns
-          # zero, the release exists and we skip.
+          # gh release view returns non-zero when the release doesn't
+          # exist — that's the expected "go publish" signal. Capture
+          # the exit code, branch on it, then explicitly exit 0 so
+          # PowerShell doesn't carry the non-zero $LASTEXITCODE forward
+          # and fail the whole step (GitHub Actions runs each pwsh
+          # script as a child process and fails the step if it returns
+          # non-zero at end of script).
           $existing = gh release view $tag --repo "${{ github.repository }}" 2>$null
-          if ($LASTEXITCODE -eq 0) {
+          $existsCode = $LASTEXITCODE
+          if ($existsCode -eq 0) {
             Write-Host "Release $tag already exists — skipping (no version bump in this push)"
             "skip=true" | Out-File -Append $env:GITHUB_OUTPUT
           } else {
             Write-Host "No release for $tag yet — proceeding to build + publish"
             "skip=false" | Out-File -Append $env:GITHUB_OUTPUT
           }
+          exit 0
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## What

One-line fix to `.github/workflows/release.yml` so the **Release** workflow's "Skip if release already exists" step exits cleanly. Re-attempts the `v1.3.0` release after the prior run (PR #21 merge) failed at the gate step.

## Root cause of the prior failure

The gate step ran correctly — `gh release view v1.3.0` returned non-zero (release doesn't exist), which we caught and branched on, and stdout showed *"No release for v1.3.0 yet — proceeding to build + publish"*. But the **step** itself exited with code 1.

Cause: PowerShell scripts in GitHub Actions inherit `$LASTEXITCODE` from the most recent native-process invocation. `gh release view`'s non-zero exit code survived past the if/else (PowerShell pipeline ops like `Out-File` don't reset it), and the step exited with that code.

## Fix

- Capture `$LASTEXITCODE` into a local right after the `gh` call
- Branch on the local
- Explicit `exit 0` at end of script so the step's exit code is what we say, not what `gh` left lying around

This pattern would bite **every** release.yml run on the branch-push trigger (the most common path forward). The tag-push and `workflow_dispatch` paths short-circuit before the `gh` call, so they're fine.

## What happens on merge

`release.yml` fires again. This time:
- Gate step exits cleanly → proceeds
- Reads VERSION.TXT (`1.3.0`) → tag = `v1.3.0`
- No existing release → builds standard installer + portable zip
- Auto-creates and pushes `v1.3.0` tag from the merge commit
- Publishes the GitHub Release with both artifacts and `1.3.0-RELEASE-NOTES.md` body
- `release-notify.yml` fires → Discord notification

## Test plan

- [x] CI green (this PR's CI run will validate against the same fix)
- [ ] On merge: watch release.yml run on the Actions tab, confirm `/releases/tag/v1.3.0` appears with both artifacts attached

🤖 Generated with [Claude Code](https://claude.com/claude-code)