### PR TITLE
test: fix stale DataForge cache-freshness tests

### DIFF
--- a/tests/fixtures/collection_items_groundtruth.txt
+++ b/tests/fixtures/collection_items_groundtruth.txt
@@ -1,0 +1,84 @@
+# Ground-truth fixture for the [Collection] item tagging feature (issue #97).
+#
+# Captured by hand by the maintainer from a LIVE global.ini export (May 2026,
+# ~1.4.2 era). These are the items that appear as objectives in Collection
+# missions and should receive the Collection flag in their display name.
+#
+# Purpose: validate the 1.5.0 generator that auto-discovers Collection-mission
+# items from DataForge. The generated output should flag (at least) every key
+# below. This file encodes the DURABLE part (which items qualify, and whether
+# each is also a crafting material), not a pinned rendered string, because the
+# rendered tag depends on user Tag Builder config.
+#
+# Rendering (the "Commodity Tagging" Tag Builder category, default config):
+#   - collection only          ->  <Name> <EM4>[Collection]</EM4>
+#   - crafting + collection     ->  <Name> <EM4>[CF|Collection]</EM4>
+#   - crafting only (NOT below) ->  <Name> <EM4>[CF]</EM4>   (unchanged today)
+# Collection flag forms (short/medium/long, default long):
+#   Col / Collect / Collection
+# Defaults: flag order CF|Collection, separator "|", emphasis EM4.
+#
+# Key namespaces: Mission_Item_*, items_commodities_*, harvestable_*. The same
+# physical item often has more than one key (e.g. Mission_Item_0183 and
+# items_commodities_decaripod are both "Decari Pod"); the tagger must cover all.
+#
+# Format (pipe-delimited):  key | base_name | also_crafting(yes/no)
+# 57 entries; 8 are also crafting materials (also_crafting=yes).
+
+Mission_Item_0183 | Decari Pod | no
+Mission_Item_0184 | Degnous Root | no
+Mission_Item_0186 | Golden Medmon | no
+Mission_Item_0191 | Pitambu | no
+Mission_Item_0192 | Prota | no
+Mission_Item_0195 | Sunset Berry | no
+Mission_Item_0214 | Compboard | no
+harvestable_Armillaria | Bluemoon Fungus | no
+items_commodities_amiantpod | Amiant Pod | no
+items_commodities_amioshiplague | Amioshi Plague | no
+items_commodities_beradom | Beradom | yes
+items_commodities_carinite | Carinite | yes
+items_commodities_carinite_pure | Carinite (Pure) | yes
+items_commodities_carinite_raw | Carinite (Raw) | no
+items_commodities_compboard | Compboard | no
+items_commodities_decaripod | Decari Pod | no
+items_commodities_degnousroot | Degnous Root | no
+items_commodities_dopple | Dopple | no
+items_commodities_feynmaline | Feynmaline | yes
+items_commodities_flareweedstalk | Flareweed Stalk | no
+items_commodities_fotiascrub | Fotia Seedpod | no
+items_commodities_freeze | Freeze | no
+items_commodities_glacosite | Glacosite | yes
+items_commodities_glow | Glow | no
+items_commodities_goldenmedmon | Golden Medmon | yes
+items_commodities_heartofthewoods | Heart of the Woods | no
+items_commodities_jaclium | Jaclium | no
+items_commodities_jaclium_ore | Jaclium (Ore) | no
+items_commodities_janalite | Janalite | yes
+items_commodities_kopionhorn_irradiated | Irradiated Kopion Horn | no
+items_commodities_mala | Mala | no
+items_commodities_marokgem | Marok Gem | no
+items_commodities_pingala | Pingala Seeds | no
+items_commodities_pitambu | Pitambu | no
+items_commodities_prota | Prota | no
+items_commodities_rantadung | Ranta Dung | no
+items_commodities_revenantpod | Revenant Pod | no
+items_commodities_sadaryx | Sadaryx | yes
+items_commodities_saldynium | Saldynium | no
+items_commodities_saldynium_ore | Saldynium (Ore) | no
+items_commodities_stonebugshell | Stone Bug Shell | no
+items_commodities_sunsetberry | Sunset Berries | no
+items_commodities_valakkaregg_irradiated | Irradiated Valakkar Egg | no
+items_commodities_valakkarfang_adult | Valakkar Fang (Adult) | no
+items_commodities_valakkarfang_adult_irradiated | Irradiated Valakkar Fang (Adult) | no
+items_commodities_valakkarfang_apex_irradiated | Irradiated Valakkar Fang (Apex) | no
+items_commodities_valakkarfang_juvenile | Valakkar Fang (Juvenile) | no
+items_commodities_valakkarfang_juvenile_irradiated | Irradiated Valakkar Fang (Juvenile) | no
+items_commodities_valakkarpearl_apex_irradiated | Irradiated Valakkar Pearl | no
+items_commodities_valakkarpearl_apex_irradiated_tier1 | Irradiated Valakkar Pearl (AAA) | no
+items_commodities_valakkarpearl_apex_irradiated_tier2 | Irradiated Valakkar Pearl (AA) | no
+items_commodities_valakkarpearl_apex_irradiated_tier3 | Irradiated Valakkar Pearl (A) | no
+items_commodities_valakkarpearl_apex_irradiated_tier4 | Irradiated Valakkar Pearl (B) | no
+items_commodities_valakkarpearl_apex_irradiated_tier5 | Irradiated Valakkar Pearl (C) | no
+items_commodities_wuotanseed | Wuotan Seed | no
+items_commodities_yormandi_eye | Yormandi Eye | no
+items_commodities_zip | Zip | no

