### PR TITLE
Add "Reset user.ini" Tools button with confirmation + auto-backup

### DIFF
--- a/src/gui/config_tab.py
+++ b/src/gui/config_tab.py
@@ -22,6 +22,10 @@ class ConfigTab(QWidget):
     merge_requested = pyqtSignal()
     p4k_extract_requested = pyqtSignal()
     import_ini_requested = pyqtSignal()
+    # Emitted when the user clicks the "Reset user.ini" Tools button.
+    # MainWindow runs the confirmation dialog and the actual file work so
+    # this tab stays decoupled from filesystem state + reload orchestration.
+    reset_user_ini_requested = pyqtSignal()
     # Emitted after the user picks a new channel in the combo AND the choice
     # has already been persisted via AppSettings.set_active_channel(). Main
     # window listens and triggers a reload against the new channel's data.
@@ -234,6 +238,15 @@ class ConfigTab(QWidget):
         import_btn.setMaximumWidth(150)
         import_btn.clicked.connect(self.import_ini_requested.emit)
         button_layout.addWidget(import_btn)
+
+        reset_user_ini_btn = QPushButton("Reset user.ini...")
+        reset_user_ini_btn.setMaximumWidth(150)
+        reset_user_ini_btn.setToolTip(
+            "Delete every custom string override for the active channel. "
+            "A timestamped backup is saved next to the original so you can restore it."
+        )
+        reset_user_ini_btn.clicked.connect(self.reset_user_ini_requested.emit)
+        button_layout.addWidget(reset_user_ini_btn)
 
         preview_btn = QPushButton("Preview Apply")
         preview_btn.setMaximumWidth(150)

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -377,6 +377,7 @@ class MainWindow(QMainWindow):
         self.config_tab.merge_requested.connect(self.perform_merge_and_reload)
         self.config_tab.p4k_extract_requested.connect(self._run_p4k_extraction)
         self.config_tab.import_ini_requested.connect(self._handle_import_ini)
+        self.config_tab.reset_user_ini_requested.connect(self._handle_reset_user_ini)
         self.config_tab.channel_changed.connect(self._on_channel_changed)
         self.config_tab.check_updates_requested.connect(self._on_check_updates_clicked)
         self.config_tab.data_dir_changed.connect(self._on_data_dir_changed)
@@ -1600,6 +1601,101 @@ class MainWindow(QMainWindow):
         if hasattr(self, "help_browser"):
             self._render_help_html()
         self._apply_editor_dock_canvas_tint()
+
+    def _handle_reset_user_ini(self):
+        """Confirm + delete the active channel's user.ini, preserving a backup.
+
+        Flow:
+          1. Resolve the channel-scoped user.ini path. If absent, surface
+             "nothing to reset" and return.
+          2. Show a destructive-action confirmation dialog (default = No)
+             listing the path, file size, and what the backup will be named.
+          3. Rename user.ini → user.ini.bak-YYYYMMDD-HHMMSS via
+             user_ini_manager.reset_user_ini. On OSError (locked file,
+             permissions), surface the error and bail without changing
+             in-memory state.
+          4. Clear ``custom_value`` on every in-memory entry so the
+             close-time autosave guard doesn't see them as modifications
+             and re-write the file we just removed. The async reload that
+             follows replaces self.entries wholesale, but the window
+             between delete and reload completion is a real one where
+             closeEvent could fire and undo the reset.
+          5. Kick off a full FileLoaderWorker reload via
+             _show_loading_progress so the table reflects stock values
+             with the user-override layer gone.
+        """
+        from src.utils.user_ini_manager import reset_user_ini
+
+        user_ini_path = AppSettings.get_user_ini_path()
+        channel = AppSettings.get_active_channel()
+
+        if not user_ini_path.exists():
+            QMessageBox.information(
+                self,
+                "Nothing to Reset",
+                f"There is no user.ini for the {channel} channel — already at "
+                f"stock values.\n\nPath checked:\n{user_ini_path}",
+            )
+            return
+
+        try:
+            size_kb = user_ini_path.stat().st_size / 1024
+            size_str = f"{size_kb:.1f} KB"
+        except OSError:
+            size_str = "unknown size"
+
+        reply = QMessageBox.warning(
+            self,
+            "Reset user.ini?",
+            f"This will remove every custom string override for the "
+            f"{channel} channel.\n\n"
+            f"File: {user_ini_path}\n"
+            f"Size: {size_str}\n\n"
+            f"A timestamped backup will be saved next to the original "
+            f"(user.ini.bak-YYYYMMDD-HHMMSS) so you can restore by renaming it "
+            f"back to user.ini.\n\n"
+            f"This does NOT touch the game's global.ini — to revert what "
+            f"the game sees in-game, run Apply to Game after the reset, or "
+            f"use Restore Backup.\n\n"
+            f"Proceed?",
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+            QMessageBox.StandardButton.No,
+        )
+        if reply != QMessageBox.StandardButton.Yes:
+            return
+
+        try:
+            backup_path = reset_user_ini(user_ini_path, backup=True)
+        except OSError as e:
+            logger.exception(f"Failed to reset user.ini at {user_ini_path}")
+            QMessageBox.critical(
+                self,
+                "Reset Failed",
+                f"Could not reset user.ini:\n\n{e}\n\n"
+                f"The file is still in place. Close any other application that "
+                f"might have it open (text editor, sync client) and try again.",
+            )
+            return
+
+        # In-memory wipe before the async reload — see step 4 docstring.
+        for entry in self.entries:
+            if entry.custom_value:
+                entry.custom_value = ""
+
+        self._show_loading_progress(
+            f"Reloading {channel} after user.ini reset..."
+        )
+
+        backup_note = f"\n\nBackup saved to:\n{backup_path}" if backup_path else ""
+        self.statusBar().showMessage(
+            f"user.ini reset for {channel} (backup created)", 5000
+        )
+        QMessageBox.information(
+            self,
+            "user.ini Reset",
+            f"All custom overrides for the {channel} channel have been "
+            f"cleared.{backup_note}",
+        )
 
     def _handle_import_ini(self):
         """Handle Import INI button: get source, validate, resolve conflicts, merge."""

