### PR TITLE
fix(deps): bump lxml to >=6.1.0 for CVE-2026-41066 XXE fix

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,7 +4,7 @@
 PyQt6>=6.10.0
 PyInstaller>=6.3.0
 pyperclip>=1.8.2
-lxml>=5.0
+lxml>=6.1.0
 
 # Testing
 pytest>=7.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 PyQt6>=6.10.0
-lxml>=5.0
+lxml>=6.1.0
 pyinstaller>=6.3.0
 pyperclip>=1.8.2


### PR DESCRIPTION
## Summary

Bumps the lxml minimum version from >=5.0 to >=6.1.0 to address CVE-2026-41066, an XXE (XML External Entity) vulnerability.

## CVE Details

- CVE-2026-41066 — Improper Restriction of XML External Entity Reference (CWE-611)
- Severity: CVSS 3.1 7.5 HIGH
- Affected: lxml < 6.1.0
- Fixed in: lxml 6.1.0
- Description: Default resolve_entities=True in iterparse() and ETCompatXMLParser() allows reading local files via XXE

## Changes

| File | Change |
|------|--------|
| requirements.txt | lxml>=5.0 -> lxml>=6.1.0 |
| requirements-dev.txt | lxml>=5.0 -> lxml>=6.1.0 |

## References

- NVD - CVE-2026-41066: https://nvd.nist.gov/vuln/detail/CVE-2026-41066
- GitHub Advisory - GHSA-vfmq-68hx-4jfw: https://github.com/lxml/lxml/security/advisories/GHSA-vfmq-68hx-4jfw