--- a/tests/test_pak_extraction.py
+++ b/tests/test_pak_extraction.py
@@ -28,75 +28,81 @@ from utils.pak_extractor import (
 class TestDataForgeCache:
     """Test DataForge cache freshness detection"""
 
-    def test_cache_is_fresh_when_newer(self):
-        """Test that cache is fresh when it's newer than p4k"""
+    # NOTE: freshness is keyed off a ``.p4k_mtime`` stamp file written into
+    # the cache dir at extraction time PLUS real ``raw/libs`` XML content,
+    # and the signature is dataforge_cache_is_fresh(p4k_path, cache_dir).
+    # (Earlier versions of these tests utime'd the cache directory and passed
+    # the args swapped as strings — both wrong against the current contract.)
+
+    @staticmethod
+    def _populate_cache(cache_dir: Path, stamp_mtime: float, *, with_xml: bool = True) -> None:
+        """Build a cache dir the way a real extraction leaves it: a
+        ``.p4k_mtime`` stamp plus ``raw/libs`` content."""
+        libs = cache_dir / "raw" / "libs"
+        libs.mkdir(parents=True, exist_ok=True)
+        if with_xml:
+            (libs / "sample.xml").write_text("<x/>")
+        (cache_dir / ".p4k_mtime").write_text(str(stamp_mtime))
+
+    def test_cache_is_fresh_when_stamp_newer(self):
+        """Fresh when the stamped mtime is >= the p4k mtime and XMLs exist."""
         with tempfile.TemporaryDirectory() as tmpdir:
-            # Create dummy p4k with old mtime
-            p4k_path = os.path.join(tmpdir, 'Data.p4k')
-            with open(p4k_path, 'w') as f:
-                f.write('dummy')
+            tmp = Path(tmpdir)
+            p4k_path = tmp / "Data.p4k"
+            p4k_path.write_text("dummy")
+            os.utime(p4k_path, (1_000_000_000, 1_000_000_000))  # Jan 2001
 
-            # Set p4k mtime to old date
-            old_time = 1000000000  # Jan 2001
-            os.utime(p4k_path, (old_time, old_time))
+            cache_dir = tmp / "dataforge"
+            self._populate_cache(cache_dir, stamp_mtime=2_000_000_000)  # newer
 
-            # Create cache dir with newer mtime
-            cache_dir = os.path.join(tmpdir, 'dataforge')
-            os.makedirs(cache_dir, exist_ok=True)
-            recent_time = 9999999999  # Far future
-            os.utime(cache_dir, (recent_time, recent_time))
+            assert dataforge_cache_is_fresh(p4k_path, cache_dir) is True
 
-            # Cache should be fresh (newer than p4k)
-            is_fresh = dataforge_cache_is_fresh(cache_dir, p4k_path)
-            assert is_fresh is True
-
-    def test_cache_is_stale_when_older(self):
-        """Test that cache is stale when p4k is newer"""
+    def test_cache_is_stale_when_stamp_older(self):
+        """Stale when the stamped mtime is older than the p4k mtime."""
         with tempfile.TemporaryDirectory() as tmpdir:
-            # Create dummy p4k with new mtime
-            p4k_path = os.path.join(tmpdir, 'Data.p4k')
-            with open(p4k_path, 'w') as f:
-                f.write('dummy')
+            tmp = Path(tmpdir)
+            p4k_path = tmp / "Data.p4k"
+            p4k_path.write_text("dummy")
+            os.utime(p4k_path, (9_999_999_999, 9_999_999_999))  # far future
 
-            recent_time = 9999999999  # Far future
-            os.utime(p4k_path, (recent_time, recent_time))
+            cache_dir = tmp / "dataforge"
+            self._populate_cache(cache_dir, stamp_mtime=1_000_000_000)  # older
 
-            # Create cache dir with old mtime
-            cache_dir = os.path.join(tmpdir, 'dataforge')
-            os.makedirs(cache_dir, exist_ok=True)
-            old_time = 1000000000  # Jan 2001
-            os.utime(cache_dir, (old_time, old_time))
+            assert dataforge_cache_is_fresh(p4k_path, cache_dir) is False
 
-            # Cache should be stale (older than p4k)
-            is_fresh = dataforge_cache_is_fresh(cache_dir, p4k_path)
-            assert is_fresh is False
-
-    def test_cache_is_fresh_when_cache_missing(self):
-        """Test that missing cache is treated as stale"""
+    def test_cache_is_stale_when_cache_missing(self):
+        """A cache dir with no stamp and no libs is stale."""
         with tempfile.TemporaryDirectory() as tmpdir:
-            p4k_path = os.path.join(tmpdir, 'Data.p4k')
-            with open(p4k_path, 'w') as f:
-                f.write('dummy')
+            tmp = Path(tmpdir)
+            p4k_path = tmp / "Data.p4k"
+            p4k_path.write_text("dummy")
 
-            # Cache directory doesn't exist
-            cache_dir = os.path.join(tmpdir, 'nonexistent')
+            cache_dir = tmp / "nonexistent"
+            assert dataforge_cache_is_fresh(p4k_path, cache_dir) is False
 
-            # Cache should be stale (doesn't exist)
-            is_fresh = dataforge_cache_is_fresh(cache_dir, p4k_path)
-            assert is_fresh is False
-
-    def test_cache_is_fresh_when_p4k_missing(self):
-        """Test that missing p4k is handled"""
+    def test_cache_is_stale_when_stamp_present_but_no_xml(self):
+        """A stamp-only remnant from a failed/partial extraction is stale."""
         with tempfile.TemporaryDirectory() as tmpdir:
-            p4k_path = os.path.join(tmpdir, 'nonexistent', 'Data.p4k')
+            tmp = Path(tmpdir)
+            p4k_path = tmp / "Data.p4k"
+            p4k_path.write_text("dummy")
+            os.utime(p4k_path, (1_000_000_000, 1_000_000_000))
 
-            cache_dir = os.path.join(tmpdir, 'dataforge')
-            os.makedirs(cache_dir, exist_ok=True)
+            cache_dir = tmp / "dataforge"
+            self._populate_cache(cache_dir, stamp_mtime=2_000_000_000, with_xml=False)
 
-            # Should handle missing p4k gracefully
-            is_fresh = dataforge_cache_is_fresh(cache_dir, p4k_path)
-            # Missing p4k could mean cache is stale (can't verify freshness)
-            assert isinstance(is_fresh, bool)
+            assert dataforge_cache_is_fresh(p4k_path, cache_dir) is False
+
+    def test_cache_is_stale_when_p4k_missing(self):
+        """A missing p4k cannot be verified against, so treat the cache as stale."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            p4k_path = tmp / "nonexistent" / "Data.p4k"  # does not exist
+
+            cache_dir = tmp / "dataforge"
+            self._populate_cache(cache_dir, stamp_mtime=2_000_000_000)
+
+            assert dataforge_cache_is_fresh(p4k_path, cache_dir) is False
 
 
 class TestDataForgeExtraction:


### PR DESCRIPTION
## What

`TestDataForgeCache` was failing with `TypeError: unsupported operand type(s) for /: 'str' and 'str'`. The tests predated the current `dataforge_cache_is_fresh` contract: they `os.utime`'d the cache *directory* and called the function with the arguments swapped and passed as strings.

## Not a runtime bug

The app callers (`main_window.py`, `enhancements_tab.py`) always call it correctly: `(p4k_path, cache_dir)` with `Path` objects. So the freshness check works fine in the app; only the tests were stale. (Found while triaging #99.)

## Changes

- Rewrite the cases against the real contract: a `.p4k_mtime` stamp file plus `raw/libs` XML content, correct argument order, `Path` objects.
- Add a partial-extraction case (stamp present but no XML, expect stale).

Full suite after this: 616 passed, 0 failures.