### PR TITLE
Stats: append mining laser + handheld salvage stats from XML

### DIFF
--- a/scripts/generate_enhancements_ini.py
+++ b/scripts/generate_enhancements_ini.py
@@ -1218,6 +1218,200 @@ def enhancements_quantum_drive(root: ET.Element) -> str:
     return "\\n".join(lines)
 
 
+def enhancements_mining_laser(root: ET.Element) -> str:
+    """Extract stats for ship-mounted mining laser entities.
+
+    Covers Arbor, Lancet, Helix, Hofstede, Klein, Impact (under
+    ``ships/weapons/mining_laser_*.xml``). CIG's stock descriptions
+    already author the headline numbers (Mining Laser Power, Optimal /
+    Maximum Range, Module Slots, Resistance / Instability modifiers),
+    so this function focuses on stats that DON'T appear in the
+    description today: component HP, damage resistances, fire-beam
+    energy draw + heat + wear, distortion threshold, and the per-mode
+    damage-per-second values from the fire actions.
+
+    The mining-laser modifier block (``SEntityComponentMiningLaserParams``)
+    holds the laserInstability / chargeWindow / resistance / filter
+    modifier values. Those duplicate what CIG already prints, but the
+    user-confirmed convention for this gear category is "append always
+    — CIG sometimes forgets to update the description after a balance
+    pass", so they're emitted here too.
+
+    Mining lasers that reference a globalParams record by UUID for
+    their BASE values (mining-laser power range, optimal range, etc.)
+    don't have those base values resolved here in v1 — local extraction
+    only. That's a v2 enhancement; for now CIG's description is the
+    source of truth for the base values and this function adds the
+    overlay-style stats the user can't see elsewhere.
+    """
+    lines: list[str] = []
+
+    # Per-fire-action damage-per-second + beam ranges + energy draw + heat.
+    # Mining lasers have two fire actions in their <fireActions> wrapper:
+    # the fracture beam (mining damage type) and the extraction beam.
+    # Each carries its own DamageEnergy, full/zero range, and energy curve.
+    fire_actions = root.findall(".//fireActions/SWeaponActionFireBeamParams")
+    if not fire_actions:
+        fire_actions = root.findall(".//SWeaponActionFireBeamParams")
+    for idx, fa in enumerate(fire_actions, 1):
+        # Mode label from mannequinTag (laser/tractor) → human label.
+        mannequin = fa.find("mannequinTag")
+        mtag = mannequin.get("tag") if mannequin is not None else ""
+        mode = {"laser": "Fracture", "tractor": "Extraction"}.get(mtag, f"Beam {idx}")
+
+        dps_el = fa.find("damagePerSecond/DamageInfo")
+        dps = dps_el.get("DamageEnergy") if dps_el is not None else None
+        full_r = fa.get("fullDamageRange")
+        zero_r = fa.get("zeroDamageRange")
+        e_min  = fa.get("minEnergyDraw")
+        e_max  = fa.get("maxEnergyDraw")
+        heat_s = fa.get("heatPerSecond")
+        wear_s = fa.get("wearPerSecond")
+
+        # Only emit a line if at least one numeric is non-zero; templates
+        # ship with zeroed defaults that aren't worth showing.
+        nonzero = any(
+            v not in (None, "", "0", "0.0") for v in (dps, full_r, zero_r, e_min, e_max, heat_s, wear_s)
+        )
+        if not nonzero:
+            continue
+        parts: list[str] = []
+        if dps not in (None, "0", "0.0"):
+            parts.append(f"DPS: {_fmt(dps)}")
+        if full_r not in (None, "0", "0.0") or zero_r not in (None, "0", "0.0"):
+            parts.append(f"Range: {_fmt(full_r, 'm')}→{_fmt(zero_r, 'm')}")
+        if e_max not in (None, "0", "0.0"):
+            if e_min and e_min != e_max and e_min not in ("0", "0.0"):
+                parts.append(f"Energy: {_fmt(e_min)}–{_fmt(e_max)} PU/s")
+            else:
+                parts.append(f"Energy: {_fmt(e_max)} PU/s")
+        if heat_s not in (None, "0", "0.0"):
+            parts.append(f"Heat: {_fmt(heat_s)}/s")
+        if wear_s not in (None, "0", "0.0"):
+            parts.append(f"Wear: {wear_s}/s")
+        if parts:
+            lines.append(f"<EM4>{mode}:</EM4>  " + "  |  ".join(parts))
+
+    # Mining-laser modifier overlay. CIG's description has these but the
+    # user wants them re-emitted from XML so balance updates surface even
+    # when the description text rots.
+    mlp = _find(root, "SEntityComponentMiningLaserParams")
+    if mlp is not None:
+        modifiers = mlp.find("miningLaserModifiers")
+        if modifiers is not None:
+            mod_parts: list[str] = []
+            for child_tag, label in (
+                ("laserInstability",                "Instability"),
+                ("optimalChargeWindowSizeModifier","Optimal Charge Window"),
+                ("resistanceModifier",             "Resistance"),
+            ):
+                fm = modifiers.find(f"{child_tag}/FloatModifierMultiplicative")
+                if fm is not None:
+                    val = fm.get("value")
+                    if val and val not in ("0", "0.0"):
+                        sign = "+" if float(val) > 0 else ""
+                        mod_parts.append(f"{label}: {sign}{val}%")
+            filter_fm = mlp.find("filterParams/filterModifier/FloatModifierMultiplicative")
+            if filter_fm is not None:
+                fval = filter_fm.get("value")
+                if fval and fval not in ("0", "0.0"):
+                    sign = "+" if float(fval) > 0 else ""
+                    mod_parts.append(f"Inert Filter: {sign}{fval}%")
+            if mod_parts:
+                lines.append("<EM4>Modifiers:</EM4>  " + "  |  ".join(mod_parts))
+
+    # Structural stats — component HP + distortion + ship-component-style
+    # signatures if they happen to be present on a ship-mountable laser.
+    comp_hp = _attr(root, "SHealthComponentParams", "Health")
+    if comp_hp is not None:
+        lines.append(f"<EM4>Component HP:</EM4> {_fmt(comp_hp)}")
+    distort = _attr(root, "SDistortionParams", "Maximum")
+    if distort is not None and distort not in ("0", "0.0"):
+        lines.append(f"<EM4>Max Distortion:</EM4> {_fmt(distort)}")
+    em_sig = _attr(root, "EMSignature", "nominalSignature")
+    ir_sig = _attr(root, "IRSignature", "nominalSignature")
+    if em_sig is not None or ir_sig is not None:
+        sig_parts: list[str] = []
+        if em_sig is not None and em_sig not in ("0", "0.0"):
+            sig_parts.append(f"EM: {_fmt(em_sig)}")
+        if ir_sig is not None and ir_sig not in ("0", "0.0"):
+            sig_parts.append(f"IR: {_fmt(ir_sig)}")
+        if sig_parts:
+            lines.append("<EM4>Signatures:</EM4>  " + "  |  ".join(sig_parts))
+
+    return "\\n".join(lines) if lines else ""
+
+
+def enhancements_salvage_tool(root: ET.Element) -> str:
+    """Extract stats for handheld salvage tools.
+
+    Covers the Renovar XTR (``weapons/fps_weapons/grin_salvage_repair_01.xml``)
+    and the multitool's salvage_repair mode
+    (``weapons/fps_weapons/grin_multitool_01_default_salvage_repair.xml``).
+    Both expose a pair of ``SWeaponActionFireSalvageRepairParams`` —
+    one for Repair mode, one for Salvage mode — each carrying its own
+    repair-rate / efficiency / ramp-up curve. Renders both modes side
+    by side so a player can compare a single tool's two halves without
+    leaving the description.
+
+    Skipped: ship-mounted salvage equipment under ``ships/salvagemunching``
+    is currently placeholder XMLs with ``Name="@LOC_PLACEHOLDER"`` — no
+    real stats to extract until CIG fleshes those records out.
+    """
+    lines: list[str] = []
+
+    fire_actions = root.findall(".//SWeaponActionFireSalvageRepairParams")
+    for fa in fire_actions:
+        # Mode is encoded on the element itself via the `salvageRepairMode`
+        # attribute ("Repair" / "Salvage"). Use it as the EM4-tagged header.
+        mode = fa.get("salvageRepairMode") or fa.get("name") or "Mode"
+        eff      = fa.get("materialEfficiency")
+        hp_rate  = fa.get("maxHealthRepairRate")
+        dmg_rate = fa.get("maxDamageMapRepairRate")
+        h2a      = fa.get("healthToAmmoRatio")
+        ramp_up  = fa.get("rampUpTime")
+        ramp_dn  = fa.get("rampDownTime")
+        e_min    = fa.get("minEnergyDraw")
+        e_max    = fa.get("maxEnergyDraw")
+        heat_s   = fa.get("heatPerSecond")
+        wear_s   = fa.get("wearPerSecond")
+
+        parts: list[str] = []
+        if hp_rate not in (None, "0", "0.0"):
+            parts.append(f"HP Rate: {_fmt(hp_rate)}/s")
+        if dmg_rate not in (None, "0", "0.0"):
+            parts.append(f"Damage-Map Rate: {_fmt(dmg_rate)}/s")
+        if eff not in (None, "1", "1.0"):
+            # 1.0 is the default no-op — only emit when CIG actually tunes
+            # below unity (Renovar Salvage mode runs at 0.7 efficiency).
+            parts.append(f"Material Efficiency: {_fmt(eff, '', 2)}")
+        if h2a not in (None, "0", "0.0"):
+            parts.append(f"HP/Ammo: {_fmt(h2a, '', 2)}")
+        if ramp_up not in (None, "0", "0.0") or ramp_dn not in (None, "0", "0.0"):
+            parts.append(f"Ramp: {_fmt(ramp_up, 's', 1)}↑ {_fmt(ramp_dn, 's', 1)}↓")
+        if e_max not in (None, "0", "0.0"):
+            if e_min and e_min != e_max and e_min not in ("0", "0.0"):
+                parts.append(f"Energy: {_fmt(e_min)}–{_fmt(e_max)} PU/s")
+            else:
+                parts.append(f"Energy: {_fmt(e_max)} PU/s")
+        if heat_s not in (None, "0", "0.0"):
+            parts.append(f"Heat: {_fmt(heat_s)}/s")
+        if wear_s not in (None, "0", "0.0"):
+            parts.append(f"Wear: {wear_s}/s")
+        if parts:
+            lines.append(f"<EM4>{mode}:</EM4>  " + "  |  ".join(parts))
+
+    # Structural stats (durability / wear) — same pattern as mining lasers.
+    comp_hp = _attr(root, "SHealthComponentParams", "Health")
+    if comp_hp is not None and comp_hp not in ("0", "0.0"):
+        lines.append(f"<EM4>Component HP:</EM4> {_fmt(comp_hp)}")
+    wear_max = _attr(root, "SWearAccumulatorParams", "MaxLifetimeHours")
+    if wear_max is not None and wear_max not in ("0", "0.0"):
+        lines.append(f"<EM4>Max Lifetime:</EM4> {_fmt(wear_max, 'h', 1)}")
+
+    return "\\n".join(lines) if lines else ""
+
+
 def _extract_mission_xp(root: ET.Element, reputation_lookup: dict[str, int] | None = None) -> int:
     """Extract mission success XP from primary reputation scope only.
 
@@ -3242,6 +3436,37 @@ def _run_gen_missiles(ctx: dict) -> dict[str, str]:
     return out
 
 
+def _ship_weapon_dispatch(root: ET.Element, vehicle_ammo: dict, loc: dict) -> str:
+    """Polymorphic dispatch for entities in ``ships/weapons/``.
+
+    The directory mixes combat weapons (cannons, repeaters, scatterguns)
+    with non-combat ship-mounted gear (mining lasers — and likely
+    tractor / salvage beams in the future). Pick the right extractor
+    based on a marker element present only on the specialised entity:
+
+      - SEntityComponentMiningLaserParams → mining laser → enhancements_mining_laser
+      - everything else                  → enhancements_weapon (combat)
+
+    Keeps the single-pass scan_entity_dir wiring intact while letting
+    each entity class get the stats most relevant to it.
+    """
+    if _find(root, "SEntityComponentMiningLaserParams") is not None:
+        return enhancements_mining_laser(root)
+    return enhancements_weapon(root, vehicle_ammo, loc)
+
+
+def _fps_weapon_dispatch(root: ET.Element, fps_ammo: dict, loc: dict, mag_lookup: dict) -> str:
+    """Polymorphic dispatch for entities in ``weapons/fps_weapons/``.
+
+    Same shape as ``_ship_weapon_dispatch``: handheld salvage tools
+    (Renovar XTR + multitool salvage mode) need a different extractor
+    than combat FPS weapons, but they live in the same directory.
+    """
+    if _find(root, "SWeaponActionFireSalvageRepairParams") is not None:
+        return enhancements_salvage_tool(root)
+    return enhancements_weapon(root, fps_ammo, loc, mag_lookup)
+
+
 def _run_gen_ship_weapons(ctx: dict) -> dict[str, str]:
     loc            = ctx["loc"]
     ships_scitem   = ctx["ships_scitem"]
@@ -3253,7 +3478,7 @@ def _run_gen_ship_weapons(ctx: dict) -> dict[str, str]:
     if weapons_dir.exists():
         out = scan_entity_dir(
             weapons_dir,
-            lambda root: enhancements_weapon(root, vehicle_ammo, loc),
+            lambda root: _ship_weapon_dispatch(root, vehicle_ammo, loc),
             loc=loc,
             xml_path_index=xml_path_index, records_dir=records,
         )
@@ -3272,7 +3497,7 @@ def _run_gen_fps_weapons(ctx: dict) -> dict[str, str]:
     if fps_dir.exists():
         out = scan_entity_dir(
             fps_dir,
-            lambda root: enhancements_weapon(root, fps_ammo, loc, mag_lookup),
+            lambda root: _fps_weapon_dispatch(root, fps_ammo, loc, mag_lookup),
             loc=loc,
             xml_path_index=xml_path_index, records_dir=records,
         )

--- a/tests/test_mining_salvage_stats.py
+++ b/tests/test_mining_salvage_stats.py
@@ -1,0 +1,321 @@
+"""Tests for ``enhancements_mining_laser`` and ``enhancements_salvage_tool``.
+
+These extractors pull stats from XML element shapes that already exist
+on every shipped mining-laser / handheld-salvage entity in the cache
+(Arbor, Lancet, Helix, Hofstede, Klein, Impact mining lasers under
+``ships/weapons/mining_laser_*.xml``; Renovar XTR + multitool salvage
+mode under ``weapons/fps_weapons/grin_*salvage_repair*.xml``). The
+tests fabricate minimal XMLs in tmp_path that hit each branch the
+function reads — so the suite doesn't require an extracted DataForge
+cache to be present on disk.
+
+Scope of v1 (also documented at the function level):
+  - Ship mining lasers: per-mode beam stats (Fracture / Extraction),
+    SEntityComponentMiningLaserParams modifier overlays, component
+    HP, distortion, signatures.
+  - Handheld salvage tools: per-mode (Repair / Salvage) repair-rate /
+    efficiency / ramp / energy / heat / wear, component HP, max lifetime.
+  - Excluded: globalParams UUID resolution (would surface base mining
+    laser power / range, not just modifiers — future enhancement);
+    ship-mounted salvage equipment (currently placeholder XMLs); mining
+    gadgets (attachable modifiers, low local-stat content).
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+from lxml import etree as ET
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture(scope="module")
+def gen_module():
+    repo_root = Path(__file__).resolve().parent.parent
+    script_path = repo_root / "scripts" / "generate_enhancements_ini.py"
+    spec = importlib.util.spec_from_file_location("generate_enhancements_ini_stats_test", script_path)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# ── Mining laser extractor ───────────────────────────────────────────────────
+
+class TestEnhancementsMiningLaser:
+    """Covers ``enhancements_mining_laser`` against fabricated entity
+    XMLs that exercise each output line independently."""
+
+    def _arbor_like_xml(self):
+        """Realistic-shape XML mirroring Arbor S1's stats layout —
+        two fire actions (Fracture + Extraction), a modifier block,
+        component HP, distortion. Returns the parsed root."""
+        xml = """<EntityClassDefinition>
+  <Components>
+    <SHealthComponentParams Health="8000"/>
+    <SDistortionParams Maximum="500000"/>
+    <SCItemWeaponComponentParams>
+      <fireActions>
+        <SWeaponActionFireBeamParams fullDamageRange="60" zeroDamageRange="180"
+                                     minEnergyDraw="0" maxEnergyDraw="0"
+                                     heatPerSecond="0" wearPerSecond="0">
+          <mannequinTag tag="laser"/>
+          <damagePerSecond>
+            <DamageInfo DamageEnergy="1890"/>
+          </damagePerSecond>
+        </SWeaponActionFireBeamParams>
+        <SWeaponActionFireBeamParams fullDamageRange="60" zeroDamageRange="180"
+                                     minEnergyDraw="0" maxEnergyDraw="0"
+                                     heatPerSecond="0" wearPerSecond="0">
+          <mannequinTag tag="tractor"/>
+          <damagePerSecond>
+            <DamageInfo DamageEnergy="1850"/>
+          </damagePerSecond>
+        </SWeaponActionFireBeamParams>
+      </fireActions>
+    </SCItemWeaponComponentParams>
+    <SEntityComponentMiningLaserParams>
+      <miningLaserModifiers>
+        <laserInstability>
+          <FloatModifierMultiplicative value="-35"/>
+        </laserInstability>
+        <optimalChargeWindowSizeModifier>
+          <FloatModifierMultiplicative value="40"/>
+        </optimalChargeWindowSizeModifier>
+        <resistanceModifier>
+          <FloatModifierMultiplicative value="25"/>
+        </resistanceModifier>
+      </miningLaserModifiers>
+      <filterParams>
+        <filterModifier>
+          <FloatModifierMultiplicative value="30"/>
+        </filterModifier>
+      </filterParams>
+    </SEntityComponentMiningLaserParams>
+  </Components>
+</EntityClassDefinition>"""
+        return ET.fromstring(xml)
+
+    def test_arbor_like_full_stats(self, gen_module):
+        """Realistic Arbor-shape input → all four sections present:
+        Fracture beam, Extraction beam, Modifiers, Component HP, Max Distortion."""
+        result = gen_module.enhancements_mining_laser(self._arbor_like_xml())
+        assert "Fracture:" in result
+        assert "DPS: 1,890" in result
+        assert "Extraction:" in result
+        assert "DPS: 1,850" in result
+        assert "Range: 60m" in result
+        assert "180m" in result
+        assert "Instability: -35%" in result
+        assert "Optimal Charge Window: +40%" in result
+        assert "Resistance: +25%" in result
+        assert "Inert Filter: +30%" in result
+        assert "Component HP:" in result and "8,000" in result
+        assert "Max Distortion:" in result and "500,000" in result
+
+    def test_modes_named_by_mannequin_tag(self, gen_module):
+        """Fire actions are labelled by mannequinTag — `laser` → Fracture,
+        `tractor` → Extraction. Unknown tags fall back to ``Beam {idx}``."""
+        xml = """<E><Components><SCItemWeaponComponentParams><fireActions>
+            <SWeaponActionFireBeamParams fullDamageRange="10" zeroDamageRange="20">
+              <mannequinTag tag="unknown_tag"/>
+              <damagePerSecond><DamageInfo DamageEnergy="42"/></damagePerSecond>
+            </SWeaponActionFireBeamParams>
+        </fireActions></SCItemWeaponComponentParams></Components></E>"""
+        result = gen_module.enhancements_mining_laser(ET.fromstring(xml))
+        assert "Beam 1:" in result, f"unknown tag should fall back to numbered beam: {result}"
+        assert "DPS: 42" in result
+
+    def test_skips_zero_only_fire_actions(self, gen_module):
+        """Template XMLs ship with all-zero stats. Skip them so the
+        output isn't littered with ``Beam N: `` empty lines."""
+        xml = """<E><Components><SCItemWeaponComponentParams><fireActions>
+            <SWeaponActionFireBeamParams fullDamageRange="0" zeroDamageRange="0"
+                                         minEnergyDraw="0" maxEnergyDraw="0"
+                                         heatPerSecond="0" wearPerSecond="0">
+              <mannequinTag tag="laser"/>
+              <damagePerSecond><DamageInfo DamageEnergy="0"/></damagePerSecond>
+            </SWeaponActionFireBeamParams>
+        </fireActions></SCItemWeaponComponentParams></Components></E>"""
+        result = gen_module.enhancements_mining_laser(ET.fromstring(xml))
+        assert "Fracture" not in result
+        assert "Beam" not in result
+
+    def test_skips_modifier_section_when_all_zero(self, gen_module):
+        """A mining-laser params block whose modifiers are all 0 → no
+        Modifiers: line in output. Filters out template / unmodified
+        base lasers that genuinely have no overlay to declare."""
+        xml = """<E><Components>
+          <SEntityComponentMiningLaserParams>
+            <miningLaserModifiers>
+              <laserInstability><FloatModifierMultiplicative value="0"/></laserInstability>
+            </miningLaserModifiers>
+          </SEntityComponentMiningLaserParams>
+        </Components></E>"""
+        result = gen_module.enhancements_mining_laser(ET.fromstring(xml))
+        assert "Modifiers:" not in result
+
+    def test_positive_modifier_gets_plus_sign(self, gen_module):
+        """Output reads ``+25%`` for positive modifiers and ``-35%`` for
+        negatives — the strict regex on the rendering side reads the sign."""
+        xml = """<E><Components><SEntityComponentMiningLaserParams><miningLaserModifiers>
+          <resistanceModifier><FloatModifierMultiplicative value="25"/></resistanceModifier>
+        </miningLaserModifiers></SEntityComponentMiningLaserParams></Components></E>"""
+        result = gen_module.enhancements_mining_laser(ET.fromstring(xml))
+        assert "Resistance: +25%" in result
+
+    def test_returns_empty_when_nothing_extractable(self, gen_module):
+        """Bare entity with no relevant params → empty string, NOT None
+        (so scan_entity_dir treats it as 'no enhancements' cleanly)."""
+        xml = "<EntityClassDefinition><Components/></EntityClassDefinition>"
+        assert gen_module.enhancements_mining_laser(ET.fromstring(xml)) == ""
+
+    def test_signatures_emitted_when_present(self, gen_module):
+        """Some mining lasers carry EMSignature / IRSignature — render
+        them in the same shape as the existing component extractors."""
+        xml = """<E><Components>
+          <EMSignature nominalSignature="120"/>
+          <IRSignature nominalSignature="80"/>
+        </Components></E>"""
+        result = gen_module.enhancements_mining_laser(ET.fromstring(xml))
+        assert "Signatures:" in result
+        assert "EM: 120" in result
+        assert "IR: 80" in result
+
+
+# ── Salvage tool extractor ───────────────────────────────────────────────────
+
+class TestEnhancementsSalvageTool:
+    """Covers ``enhancements_salvage_tool`` against fabricated XMLs
+    matching the Renovar / multitool-salvage shape."""
+
+    def _renovar_like_xml(self):
+        xml = """<EntityClassDefinition>
+  <Components>
+    <SHealthComponentParams Health="500"/>
+    <SCItemWeaponComponentParams>
+      <fireActions>
+        <SWeaponActionFireSalvageRepairParams salvageRepairMode="Repair"
+            materialEfficiency="1" maxHealthRepairRate="160" maxDamageMapRepairRate="10"
+            healthToAmmoRatio="0.1" rampUpTime="0.5" rampDownTime="0.1"
+            minEnergyDraw="0" maxEnergyDraw="0" heatPerSecond="0" wearPerSecond="0"/>
+        <SWeaponActionFireSalvageRepairParams salvageRepairMode="Salvage"
+            materialEfficiency="0.7" maxHealthRepairRate="670" maxDamageMapRepairRate="10"
+            healthToAmmoRatio="5.8" rampUpTime="4" rampDownTime="2"
+            minEnergyDraw="0" maxEnergyDraw="0" heatPerSecond="0" wearPerSecond="0"/>
+      </fireActions>
+    </SCItemWeaponComponentParams>
+  </Components>
+</EntityClassDefinition>"""
+        return ET.fromstring(xml)
+
+    def test_renovar_like_full_stats(self, gen_module):
+        result = gen_module.enhancements_salvage_tool(self._renovar_like_xml())
+        # Both modes labelled and present.
+        assert "Repair:" in result
+        assert "Salvage:" in result
+        # Repair mode stats (Renovar values).
+        assert "HP Rate: 160/s" in result
+        assert "Damage-Map Rate: 10/s" in result
+        # Salvage mode stats — note efficiency only emits when != 1.0.
+        assert "HP Rate: 670/s" in result
+        assert "Material Efficiency: 0.70" in result, (
+            f"non-unity efficiency should render: {result}"
+        )
+        assert "HP/Ammo: 5.80" in result
+        # Component HP.
+        assert "Component HP:" in result and "500" in result
+
+    def test_skips_efficiency_when_unity(self, gen_module):
+        """``materialEfficiency=1`` is the default no-op (Renovar's Repair
+        mode runs at 1.0). Don't emit a line for it — clutter."""
+        xml = """<E><Components><SCItemWeaponComponentParams><fireActions>
+          <SWeaponActionFireSalvageRepairParams salvageRepairMode="Repair"
+              materialEfficiency="1" maxHealthRepairRate="100"/>
+        </fireActions></SCItemWeaponComponentParams></Components></E>"""
+        result = gen_module.enhancements_salvage_tool(ET.fromstring(xml))
+        assert "Material Efficiency" not in result, (
+            f"unity efficiency should not render: {result}"
+        )
+        assert "HP Rate: 100/s" in result
+
+    def test_falls_back_to_name_attr_for_mode_label(self, gen_module):
+        """When salvageRepairMode isn't set, fall back to the ``name``
+        attribute (multitool / older entity shape)."""
+        xml = """<E><Components><SCItemWeaponComponentParams><fireActions>
+          <SWeaponActionFireSalvageRepairParams name="CustomMode" maxHealthRepairRate="50"/>
+        </fireActions></SCItemWeaponComponentParams></Components></E>"""
+        result = gen_module.enhancements_salvage_tool(ET.fromstring(xml))
+        assert "CustomMode:" in result
+
+    def test_emits_max_lifetime_when_set(self, gen_module):
+        xml = """<E><Components>
+          <SWearAccumulatorParams MaxLifetimeHours="120"/>
+        </Components></E>"""
+        result = gen_module.enhancements_salvage_tool(ET.fromstring(xml))
+        assert "Max Lifetime:" in result and "120" in result
+
+    def test_returns_empty_when_no_salvage_params(self, gen_module):
+        """No SWeaponActionFireSalvageRepairParams element → empty result
+        even if other component params are present. Dispatch will then
+        route through enhancements_weapon instead."""
+        xml = """<E><Components>
+          <SHealthComponentParams Health="100"/>
+        </Components></E>"""
+        # Health alone shouldn't trigger any output for a salvage tool —
+        # if there's no salvage params, this isn't a salvage tool.
+        # (The Component HP line still fires though, which is the only
+        # output. Either behavior is defensible; assert what we ship.)
+        result = gen_module.enhancements_salvage_tool(ET.fromstring(xml))
+        assert "Salvage:" not in result and "Repair:" not in result
+
+
+# ── Dispatch helpers ──────────────────────────────────────────────────────────
+
+class TestPolymorphicDispatch:
+    """The _ship_weapon_dispatch / _fps_weapon_dispatch helpers pick
+    the right extractor based on a marker element. Tests verify the
+    fallback to enhancements_weapon when the marker is absent."""
+
+    def test_ship_dispatch_routes_mining_laser_to_specialised(self, gen_module):
+        """SEntityComponentMiningLaserParams present → mining laser path."""
+        xml = """<E><Components>
+          <SHealthComponentParams Health="1000"/>
+          <SEntityComponentMiningLaserParams/>
+        </Components></E>"""
+        result = gen_module._ship_weapon_dispatch(ET.fromstring(xml), vehicle_ammo={}, loc={})
+        # Mining laser extractor emits Component HP in its EM4-tagged shape.
+        assert "<EM4>Component HP:</EM4>" in result
+
+    def test_ship_dispatch_routes_combat_weapon_to_default(self, gen_module):
+        """No mining-laser marker → enhancements_weapon path. We don't
+        validate enhancements_weapon's output shape here — just confirm
+        the dispatch didn't accidentally route to the mining extractor
+        (which would emit the EM4-tagged Component HP line)."""
+        xml = "<E><Components><SHealthComponentParams Health=\"1000\"/></Components></E>"
+        result = gen_module._ship_weapon_dispatch(ET.fromstring(xml), vehicle_ammo={}, loc={})
+        assert "<EM4>Component HP:</EM4>" not in result
+
+    def test_fps_dispatch_routes_salvage_tool_to_specialised(self, gen_module):
+        """SWeaponActionFireSalvageRepairParams present → salvage tool path."""
+        xml = """<E><Components><SCItemWeaponComponentParams><fireActions>
+          <SWeaponActionFireSalvageRepairParams salvageRepairMode="Salvage"
+              maxHealthRepairRate="100"/>
+        </fireActions></SCItemWeaponComponentParams></Components></E>"""
+        result = gen_module._fps_weapon_dispatch(
+            ET.fromstring(xml), fps_ammo={}, loc={}, mag_lookup={},
+        )
+        assert "Salvage:" in result and "HP Rate: 100/s" in result
+
+    def test_fps_dispatch_falls_back_to_default_weapon(self, gen_module):
+        """No salvage-tool marker → enhancements_weapon. Same shape
+        assertion as the ship_dispatch fallback."""
+        xml = "<E><Components/></E>"
+        result = gen_module._fps_weapon_dispatch(
+            ET.fromstring(xml), fps_ammo={}, loc={}, mag_lookup={},
+        )
+        # Default enhancements_weapon on a bare XML returns empty string.
+        assert "Salvage:" not in result and "Repair:" not in result


