### PR TITLE
Inline Discord notification into release.yml + fix manual recovery

### DIFF
--- a/.github/workflows/release-notify.yml
+++ b/.github/workflows/release-notify.yml
@@ -1,42 +1,54 @@
-name: Notify Discord on Release
+name: Notify Discord on Release (manual recovery)
+
+# Manual-only workflow for re-firing Discord notifications when the
+# automatic post baked into release.yml didn't fire (rare — usually
+# only if Discord's webhook 5xx'd at the moment release.yml ran).
+#
+# The `release: published` trigger was removed when Discord posting was
+# inlined into release.yml. GitHub's workflow-loop safety meant the
+# inline path was the only one that worked anyway: events triggered
+# by GITHUB_TOKEN-based actions (like softprops/action-gh-release)
+# don't trigger downstream workflows, so this workflow's `release`
+# trigger never actually fired for releases created by release.yml.
+#
+# Kept around as workflow_dispatch because:
+#   - Recovery from a failed Discord post (retry without re-running
+#     the full ~13-min release pipeline)
+#   - Re-firing a notification for a release created outside Actions
+#     (manual web UI, future tooling)
 
 on:
-  release:
-    types: [published]
   workflow_dispatch:
     inputs:
       version:
-        description: 'Release tag (e.g. v0.5.2)'
+        description: 'Release tag to notify for (e.g. v1.3.0)'
         required: true
-        default: 'v0.5.2'
+        type: string
 
 jobs:
   notify:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Need the full history so the {VERSION}-RELEASE-NOTES.md
+          # file is on disk for discord_notify.py to read.
+          fetch-depth: 0
+          # Checkout the specific tag so we get the release-notes file
+          # as it existed AT release time, not whatever's on main now.
+          ref: ${{ github.event.inputs.version }}
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: '3.11'
 
       - name: Install dependencies
         run: pip install python-dotenv
 
-      - name: Get release tag
-        id: tag
-        run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "version=${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
-          else
-            echo "version=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
-          fi
-
       - name: Send Discord notification
-        run: |
-          python scripts/discord_notify.py "${{ steps.tag.outputs.version }}" "$RELEASE_BODY"
+        # discord_notify.py self-resolves notes from
+        # {VERSION}-RELEASE-NOTES.md when not given as argv.
+        run: python scripts/discord_notify.py "${{ github.event.inputs.version }}"
         env:
           DISCORD_RELEASE_WEBHOOK_URL: ${{ secrets.DISCORD_RELEASE_WEBHOOK_URL }}
-          RELEASE_BODY: ${{ github.event.release.body }}
-        continue-on-error: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ on:
 
 jobs:
   build-and-release:
-    name: Build installer + portable + publish GitHub Release
+    name: Build & Release
     runs-on: windows-latest
     timeout-minutes: 30
     permissions:
@@ -273,3 +273,27 @@ jobs:
           fail_on_unmatched_files: true
           draft: false
           prerelease: false
+
+      - name: Post Discord notification
+        # Inlined here because the standalone release-notify.yml workflow
+        # — which subscribes to `release: published` — is blocked from
+        # firing by GitHub's workflow-loop safety: events triggered by
+        # workflows using GITHUB_TOKEN don't trigger downstream
+        # workflows. softprops/action-gh-release uses GITHUB_TOKEN, so
+        # the publish event it generates can't chain into Discord
+        # notification automatically. Calling discord_notify.py
+        # directly from the same workflow side-steps the safety net
+        # entirely. release-notify.yml is now a manual-recovery tool
+        # only (workflow_dispatch).
+        if: steps.gate.outputs.skip == 'false'
+        shell: pwsh
+        run: |
+          python -m pip install python-dotenv --quiet
+          python scripts/discord_notify.py "${{ steps.resolve.outputs.tag }}"
+        env:
+          DISCORD_RELEASE_WEBHOOK_URL: ${{ secrets.DISCORD_RELEASE_WEBHOOK_URL }}
+        # Don't fail the workflow if Discord posting hits a transient
+        # webhook error — the release is already published, that's the
+        # primary success criterion. A failed Discord post can be
+        # retried via release-notify.yml's workflow_dispatch.
+        continue-on-error: true

--- a/scripts/discord_notify.py
+++ b/scripts/discord_notify.py
@@ -110,22 +110,53 @@ def send_discord_notification(version: str, release_notes: str = "") -> bool:
         return False
 
 
