### PR TITLE
gui: add tooltips to interactive widgets that were missing them

### DIFF
--- a/src/gui/config_tab.py
+++ b/src/gui/config_tab.py
@@ -114,6 +114,7 @@ class ConfigTab(QWidget):
 
         game_browse_btn = QPushButton("Browse...")
         game_browse_btn.setMaximumWidth(100)
+        game_browse_btn.setToolTip("Pick the Star Citizen install root in a folder browser.")
         game_browse_btn.clicked.connect(self._browse_game_path)
         game_input_layout.addWidget(game_browse_btn)
         game_layout.addLayout(game_input_layout)
@@ -173,6 +174,7 @@ class ConfigTab(QWidget):
 
         data_browse_btn = QPushButton("Browse...")
         data_browse_btn.setMaximumWidth(100)
+        data_browse_btn.setToolTip("Pick the Smart Citizen data folder in a folder browser.")
         data_browse_btn.clicked.connect(self._browse_data_dir)
         data_input_layout.addWidget(data_browse_btn)
 
@@ -211,6 +213,11 @@ class ConfigTab(QWidget):
 
         self._extract_btn = QPushButton("Extract from Data.p4k")
         self._extract_btn.setMaximumWidth(180)
+        self._extract_btn.setToolTip(
+            "Unpack stock localization (base.ini) plus the DataForge entity XMLs "
+            "from your installed Data.p4k. Run after every Star Citizen patch — "
+            "the strings reload into the table automatically when extraction finishes."
+        )
         self._extract_btn.clicked.connect(self.p4k_extract_requested.emit)
         p4k_status_row.addWidget(self._extract_btn)
 
@@ -236,6 +243,11 @@ class ConfigTab(QWidget):
 
         import_btn = QPushButton("Import INI...")
         import_btn.setMaximumWidth(150)
+        import_btn.setToolTip(
+            "Fold an external .ini into your overrides. A conflict-resolution "
+            "dialog lets you decide per key: keep current, use imported, append, "
+            "prepend, or provide a custom value."
+        )
         import_btn.clicked.connect(self.import_ini_requested.emit)
         button_layout.addWidget(import_btn)
 
@@ -250,6 +262,12 @@ class ConfigTab(QWidget):
 
         preview_btn = QPushButton("Preview Apply")
         preview_btn.setMaximumWidth(150)
+        preview_btn.setToolTip(
+            "Dry-run summary of what Apply to Game would write — per-source key "
+            "counts (with Enhancements broken down by category) and a "
+            "Modified / Enhanced / Unmodified / New status tally. Nothing is "
+            "written to the game until you click Apply to Game."
+        )
         preview_btn.clicked.connect(self.preview_merge)
         button_layout.addWidget(preview_btn)
 

--- a/src/gui/import_dialog.py
+++ b/src/gui/import_dialog.py
@@ -59,10 +59,12 @@ class ImportConflictDialog(QDialog):
         # Bulk action buttons
         button_row = QHBoxLayout()
         keep_all_btn = QPushButton("Keep All Current")
+        keep_all_btn.setToolTip("Resolve every conflict by keeping your existing value and discarding the imported one.")
         keep_all_btn.clicked.connect(self._keep_all)
         button_row.addWidget(keep_all_btn)
 
         import_all_btn = QPushButton("Import All")
+        import_all_btn.setToolTip("Resolve every conflict by accepting the imported value and overwriting your existing one.")
         import_all_btn.clicked.connect(self._import_all)
         button_row.addWidget(import_all_btn)
 

--- a/src/gui/log_tab.py
+++ b/src/gui/log_tab.py
@@ -106,11 +106,13 @@ class LogTab(QWidget):
 
         clear_btn = QPushButton("Clear")
         clear_btn.setMaximumWidth(70)
+        clear_btn.setToolTip("Clear the on-screen log buffer. The session log file on disk is unaffected.")
         clear_btn.clicked.connect(self._clear)
         toolbar.addWidget(clear_btn)
 
         export_btn = QPushButton("Export to file…")
         export_btn.setMaximumWidth(130)