### PR DESCRIPTION
## Summary

Adds two new XML extractors so ship mining lasers and handheld salvage tools get the same kind of appended stats block that shields / coolers / power plants / quantum drives / radars already get. CIG's stock descriptions on these items either omit stats entirely (handheld salvage — Renovar XTR and multitool salvage mode have *no* stats in their CIG-authored loc text) or routinely drift after balance passes (ship mining lasers — description text doesn't always match what the XML actually says after a re-tune). Append-always is the explicit user-requested behavior.

## Two new extractors

**`enhancements_mining_laser(root)`** — covers ship-mounted mining lasers under `entities/scitem/ships/weapons/mining_laser_*.xml` (Arbor, Lancet, Helix, Hofstede, Klein, Impact). Output sections:
- **Per-mode beam stats**: DPS, range, energy draw, heat, wear — labelled by `mannequinTag` (`laser` → Fracture, `tractor` → Extraction). Skips template / zeroed entities cleanly.
- **Modifier overlay**: `laserInstability`, `optimalChargeWindowSizeModifier`, `resistanceModifier`, `filterModifier` from `SEntityComponentMiningLaserParams`. These technically duplicate what CIG's description prints today — but the whole point of the append-always behavior is to re-emit them from XML so a balance pass that updates the XML but not the description still surfaces.
- **Structural**: component HP, max distortion, EM / IR signatures when present.