--- a/src/utils/user_ini_manager.py
+++ b/src/utils/user_ini_manager.py
@@ -1,13 +1,52 @@
 """User INI persistence and import utilities."""
 import logging
+from datetime import datetime
 from pathlib import Path
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 from src.models.string_model import StringEntry
 from src.parser.ini_parser import parse_ini_file
 from src.utils.perf import timed
 
 logger = logging.getLogger(__name__)
+
+
+def reset_user_ini(user_ini_path: Path, backup: bool = True) -> Optional[Path]:
+    """Remove ``user.ini`` for the active channel, optionally renaming it to a
+    timestamped backup first.
+
+    Used by the "Reset user.ini" tools-tab button. Returns the backup path
+    when ``backup=True`` and a rename happened, otherwise ``None``.
+
+    If the file doesn't exist, returns ``None`` — caller should treat that
+    as a no-op (e.g. surface "already at stock values").
+
+    Backup naming: ``user.ini.bak-YYYYMMDD-HHMMSS`` next to the original. If
+    the timestamped target somehow already exists (double-click producing
+    two resets inside one second), a numeric suffix ``-2`` / ``-3`` / … is
+    appended until a free name is found, so the second click can never
+    silently destroy the first backup.
+    """
+    if not user_ini_path.exists():
+        return None
+
+    if not backup:
+        user_ini_path.unlink()
+        logger.info(f"Deleted user.ini (no backup) at {user_ini_path}")
+        return None
+
+    timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    candidate = user_ini_path.with_name(f"{user_ini_path.name}.bak-{timestamp}")
+    suffix = 2
+    while candidate.exists():
+        candidate = user_ini_path.with_name(
+            f"{user_ini_path.name}.bak-{timestamp}-{suffix}"
+        )
+        suffix += 1
+
+    user_ini_path.rename(candidate)
+    logger.info(f"Reset user.ini: {user_ini_path} → backup {candidate}")
+    return candidate
 
 
 def should_autosave_user_ini(entries: List[StringEntry], user_ini_path: Path) -> bool:

--- a/tests/test_user_ini_reset.py
+++ b/tests/test_user_ini_reset.py
@@ -1,0 +1,99 @@
+"""Tests for :func:`src.utils.user_ini_manager.reset_user_ini`.
+
+Locks the contract used by the Config tab's "Reset user.ini" button:
+  * Returns the backup path on success and leaves the original gone.
+  * Returns ``None`` when the source file doesn't exist (caller treats
+    that as a no-op).
+  * ``backup=False`` deletes outright and still returns ``None``.
+  * Backup naming guards against same-second double invocations — the
+    second call must NOT silently overwrite the first backup, even if
+    both calls land inside the same wall-clock second (which produces
+    the same ``YYYYMMDD-HHMMSS`` stamp).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from src.utils.user_ini_manager import reset_user_ini
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+class TestResetUserIni:
+    def test_returns_none_when_source_absent(self, tmp_path: Path):
+        missing = tmp_path / "user.ini"
+        assert reset_user_ini(missing, backup=True) is None
+        assert not missing.exists()
+
+    def test_backup_true_renames_to_timestamped_sibling(self, tmp_path: Path):
+        src = tmp_path / "user.ini"
+        _write(src, "some_key=Custom Value\nother_key=Another\n")
+
+        backup = reset_user_ini(src, backup=True)
+
+        assert backup is not None
+        assert backup.exists()
+        assert backup.parent == src.parent
+        assert backup.name.startswith("user.ini.bak-")
+        # Backup must preserve content byte-for-byte.
+        assert backup.read_text(encoding="utf-8") == \
+            "some_key=Custom Value\nother_key=Another\n"
+        # Original must be gone.
+        assert not src.exists()
+
+    def test_backup_false_deletes_outright(self, tmp_path: Path):
+        src = tmp_path / "user.ini"
+        _write(src, "key=value\n")
+
+        result = reset_user_ini(src, backup=False)
+
+        assert result is None
+        assert not src.exists()
+        # No sibling backup file was created.
+        assert list(tmp_path.iterdir()) == []
+
+    def test_double_call_same_second_does_not_clobber_first_backup(
+        self, tmp_path: Path, monkeypatch
+    ):
+        """Two resets producing the same YYYYMMDD-HHMMSS stamp must coexist.
+
+        Real-world trigger: user double-clicks the button, restores from
+        backup, hits reset again — and a fast machine can land both
+        invocations inside one wall-clock second. The function must add
+        a numeric suffix instead of overwriting the first backup.
+
+        We monkey-patch :func:`datetime.now` inside the module so both
+        calls observe the same timestamp deterministically (the real
+        clock would race the test).
+        """
+        from datetime import datetime
+        import src.utils.user_ini_manager as mod
+
+        class _FrozenClock:
+            @classmethod
+            def now(cls):
+                return datetime(2026, 5, 17, 12, 34, 56)
+
+        monkeypatch.setattr(mod, "datetime", _FrozenClock)
+
+        first_src = tmp_path / "user.ini"
+        _write(first_src, "first=alpha\n")
+        first_backup = reset_user_ini(first_src, backup=True)
+
+        # Recreate user.ini for the second invocation (simulates the user
+        # re-introducing overrides between the two resets).
+        _write(first_src, "second=beta\n")
+        second_backup = reset_user_ini(first_src, backup=True)
+
+        assert first_backup is not None and second_backup is not None
+        assert first_backup != second_backup
+        assert first_backup.exists() and second_backup.exists()
+        # Distinct contents — second call did not overwrite the first.
+        assert first_backup.read_text(encoding="utf-8") == "first=alpha\n"
+        assert second_backup.read_text(encoding="utf-8") == "second=beta\n"
+        # Naming: first is the bare timestamp, second carries a suffix.
+        assert first_backup.name == "user.ini.bak-20260517-123456"
+        assert second_backup.name == "user.ini.bak-20260517-123456-2"


### PR DESCRIPTION
## Summary

- New Config-tab Tools button that wipes the active channel's `user.ini` in one click after a destructive-action confirmation dialog.
- Auto-backup before delete: `user.ini` → `user.ini.bak-YYYYMMDD-HHMMSS` next to the original. Same-second double-invocation gets a `-2` / `-3` / … numeric suffix so a second click can never silently destroy the first backup.
- Closes a real race: in-memory `custom_value` is cleared before the async reload so a window-close between rename and FileLoaderWorker completion can't fire the close-time autosave and re-write the user.ini we just removed.

## Files

- `src/utils/user_ini_manager.py` — new `reset_user_ini(path, backup=True)` pure-Python helper.
- `src/gui/config_tab.py` — new `reset_user_ini_requested` signal + Tools-group button, mirroring the existing `import_ini_requested` decoupling pattern (tab stays free of filesystem state).
- `src/gui/main_window.py` — new `_handle_reset_user_ini` handler with "nothing to reset" short-circuit, default-No confirmation dialog listing path + size + backup naming, `OSError` surfacing on locked files, in-memory wipe + `_show_loading_progress` reload.
- `tests/test_user_ini_reset.py` — 4 tests covering missing source, backup-true, backup-false, and the same-second collision path (with `datetime.now()` monkey-patched to a fixed value).

## Test plan

- [ ] `pytest tests/test_user_ini_reset.py -v` passes (verified locally — 4/4 green).
- [ ] Full `pytest tests/` still green.
- [ ] Manual GUI smoke (per `CLAUDE.md` — workers have no automated tests):
  - [ ] With a populated `user.ini`: confirm dialog shows path + size; accept; verify table refreshes to stock values; verify `user.ini.bak-*` exists in the same folder; original is gone.
  - [ ] With no `user.ini`: "Nothing to Reset" info dialog shows instead of confirmation.
  - [ ] Click `No` on confirmation: nothing happens, `user.ini` untouched.
  - [ ] Close the window during the async reload (between rename and reload completion): verify the file stays gone (close-time autosave does not re-write it).
  - [ ] Double-click the button rapidly: second invocation either short-circuits via "Nothing to Reset" (file already moved) or produces a second backup with a `-2` suffix — neither path destroys the first backup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)