### PR TITLE
Hotfix: installer's data-folder choice now persists (re-release v1.3.0)

### DIFF
--- a/1.3.0-RELEASE-NOTES.md
+++ b/1.3.0-RELEASE-NOTES.md
@@ -1,5 +1,7 @@
 # Smart Citizen 1.3.0 — Mission Intel + Portable Build + Apache 2.0
 
+> 🔁 **Re-released to fix an installer bug.** The original v1.3.0 artifacts had a Pascal-callback bug in the installer that silently dropped the user's "Smart Citizen Data" folder choice on the floor — users who picked a custom data folder would launch the app and find it pointing at `Documents\Smart Citizen` anyway. Fixed in this re-release; both `SmartCitizen-1.3.0-Setup.exe` and `SmartCitizen-Portable-v1.3.0.zip` on this page have the corrected installer. If you grabbed v1.3.0 in its first few hours and your data folder is wrong, either re-run the new installer or just set the path manually in the Config tab — your override is honored either way.
+
 > ⚠️ **Heads-up if Windows blocks the installer:** Smart Citizen is not yet code-signed, and Windows 11's **Smart App Control** (SAC) blocks unsigned installers — Properties → Unblock does **not** help with SAC. To install:
 >
 > 1. Open **Settings → Privacy & security → Windows Security → App & browser control**.

--- a/installer.iss
+++ b/installer.iss
@@ -360,6 +360,75 @@ begin
   end;
 end;
 
+procedure WriteInstallerChoicesToRegistry();
+var
+  RegPath: String;
+  FinalPath: String;
+  DataDir: String;
+  DocsDefault: String;
+begin
+  { Persist the user's choices from the installer wizard pages
+    (SC install dir + Smart Citizen data folder) into the registry
+    so the app reads them on first launch. Called from
+    CurStepChanged at ssPostInstall — AFTER files have been copied
+    so ForceDirectories on a custom data folder doesn't race the
+    install itself. }
+
+  { SC directory: written to BOTH the new (Smart Citizen) and legacy
+    (SC Localization Editor) registry nodes. The new node survives
+    the app's migrate_registry_appname() — which deletes the legacy
+    subtree after copying values across. The legacy write is a compat
+    fallback for very old app versions that haven't been launched
+    yet to perform their own migration; cheap and keeps downgrade
+    paths working. }
+  FinalPath := SCDirectoryPage.Values[0];
+  if FinalPath <> '' then
+  begin
+    RegPath := 'Software\Osiris DevWorks\Smart Citizen';
+    RegWriteStringValue(HKCU, RegPath, 'sc_directory', FinalPath);
+    RegWriteStringValue(HKCU, RegPath, 'game_install_path', FinalPath);
+    RegWriteStringValue(HKCU,
+      'Software\Osiris DevWorks\SC Localization Editor',
+      'sc_directory', FinalPath);
+    Log('Saved sc_directory to registry (Smart Citizen + legacy nodes): ' + FinalPath);
+  end;
+
+  { Persist the data folder choice. The page is always shown in 1.3.0+,
+    so every install reaches this branch. Comparison rules:
+      - Empty field, or value equal to the natural Documents default:
+        clear the override so the app's dynamic Documents resolution
+        wins on every launch (matches the in-app Reset behavior in
+        AppSettings.set_user_data_dir(None)). Keeps the registry tidy
+        for users who never wanted a custom path.
+      - Anything else: write user_data_dir. Also clear the legacy
+        camelCase 'UserDataDir' alias if present so the app reads the
+        canonical value. ForceDirectories ensures the chosen folder
+        exists by the time the app first launches.
+    Writes are scoped to the NEW (Smart Citizen) registry node — the
+    app's migrate_registry_appname() preserves it across rebrand
+    migrations. }
+  DataDir := DataDirPage.Values[0];
+  DocsDefault := GetDocumentsBase() + '\Smart Citizen';
+  if (DataDir = '') or (CompareText(DataDir, DocsDefault) = 0) then
+  begin
+    RegDeleteValue(HKCU,
+      'Software\Osiris DevWorks\Smart Citizen', 'user_data_dir');
+    RegDeleteValue(HKCU,
+      'Software\Osiris DevWorks\Smart Citizen', 'UserDataDir');
+    Log('User chose default Documents folder; cleared user_data_dir override.');
+  end
+  else
+  begin
+    RegWriteStringValue(HKCU,
+      'Software\Osiris DevWorks\Smart Citizen',
+      'user_data_dir', DataDir);
+    RegDeleteValue(HKCU,
+      'Software\Osiris DevWorks\Smart Citizen', 'UserDataDir');
+    ForceDirectories(DataDir);
+    Log('Saved user_data_dir to registry: ' + DataDir);
+  end;
+end;
+
 procedure CurStepChanged(CurStep: TSetupStep);
 begin
   if (CurStep=ssInstall) then