Smoke-tested against the live cache. Sample output for `mining_laser_grin_arbor_s1.xml`:
```
<EM4>Fracture:</EM4>  DPS: 1,890  |  Range: 60m→180m
<EM4>Extraction:</EM4>  DPS: 1,850  |  Range: 60m→180m
<EM4>Modifiers:</EM4>  Instability: -35%  |  Optimal Charge Window: +40%  |  Resistance: +25%  |  Inert Filter: +30%
<EM4>Component HP:</EM4> 8,000
<EM4>Max Distortion:</EM4> 500,000
```

**`enhancements_salvage_tool(root)`** — covers handheld salvage tools under `weapons/fps_weapons/grin_salvage_*.xml` (Renovar XTR + multitool salvage mode). Output sections:
- **Per-mode (Repair / Salvage)**: `maxHealthRepairRate`, `maxDamageMapRepairRate`, `materialEfficiency` (skipped when 1.0 since that's the no-op default), `healthToAmmoRatio`, ramp-up / ramp-down times, plus energy/heat/wear when non-zero.
- **Structural**: component HP, max lifetime hours.

Sample output for `grin_salvage_repair_01.xml` (Renovar XTR):
```
<EM4>Repair:</EM4>  HP Rate: 160/s  |  Damage-Map Rate: 10/s  |  HP/Ammo: 0.10  |  Ramp: 0.5s↑ 0.1s↓
<EM4>Salvage:</EM4>  HP Rate: 670/s  |  Damage-Map Rate: 10/s  |  Material Efficiency: 0.70  |  HP/Ammo: 5.80  |  Ramp: 4.0s↑ 2.0s↓
```

## Pipeline wiring

Uses polymorphic dispatch instead of a separate top-level `_run_gen_*` function — the mining lasers and handheld salvage tools physically live in `ships/weapons/` and `weapons/fps_weapons/` alongside combat weapons, so two small helpers (`_ship_weapon_dispatch` / `_fps_weapon_dispatch`) pick the right extractor per entity:
- `SEntityComponentMiningLaserParams` present → `enhancements_mining_laser`
- `SWeaponActionFireSalvageRepairParams` present → `enhancements_salvage_tool`
- Anything else → existing `enhancements_weapon` (combat weapons), unchanged

This keeps the single-pass `scan_entity_dir` wiring intact while letting each entity class get the stats most relevant to it.

## Scope explicitly excluded from v1

Documented in function docstrings:
- **`globalParams` UUID resolution**. Ship mining lasers reference their base mining-laser-power / range values via a `globalParams` UUID on `SEntityComponentMiningLaserParams`. We only extract the local modifier overlays. CIG's description text carries the base values today, so the gap is cosmetic. Worth doing in v2 if CIG starts forgetting to keep the base values in sync too.
- **Ship-mounted salvage equipment** under `entities/scitem/ships/salvagemunching/` — every XML in that directory is currently a `Name="@LOC_PLACEHOLDER"` stub with no real stats. No point extracting nothing; revisit when CIG fleshes them out.
- **Mining gadgets** under `entities/scitem/weapons/devices/mining_gadget_*.xml` (Boremax, Stalwart, Optimax, Waveshift, Okunis, Sabir). These are `SEntityComponentAttachableModifierParams` attachments rather than standalone weapons — their stats are modifier-only and live in a different param tree.

## Test plan

- [x] `pytest tests/test_mining_salvage_stats.py -v` — 16/16 pass (extractor behavior on realistic XMLs, skip-empty edge cases, mode-labelling fallbacks, dispatch helpers)
- [x] `pytest tests/` — 329 passed / 15 skipped / 4 pre-existing unrelated failures (the `TestDataForgeCache` str/Path bug, same as on `release/1.4.0` before this branch)
- [x] Smoke-tested against live DataForge cache (`Documents/Smart Citizen/LIVE/cache/dataforge/raw/.../scitem/...`) — Arbor S1, Helix S0, Renovar XTR, multitool salvage mode all produce clean differentiated output
- [ ] User to re-extract DataForge in-app and verify the augmented `components_desc_enhancements.ini` and `fps_weapons_desc_enhancements.ini` outputs look right in-game

## Stacks on top of

Logically independent of `fix/mission-multi-source-blueprints` (#38) — branches off the same `release/1.4.0` base and touches only the components-stats / weapons-extractor side of `generate_enhancements_ini.py`. Either PR can merge first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)