+        export_btn.setToolTip("Save the current log buffer to a .log file — useful when filing a bug report.")
         export_btn.clicked.connect(self._export)
         toolbar.addWidget(export_btn)
 

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -1843,6 +1843,7 @@ class MainWindow(QMainWindow):
         input_row.addWidget(line_edit)
 
         browse_btn = QPushButton("Browse...")
+        browse_btn.setToolTip("Pick a local .ini file to import.")
         def browse():
             path, _ = QFileDialog.getOpenFileName(
                 dialog, "Select INI File", "", "INI Files (*.ini);;All Files (*)")
@@ -2931,7 +2932,9 @@ class MainWindow(QMainWindow):
         button_row = QHBoxLayout()
         generate_btn = QPushButton("Generate")
         generate_btn.setDefault(True)
+        generate_btn.setToolTip("Run the DataForge extraction + enhancements pipeline now. Takes a few minutes the first time.")
         skip_btn = QPushButton("Skip")
+        skip_btn.setToolTip("Continue without generating enhancements. You can run it later from the Enhancements tab.")
 
         generate_btn.clicked.connect(dialog.accept)
         skip_btn.clicked.connect(dialog.reject)

--- a/src/gui/tag_mapping_dialog.py
+++ b/src/gui/tag_mapping_dialog.py
@@ -71,6 +71,7 @@ class TagMappingDialog(QDialog):
 
         button_row = QHBoxLayout()
         reset_btn = QPushButton("Reset to defaults")
+        reset_btn.setToolTip("Restore every cell in this mapping table to the built-in Smart Citizen defaults.")
         reset_btn.clicked.connect(self._reset_to_defaults)
         button_row.addWidget(reset_btn)
         button_row.addStretch()


### PR DESCRIPTION
## Summary
User report: the **Preview Apply** button has no tooltip. Audited the rest of `src/gui/` for the same problem and filled 13 tooltip gaps total.

Coach-mark Skip / Back / Next buttons were intentionally left alone — the tutorial overlay is itself contextual help; tooltips on those buttons would be redundant and weird.

### Widgets that got tooltips

**Config tab** (`src/gui/config_tab.py`)
- Browse… (Star Citizen install path)
- Browse… (Smart Citizen data folder)
- Extract from Data.p4k
- Import INI…
- **Preview Apply** ← user-reported

**Log tab** (`src/gui/log_tab.py`)
- Clear
- Export to file…

**Import-conflict dialog** (`src/gui/import_dialog.py`)
- Keep All Current
- Import All

**Tag-mapping dialog** (`src/gui/tag_mapping_dialog.py`)
- Reset to defaults

**Main window — INI import sub-dialog** (`src/gui/main_window.py`)
- Browse…

**Main window — DataForge startup prompt** (`src/gui/main_window.py`)
- Generate
- Skip

### Already-tooltipped widgets (sample, ~40 in total)
All of these were verified to already have tooltips: Apply to Game, Restore Backup, Clear Localization, Clear Cache, Export Loc-Pack, Editor, Help, Tutorial, every Enhancements-tab combo, the Tag Builder up/down/enable controls, Status / Category filters, Hide Unmodified / Favorites Only, Grouped Sort, Clear Filters, Copy Filtered, Reset user.ini, Check for Updates, theme/channel combos, EM3/EM4 emphasis buttons, the Osiris logo button, the per-column filter row editors, etc.

## Test plan
- [ ] Hover **Preview Apply** in the Config tab → tooltip describes the dry-run output (key counts + status tally).
- [ ] Hover both **Browse…** buttons in the Config tab → distinct tooltips for install path vs data folder.
- [ ] Hover **Extract from Data.p4k** and **Import INI…** → tooltips describe the action and when to use it.
- [ ] Open Log tab → Clear and Export to file… tooltips render.
- [ ] Trigger Import INI → Keep All Current / Import All / Browse… tooltips render.
- [ ] Open a Tag Builder mapping dialog → Reset to defaults tooltip renders.
- [ ] First-launch DataForge prompt → Generate / Skip tooltips render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)