### PR TITLE
fix: remove non-rendering EM1/EM2 emphasis tag options (#99)

### DIFF
--- a/src/gui/enhancements_tab.py
+++ b/src/gui/enhancements_tab.py
@@ -319,7 +319,7 @@ class EnhancementsTab(QWidget):
 
         grid.addWidget(QLabel("Header tag:"), 1, 4)
         self._header_em_combo = QComboBox()
-        for tag in ("EM1", "EM2", "EM3", "EM4"):
+        for tag in AppSettings.MISSION_HEADER_EM_TAGS:
             self._header_em_combo.addItem(tag, userData=tag)
         current_em = AppSettings.get_mission_header_em_tag()
         for i in range(self._header_em_combo.count()):

--- a/src/utils/settings.py
+++ b/src/utils/settings.py
@@ -34,6 +34,9 @@ class AppSettings:
     # Mission label defaults — source of truth for fallback values
     DEFAULT_REP_XP_LABEL = "Rep"
     DEFAULT_MISSION_HEADER_EM_TAG = "EM3"
+    # Selectable emphasis tags. EM1/EM2 were removed in 1.5.0 — they never
+    # render in-game (only EM3 = underline and EM4 = color do). See issue #99.
+    MISSION_HEADER_EM_TAGS = ("EM3", "EM4")
     MISSION_HEADER_DEFAULTS = {
         "details": "MISSION DETAILS",
         "blueprints": "POTENTIAL BLUEPRINTS",
@@ -289,7 +292,14 @@ class AppSettings:
 
     @staticmethod
     def get_mission_header_em_tag() -> str:
-        return AppSettings.settings().value(AppSettings.MISSION_HEADER_EM_TAG, AppSettings.DEFAULT_MISSION_HEADER_EM_TAG)
+        tag = AppSettings.settings().value(
+            AppSettings.MISSION_HEADER_EM_TAG, AppSettings.DEFAULT_MISSION_HEADER_EM_TAG
+        )
+        # Coerce a stored EM1/EM2 (removed in 1.5.0; never rendered in-game)
+        # back to the default so generated output never carries a dead tag.
+        if tag not in AppSettings.MISSION_HEADER_EM_TAGS:
+            return AppSettings.DEFAULT_MISSION_HEADER_EM_TAG
+        return tag
 
     @staticmethod
     def set_mission_header_em_tag(tag: str) -> None:

--- a/tests/fixtures/collection_items_groundtruth.txt
+++ b/tests/fixtures/collection_items_groundtruth.txt
@@ -1,0 +1,84 @@
+# Ground-truth fixture for the [Collection] item tagging feature (issue #97).
+#
+# Captured by hand by the maintainer from a LIVE global.ini export (May 2026,
+# ~1.4.2 era). These are the items that appear as objectives in Collection
+# missions and should receive the Collection flag in their display name.
+#
+# Purpose: validate the 1.5.0 generator that auto-discovers Collection-mission
+# items from DataForge. The generated output should flag (at least) every key
+# below. This file encodes the DURABLE part (which items qualify, and whether
+# each is also a crafting material), not a pinned rendered string, because the
+# rendered tag depends on user Tag Builder config.
+#
+# Rendering (the "Commodity Tagging" Tag Builder category, default config):
+#   - collection only          ->  <Name> <EM4>[Collection]</EM4>
+#   - crafting + collection     ->  <Name> <EM4>[CF|Collection]</EM4>
+#   - crafting only (NOT below) ->  <Name> <EM4>[CF]</EM4>   (unchanged today)
+# Collection flag forms (short/medium/long, default long):
+#   Col / Collect / Collection
+# Defaults: flag order CF|Collection, separator "|", emphasis EM4.
+#
+# Key namespaces: Mission_Item_*, items_commodities_*, harvestable_*. The same
+# physical item often has more than one key (e.g. Mission_Item_0183 and
+# items_commodities_decaripod are both "Decari Pod"); the tagger must cover all.
+#
+# Format (pipe-delimited):  key | base_name | also_crafting(yes/no)
+# 57 entries; 8 are also crafting materials (also_crafting=yes).
+
+Mission_Item_0183 | Decari Pod | no
+Mission_Item_0184 | Degnous Root | no
+Mission_Item_0186 | Golden Medmon | no
+Mission_Item_0191 | Pitambu | no
+Mission_Item_0192 | Prota | no
+Mission_Item_0195 | Sunset Berry | no
+Mission_Item_0214 | Compboard | no
+harvestable_Armillaria | Bluemoon Fungus | no
+items_commodities_amiantpod | Amiant Pod | no
+items_commodities_amioshiplague | Amioshi Plague | no
+items_commodities_beradom | Beradom | yes
+items_commodities_carinite | Carinite | yes
+items_commodities_carinite_pure | Carinite (Pure) | yes
+items_commodities_carinite_raw | Carinite (Raw) | no
+items_commodities_compboard | Compboard | no
+items_commodities_decaripod | Decari Pod | no
+items_commodities_degnousroot | Degnous Root | no
+items_commodities_dopple | Dopple | no
+items_commodities_feynmaline | Feynmaline | yes
+items_commodities_flareweedstalk | Flareweed Stalk | no
+items_commodities_fotiascrub | Fotia Seedpod | no
+items_commodities_freeze | Freeze | no
+items_commodities_glacosite | Glacosite | yes
+items_commodities_glow | Glow | no
+items_commodities_goldenmedmon | Golden Medmon | yes
+items_commodities_heartofthewoods | Heart of the Woods | no
+items_commodities_jaclium | Jaclium | no
+items_commodities_jaclium_ore | Jaclium (Ore) | no
+items_commodities_janalite | Janalite | yes
+items_commodities_kopionhorn_irradiated | Irradiated Kopion Horn | no
+items_commodities_mala | Mala | no
+items_commodities_marokgem | Marok Gem | no
+items_commodities_pingala | Pingala Seeds | no
+items_commodities_pitambu | Pitambu | no
+items_commodities_prota | Prota | no
+items_commodities_rantadung | Ranta Dung | no
+items_commodities_revenantpod | Revenant Pod | no
+items_commodities_sadaryx | Sadaryx | yes
+items_commodities_saldynium | Saldynium | no
+items_commodities_saldynium_ore | Saldynium (Ore) | no
+items_commodities_stonebugshell | Stone Bug Shell | no
+items_commodities_sunsetberry | Sunset Berries | no
+items_commodities_valakkaregg_irradiated | Irradiated Valakkar Egg | no
+items_commodities_valakkarfang_adult | Valakkar Fang (Adult) | no
+items_commodities_valakkarfang_adult_irradiated | Irradiated Valakkar Fang (Adult) | no
+items_commodities_valakkarfang_apex_irradiated | Irradiated Valakkar Fang (Apex) | no
+items_commodities_valakkarfang_juvenile | Valakkar Fang (Juvenile) | no
+items_commodities_valakkarfang_juvenile_irradiated | Irradiated Valakkar Fang (Juvenile) | no
+items_commodities_valakkarpearl_apex_irradiated | Irradiated Valakkar Pearl | no
+items_commodities_valakkarpearl_apex_irradiated_tier1 | Irradiated Valakkar Pearl (AAA) | no
+items_commodities_valakkarpearl_apex_irradiated_tier2 | Irradiated Valakkar Pearl (AA) | no
+items_commodities_valakkarpearl_apex_irradiated_tier3 | Irradiated Valakkar Pearl (A) | no
+items_commodities_valakkarpearl_apex_irradiated_tier4 | Irradiated Valakkar Pearl (B) | no
+items_commodities_valakkarpearl_apex_irradiated_tier5 | Irradiated Valakkar Pearl (C) | no
+items_commodities_wuotanseed | Wuotan Seed | no
+items_commodities_yormandi_eye | Yormandi Eye | no
+items_commodities_zip | Zip | no

--- a/tests/test_mission_header_em_tag.py
+++ b/tests/test_mission_header_em_tag.py
@@ -24,7 +24,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
 from src.utils.json_settings import JsonSettings  # noqa: E402
 from src.utils.settings import AppSettings  # noqa: E402
 
-pytestmark = pytest.mark.unit
+pytestmark = [pytest.mark.unit, pytest.mark.regression]
 
 
 @pytest.fixture

--- a/tests/test_mission_header_em_tag.py
+++ b/tests/test_mission_header_em_tag.py
@@ -1,0 +1,58 @@
+"""Regression tests for the mission-header emphasis tag option (issue #99).
+
+EM1/EM2 were removed in 1.5.0 because they never render in-game (only
+EM3 = underline and EM4 = color do). These tests lock two things:
+
+  * the selectable set is exactly (EM3, EM4), and
+  * ``get_mission_header_em_tag`` coerces any stored legacy EM1/EM2 (or
+    other junk) back to the default, so a user who previously picked a
+    dead tag never has it leak into generated output.
+
+Uses the JsonSettings backend so each test is hermetic, mirroring
+test_tag_config_settings.py.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+from src.utils.json_settings import JsonSettings  # noqa: E402
+from src.utils.settings import AppSettings  # noqa: E402
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def json_backend(tmp_path):
+    """Swap AppSettings._backend for a tmp JsonSettings so each test is hermetic."""
+    saved = AppSettings._backend
+    AppSettings._backend = JsonSettings(tmp_path / "config.json")
+    yield AppSettings._backend
+    AppSettings._backend = saved
+
+
+def test_em1_em2_not_offered():
+    assert AppSettings.MISSION_HEADER_EM_TAGS == ("EM3", "EM4")
+    assert "EM1" not in AppSettings.MISSION_HEADER_EM_TAGS
+    assert "EM2" not in AppSettings.MISSION_HEADER_EM_TAGS
+
+
+def test_default_is_em3(json_backend):
+    assert AppSettings.get_mission_header_em_tag() == "EM3"
+
+
+@pytest.mark.parametrize("valid", ["EM3", "EM4"])
+def test_valid_tag_passes_through(json_backend, valid):
+    AppSettings.set_mission_header_em_tag(valid)
+    assert AppSettings.get_mission_header_em_tag() == valid
+
+
+@pytest.mark.parametrize("legacy", ["EM1", "EM2", "EM0", "nonsense", ""])
+def test_legacy_or_junk_coerced_to_default(json_backend, legacy):
+    AppSettings.set_mission_header_em_tag(legacy)
+    assert AppSettings.get_mission_header_em_tag() == AppSettings.DEFAULT_MISSION_HEADER_EM_TAG


### PR DESCRIPTION
## What

EM1 and EM2 never render in Star Citizen. Only EM3 (underline) and EM4 (color) actually do anything in-game, so offering EM1/EM2 in the mission-header emphasis dropdown only produced dead, invisible tags. This removes them.

## Changes

- New `AppSettings.MISSION_HEADER_EM_TAGS = ("EM3", "EM4")`, and the Enhancements-tab header dropdown is built from it instead of a hardcoded EM1..EM4 list.
- `get_mission_header_em_tag()` now coerces any stored EM1/EM2 (or other junk) back to the default EM3, so anyone who had a dead tag selected stops emitting it into generated output.
- Adds `tests/test_mission_header_em_tag.py` (9 cases).

## Testing

New tests pass. Full suite is green except 4 pre-existing `test_pak_extraction::TestDataForgeCache` failures that are unrelated to this change (a separate `str`-vs-`Path` bug in `dataforge_cache_is_fresh`, being fixed on its own).

Fixes #99.