@@ -375,6 +444,19 @@ begin
 
     { Clear cached data but preserve registry settings (source paths, preferences, etc.) }
     CleanCachedData();
+  end;
+
+  if (CurStep = ssPostInstall) then
+  begin
+    { Persist wizard-page choices (sc_directory + user_data_dir) to the
+      registry. Previously this lived in a procedure named
+      `CurFinished(LastStep: TSetupStep)` — NOT a real Inno Setup event
+      callback name (Inno doesn't support that signature) — so the
+      whole block silently never ran. Users who customized the data
+      folder in the installer would see Documents\Smart Citizen on
+      first launch instead of their pick. Discovered post-1.3.0 release
+      after a user reported the data-dir choice not carrying over. }
+    WriteInstallerChoicesToRegistry();
   end;
 end;
 
@@ -463,9 +545,10 @@ begin
       2. LEGACY "SC Localization Editor" node — kept as a read-side
          fallback so users who upgrade from a version earlier than 0.9.2
          (and therefore have no NEW node yet) still get their path
-         prefilled on the first reinstall. The installer's CurFinished
-         writes to the NEW node regardless, so subsequent reinstalls
-         resolve via path 1. }
+         prefilled on the first reinstall. The installer's
+         WriteInstallerChoicesToRegistry (called from CurStepChanged
+         at ssPostInstall) writes to the NEW node regardless, so
+         subsequent reinstalls resolve via path 1. }
   NewRegPath := 'Software\Osiris DevWorks\Smart Citizen';
   LegacyRegPath := 'Software\Osiris DevWorks\SC Localization Editor';
   DefaultPath := '';
@@ -549,10 +632,11 @@ begin
       2. Else if Documents is OneDrive-synced, suggest the local
          %USERPROFILE%\Documents\Smart Citizen junction (escapes the sync).
       3. Else pre-fill Documents\Smart Citizen (the natural default).