+def _resolve_release_notes(version: str, explicit_notes: str | None) -> str:
+    """Three-tier resolution for the embed body.
+
+    1. Explicit positional argument (legacy callers, tests).
+    2. ``RELEASE_BODY`` env var (CI patterns that pre-load via env).
+    3. ``{VERSION}-RELEASE-NOTES.md`` next to scripts/ at the repo root —
+       matches the existing convention used by the build / release
+       workflow and means the script is self-sufficient when given just
+       the version.
+
+    Returns ``""`` when nothing's available; the embed falls back to its
+    "Check the release page for more details." default in that case.
+    """
+    if explicit_notes is not None and explicit_notes.strip():
+        return explicit_notes
+    env_notes = os.getenv("RELEASE_BODY", "")
+    if env_notes.strip():
+        return env_notes
+    # Strip leading "v" from the tag so v1.3.0 → 1.3.0-RELEASE-NOTES.md
+    version_bare = version.lstrip("v")
+    notes_file = project_root / f"{version_bare}-RELEASE-NOTES.md"
+    if notes_file.exists():
+        try:
+            return notes_file.read_text(encoding="utf-8")
+        except OSError as e:
+            print(f"[WARNING] Could not read {notes_file}: {e}")
+    return ""
+
+
 def main():
     if len(sys.argv) < 2:
         print("Usage: python scripts/discord_notify.py <version> [release_notes]")
-        print("Example: python scripts/discord_notify.py v0.1.0")
+        print("       (release_notes also resolved from $RELEASE_BODY env var")
+        print("        or {VERSION}-RELEASE-NOTES.md if not given)")
+        print("Example: python scripts/discord_notify.py v1.3.0")
         sys.exit(1)
 
     version = sys.argv[1]
+    explicit_notes = sys.argv[2] if len(sys.argv) > 2 else None
+    release_notes = _resolve_release_notes(version, explicit_notes)
 
-    # Get release notes from second argument or empty string
-    release_notes = ""
-    if len(sys.argv) > 2:
-        release_notes = sys.argv[2]
+    if release_notes:
+        print(f"Posting release notification for {version} ({len(release_notes)} chars of notes)...")
+    else:
+        print(f"Posting release notification for {version} (no release notes resolved)...")
 
-    print(f"Posting release notification for {version}...")
     success = send_discord_notification(version, release_notes)
-
     sys.exit(0 if success else 1)
 
 


### PR DESCRIPTION
## What

Fixes the **two** Discord-notification issues v1.3.0 surfaced:

1. `release-notify.yml` never auto-fired on the v1.3.0 release publish
2. The manual `workflow_dispatch` recovery posted an embed with no release notes

## Root causes

**Auto-fire didn't trigger.** GitHub's workflow-loop safety blocks events triggered by workflows using `GITHUB_TOKEN` from triggering downstream workflows. `softprops/action-gh-release` uses `GITHUB_TOKEN`, so the `release: published` event it emitted couldn't chain into `release-notify.yml`'s `release: published` trigger. (Same protection that prevents our own auto-tag push from re-firing release.yml.)

**Manual fallback was empty.** `release-notify.yml`'s manual path only read from `github.event.release.body` (which is empty in `workflow_dispatch` context — it's only populated for the `release` event). So the script got `version="v1.3.0"` and `notes=""`, and the embed fell through to "Check the release page for more details."

## Fix architecture

| Component | Change |
|---|---|
| **`scripts/discord_notify.py`** | New three-tier notes resolution: explicit argv → `RELEASE_BODY` env var → `{VERSION}-RELEASE-NOTES.md` from project root. Backwards compatible. |
| **`.github/workflows/release.yml`** | New "Post Discord notification" step right after Publish GitHub Release. Same workflow → same job → no `GITHUB_TOKEN`-event-loop issue. `continue-on-error: true` so a transient webhook 5xx doesn't fail the workflow (release is already published, primary success criterion met). |
| **`.github/workflows/release-notify.yml`** | Trimmed to manual-recovery-only. Dropped `release: published` trigger (never worked anyway due to token safety). `workflow_dispatch` input now actually works: checkout uses the tag's ref so `{VERSION}-RELEASE-NOTES.md` is on disk for `discord_notify.py` to auto-resolve. |

## Coverage / risk

- `discord_notify.py` changes are purely additive (new helper + fallback resolution chain); no behavior change for callers passing notes positionally or via `RELEASE_BODY`.
- `release.yml`'s new step is gated on the same `steps.gate.outputs.skip` flag as the rest of the build pipeline — won't fire on doc-only main pushes that skip the release.
- `release-notify.yml` keeps its `workflow_dispatch` interface unchanged (`version` input only), so any saved manual-trigger scripts / docs keep working.

## Recovery for v1.3.0 specifically

After this PR merges to main:
1. Go to **Actions → "Notify Discord on Release (manual recovery)" → Run workflow**
2. Enter `v1.3.0` in the version input
3. Run

The dispatch path will checkout the `v1.3.0` tag, find `1.3.0-RELEASE-NOTES.md` on disk, and post the full embed (truncated to Discord's 4000-char limit by the existing script logic).

## Test plan

- [x] YAML validates for both workflows
- [x] `discord_notify._resolve_release_notes` covered locally: explicit override wins, env-var fallback works, file-on-disk fallback finds `1.3.0-RELEASE-NOTES.md`, missing version returns `""`
- [ ] On merge: re-trigger `release-notify.yml` manually with `v1.3.0` → confirm Discord post matches the v1.2.0-style embed (full notes body, link, footer)
- [ ] Next release (v1.3.1+) will exercise the inline path automatically — Discord post should fire from `release.yml` itself, no manual step needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)