### PR TITLE
Fix release.yml: preserve installer through portable build (re-attempt v1.3.0)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -174,6 +174,22 @@ jobs:
             exit $LASTEXITCODE
           }
 
+      - name: Stash standard installer before portable rebuild
+        # build_exe.py unconditionally rmtrees `dist/` at the start of
+        # every run (including --portable). Without stashing, the
+        # standard installer compiled in the previous step gets wiped
+        # by the portable build and the verify step downstream errors
+        # with "Missing artifacts: dist/SmartCitizen-X.Y.Z-Setup.exe".
+        # Move it out, do the portable build, move it back.
+        if: steps.gate.outputs.skip == 'false'
+        shell: pwsh
+        run: |
+          $version = "${{ steps.resolve.outputs.version }}"
+          $installer = "dist/SmartCitizen-${version}-Setup.exe"
+          New-Item -ItemType Directory -Path .artifacts-stash -Force | Out-Null
+          Move-Item $installer ".artifacts-stash/SmartCitizen-${version}-Setup.exe"
+          Write-Host "Stashed installer to .artifacts-stash/"
+
       - name: Build portable variant
         # Cleans dist/ + builds the same source tree with --portable, which
         # writes src/utils/_build_info.py with IS_PORTABLE=True before
@@ -181,6 +197,16 @@ jobs:
         # script removes _build_info.py in its finally block.
         if: steps.gate.outputs.skip == 'false'
         run: python scripts/build/build_exe.py --portable
+
+      - name: Restore standard installer
+        # Move the stashed installer back into dist/ so both artifacts
+        # sit alongside each other for the verify + publish steps.
+        if: steps.gate.outputs.skip == 'false'
+        shell: pwsh
+        run: |
+          $version = "${{ steps.resolve.outputs.version }}"
+          Move-Item ".artifacts-stash/SmartCitizen-${version}-Setup.exe" "dist/SmartCitizen-${version}-Setup.exe"
+          Write-Host "Restored installer to dist/"
 
       - name: Verify both artifacts exist
         if: steps.gate.outputs.skip == 'false'


### PR DESCRIPTION
## What

One-step fix to `.github/workflows/release.yml` so the installer survives the portable build. Re-attempts the v1.3.0 release after the prior run (post-PR #22 merge) failed at "Verify both artifacts exist" with:

```
Missing artifacts: dist/SmartCitizen-1.3.0-Setup.exe
```

## Root cause of the prior failure

`build_exe.py --portable` unconditionally `rmtree`s `dist/` at the start of every run as part of its standard "clean previous builds" pass. When the workflow chains the two builds back-to-back, the portable build wipes the standard installer that the previous Inno Setup step just produced. The standalone build script can't know it's being chained — it's the right behavior for the developer use case (build, test, build again).

## Fix

Workflow-level stash. After Inno Setup compile:

1. **Move** `dist/SmartCitizen-X.Y.Z-Setup.exe` → `.artifacts-stash/`
2. Run `python scripts/build/build_exe.py --portable` (clears `dist/`, produces only the portable zip)
3. **Move** the stashed installer back → `dist/`

Both artifacts then sit in `dist/` for the existing verify + publish steps (no further changes needed).

## What happens on merge

Same flow as before, fixed:
- Gate step exits cleanly (PR #22's fix)
- Builds standard installer + Inno Setup compiles → `dist/SmartCitizen-1.3.0-Setup.exe`
- **NEW:** Stash installer → `.artifacts-stash/`
- Builds portable variant → `dist/SmartCitizen-Portable-v1.3.0.zip`
- **NEW:** Restore installer → `dist/`
- Verify finds both artifacts → ✓
- Auto-creates `v1.3.0` tag from merge commit
- Publishes Release with both files attached + curated `1.3.0-RELEASE-NOTES.md` body
- Discord notification fires

Clean slate prerequisite checked: no `v1.3.0` tag and no `v1.3.0` release exist on the repo (the prior failed run errored before the auto-tag step), so this run starts fresh.

## Test plan

- [x] CI green (this PR validates against CI which doesn't exercise the portable path — the real validation is on merge)
- [ ] On merge: watch release.yml, confirm `Stash standard installer` and `Restore standard installer` steps run cleanly, both artifacts attached at `/releases/tag/v1.3.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)