-    CurFinished compares the final value against the natural default and
-    only writes user_data_dir when the user actually picked something
-    different — so leaving the field at its default keeps the registry
-    clean and lets the app's dynamic Documents resolution win. }
+    WriteInstallerChoicesToRegistry compares the final value against the
+    natural default and only writes user_data_dir when the user actually
+    picked something different — so leaving the field at its default
+    keeps the registry clean and lets the app's dynamic Documents
+    resolution win. }
   DataDirPage := CreateInputDirPage(
     SCDirectoryPage.ID,
     'Smart Citizen Data Location',
@@ -595,70 +679,3 @@ begin
   Result := False;
 end;
 
-procedure CurFinished(LastStep: TSetupStep);
-var
-  RegPath: String;
-  FinalPath: String;
-  DataDir: String;
-  DocsDefault: String;
-begin
-  if LastStep = ssPostInstall then
-  begin
-    { Read the SC directory value at finish time (not page-change time)
-      to ensure we capture any edits the user made on the page }
-    FinalPath := SCDirectoryPage.Values[0];
-    if FinalPath <> '' then
-    begin
-      { Write to the NEW ("Smart Citizen") node so the value survives
-        the app's migrate_registry_appname() — which deletes the legacy
-        subtree after copying values across. Prior installer revs wrote
-        only to the legacy node and lost sc_directory on the next app
-        launch, so reinstalls couldn't pre-fill the path. Writing to the
-        legacy node ALSO (as a compat fallback for very old app versions
-        that don't understand the new node yet) is cheap and keeps
-        downgrade paths working. }
-      RegPath := 'Software\Osiris DevWorks\Smart Citizen';
-      RegWriteStringValue(HKCU, RegPath, 'sc_directory', FinalPath);
-      RegWriteStringValue(HKCU, RegPath, 'game_install_path', FinalPath);
-      RegWriteStringValue(HKCU,
-        'Software\Osiris DevWorks\SC Localization Editor',
-        'sc_directory', FinalPath);
-      Log('Saved sc_directory to registry (Smart Citizen + legacy nodes): ' + FinalPath);
-    end;
-
-    { Persist the data folder choice. The page is always shown in 1.3.0+,
-      so every install reaches this branch. Comparison rules:
-        - Empty field, or value equal to the natural Documents default:
-          clear the override so the app's dynamic Documents resolution
-          wins on every launch (matches the in-app Reset behavior in
-          AppSettings.set_user_data_dir(None)). Keeps the registry tidy
-          for users who never wanted a custom path.
-        - Anything else: write user_data_dir. Also clear the legacy
-          camelCase 'UserDataDir' alias if present so the app reads the
-          canonical value. ForceDirectories ensures the chosen folder
-          exists by the time the app first launches.
-      Writes are scoped to the NEW (Smart Citizen) registry node — the
-      app's migrate_registry_appname() preserves it across rebrand
-      migrations. }
-    DataDir := DataDirPage.Values[0];
-    DocsDefault := GetDocumentsBase() + '\Smart Citizen';
-    if (DataDir = '') or (CompareText(DataDir, DocsDefault) = 0) then
-    begin
-      RegDeleteValue(HKCU,
-        'Software\Osiris DevWorks\Smart Citizen', 'user_data_dir');
-      RegDeleteValue(HKCU,
-        'Software\Osiris DevWorks\Smart Citizen', 'UserDataDir');
-      Log('User chose default Documents folder; cleared user_data_dir override.');
-    end
-    else
-    begin
-      RegWriteStringValue(HKCU,
-        'Software\Osiris DevWorks\Smart Citizen',
-        'user_data_dir', DataDir);
-      RegDeleteValue(HKCU,
-        'Software\Osiris DevWorks\Smart Citizen', 'UserDataDir');
-      ForceDirectories(DataDir);
-      Log('Saved user_data_dir to registry: ' + DataDir);
-    end;
-  end;
-end;


### PR DESCRIPTION
## What

Fixes the v1.3.0 installer bug a community user reported: customizing the "Smart Citizen Data" folder on the wizard page silently dropped the choice — the app launched against `Documents\Smart Citizen` regardless. Per @osirisdevworks's direction, this ships as a **re-release of v1.3.0**, not a v1.3.1 bump.

## Root cause

The post-install registry-write block (writes `user_data_dir`, `sc_directory`, `game_install_path`) lived inside a Pascal procedure named `CurFinished(LastStep: TSetupStep)`. **Inno Setup has no such event callback.** The standard event for "after files copied" is `CurStepChanged(CurStep: TSetupStep)` with `CurStep = ssPostInstall`. Inno silently ignored the orphan procedure and the entire body never ran.

The bug masked itself for `sc_directory` / `game_install_path` because the app's first-launch auto-detection independently finds the SC install path. `user_data_dir` has no such fallback, so the user-visible regression was "my data-folder choice was ignored."

## Fix

- Move the body into a helper `WriteInstallerChoicesToRegistry()` and call it from the existing `CurStepChanged` under an `ssPostInstall` branch
- Existing `ssInstall` logic (uninstall prior version, migrate Documents folder name, clean cache) preserved unchanged
- Removed the orphan `CurFinished` procedure
- Updated comment references elsewhere in the file
- Added a re-release banner to `1.3.0-RELEASE-NOTES.md` so the release page explains why artifacts differ from the original drop

## Re-release strategy (after merge)

1. Force-move the `v1.3.0` tag to the post-merge commit on `main`
2. Trigger `release.yml` via `workflow_dispatch` with `tag=v1.3.0`
3. Workflow checks out the (now updated) v1.3.0 tag → builds standard installer + portable zip → softprops/action-gh-release UPDATES the existing release with the new asset bytes

The release URL stays the same (`/releases/tag/v1.3.0`); only the attached `.exe` and `.zip` change. Anyone who downloaded the buggy artifacts in the first few hours and re-runs the new installer gets the fix.

VERSION.TXT stays at `1.3.0` so the installer filename matches the existing release (`SmartCitizen-1.3.0-Setup.exe`).

## Verification (manual)

End-to-end Inno UI flow can't be exercised in CI. After re-release:
- [ ] Install on a clean machine, pick a custom data folder on the wizard page
- [ ] Launch app, confirm Config tab shows the custom path (not Documents)
- [ ] Bonus: confirm `HKCU\Software\Osiris DevWorks\Smart Citizen\user_data_dir` in regedit contains the custom path

## Existing users

Anyone who already installed v1.3.0 and manually re-set their data folder is fine — their override is saved correctly via `AppSettings.set_user_data_dir`. The fix only changes behavior for fresh installs going forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)