### PR TITLE
release.yml: make auto-tag step idempotent when tag already exists

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -250,10 +250,22 @@ jobs:
         # have one. Pushing tags via GITHUB_TOKEN does NOT recursively
         # trigger this workflow (that's GitHub's built-in safety against
         # workflow loops with the default token).
+        #
+        # Idempotent: a manually-pushed tag (e.g. someone ran ``git push
+        # origin v1.3.1`` after merging the release PR) races with this
+        # workflow's branch-push trigger, and ``git push origin $tag``
+        # would fail with ``! [rejected] ... (already exists)`` and red-X
+        # the workflow run even though the parallel tag-push run will
+        # publish the release fine. Pre-check origin and bail out cleanly.
         if: steps.gate.outputs.skip == 'false' && steps.resolve.outputs.trigger == 'branch'
         shell: pwsh
         run: |
           $tag = "${{ steps.resolve.outputs.tag }}"
+          $exists = git ls-remote --tags origin "refs/tags/$tag"
+          if ($exists) {
+            Write-Host "Tag $tag already exists on origin — skipping auto-tag step"
+            exit 0
+          }
           git config user.name  "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git tag -a $tag -m "Release $tag (auto-tagged by release.yml on merge to ${{ github.ref_name }})"


### PR DESCRIPTION
## Summary

Fixes the red-X on the branch-push release-workflow run that we saw on v1.3.1 (run [25758237634](https://github.com/Osiris-DevWorks/smart-citizen/actions/runs/25758237634)).

When the version tag is manually pushed (`git push origin v1.3.1`) after merging the release PR, two parallel workflow runs fire — one from the branch push, one from the tag push. They race; the branch-push run reaches "Create + push tag (branch-push only)" and `git push origin v1.3.1` fails with:

```
! [rejected]   v1.3.1 -> v1.3.1 (already exists)
```

The release publishes successfully (the parallel tag-push run does the actual work) but the branch-push run shows a red X for a purely redundant operation.

Fix: pre-check origin with `git ls-remote --tags refs/tags/$tag` and exit cleanly if it's already there.

## Test plan
- [ ] Land this PR
- [ ] On the next release: merge → manually push tag → confirm both workflow runs go green (one publishes, one no-ops at this step)

🤖 Generated with [Claude Code](https://claude.com/claude-code)