### PR TITLE
fix: space favourite prefix not saved (preserve user.ini whitespace) (#100)

### DIFF
--- a/src/parser/ini_parser.py
+++ b/src/parser/ini_parser.py
@@ -11,7 +11,7 @@ logger = logging.getLogger(__name__)
 
 
 @timed
-def parse_ini_file(path: str | Path) -> Dict[str, str]:
+def parse_ini_file(path: str | Path, *, strip_values: bool = True) -> Dict[str, str]:
     """Parse INI file line-by-line, preserving efficiency.
 
     Strips any comma-based metadata suffix from keys (e.g., "key,P" → "key").
@@ -20,6 +20,12 @@ def parse_ini_file(path: str | Path) -> Dict[str, str]:
 
     Args:
         path: Path to INI file
+        strip_values: When True (default, for base.ini / enhancements) the
+            value is whitespace-stripped. Pass False for ``user.ini`` so
+            values round-trip verbatim — the favourite prefix can be a
+            single space (the "invisible" sort-to-top marker), and stripping
+            would silently delete it, dropping the favourite on reload
+            (issue #100).
 
     Returns:
         Dictionary of key-value pairs
@@ -45,7 +51,8 @@ def parse_ini_file(path: str | Path) -> Dict[str, str]:
 
                 key, value = line.split('=', 1)
                 key = key.strip()
-                value = value.strip()
+                if strip_values:
+                    value = value.strip()
 
                 if key:
                     # Strip comma-based metadata suffix (e.g., "key,P" → "key")
@@ -91,7 +98,7 @@ def load_source_files(
     # Handle legacy custom_path parameter
     if custom_path and not user_overrides:
         logger.info(f"Loading user overrides from legacy path: {custom_path}")
-        user_overrides = parse_ini_file(custom_path)
+        user_overrides = parse_ini_file(custom_path, strip_values=False)
 
     logger.info(f"Starting merge of {sum(len(d) for d in sources_dict.values())} total keys from {len(sources_dict)} sources")
     logger.info(f"Hierarchy: {hierarchy}, Sources available: {list(sources_dict.keys())}")
@@ -288,7 +295,8 @@ def load_sources_from_settings() -> tuple[Dict[str, Dict[str, str]], List[str], 
             # User source can be empty on first run
             if source_name == AppSettings.SOURCE_USER:
                 if local_file.exists():
-                    source_data = parse_ini_file(source_path)
+                    # strip_values=False so a space favourite prefix survives (#100)
+                    source_data = parse_ini_file(source_path, strip_values=False)
                     if source_data:
                         sources_dict[source_name] = source_data
                         logger.info(f"Loaded {len(source_data)} entries from {source_name}")
@@ -365,7 +373,9 @@ def load_overrides(target_path: str | Path) -> Dict[str, str]:
     Returns:
         Dictionary of overrides
     """
-    return parse_ini_file(target_path)
+    # strip_values=False: user.ini values round-trip verbatim so a space
+    # favourite prefix is not silently stripped away on reload (#100).
+    return parse_ini_file(target_path, strip_values=False)
 
 
 def _determine_status(original_value: str, custom_value: str) -> str:

--- a/src/utils/user_ini_manager.py
+++ b/src/utils/user_ini_manager.py
@@ -184,8 +184,10 @@ def generate_user_ini_from_diff(
         return 0
 
     try:
-        reference = parse_ini_file(reference_path)
-        current = parse_ini_file(current_path)
+        # strip_values=False so a favourite applied with a space prefix is
+        # captured verbatim in the diff rather than collapsing to equal (#100).
+        reference = parse_ini_file(reference_path, strip_values=False)
+        current = parse_ini_file(current_path, strip_values=False)
 
         diffs = {}
         for key, current_value in current.items():

--- a/tests/fixtures/collection_items_groundtruth.txt
+++ b/tests/fixtures/collection_items_groundtruth.txt
@@ -1,0 +1,84 @@
+# Ground-truth fixture for the [Collection] item tagging feature (issue #97).
+#
+# Captured by hand by the maintainer from a LIVE global.ini export (May 2026,
+# ~1.4.2 era). These are the items that appear as objectives in Collection
+# missions and should receive the Collection flag in their display name.
+#
+# Purpose: validate the 1.5.0 generator that auto-discovers Collection-mission
+# items from DataForge. The generated output should flag (at least) every key
+# below. This file encodes the DURABLE part (which items qualify, and whether
+# each is also a crafting material), not a pinned rendered string, because the
+# rendered tag depends on user Tag Builder config.
+#
+# Rendering (the "Commodity Tagging" Tag Builder category, default config):
+#   - collection only          ->  <Name> <EM4>[Collection]</EM4>
+#   - crafting + collection     ->  <Name> <EM4>[CF|Collection]</EM4>
+#   - crafting only (NOT below) ->  <Name> <EM4>[CF]</EM4>   (unchanged today)
+# Collection flag forms (short/medium/long, default long):
+#   Col / Collect / Collection
+# Defaults: flag order CF|Collection, separator "|", emphasis EM4.
+#
+# Key namespaces: Mission_Item_*, items_commodities_*, harvestable_*. The same
+# physical item often has more than one key (e.g. Mission_Item_0183 and
+# items_commodities_decaripod are both "Decari Pod"); the tagger must cover all.
+#
+# Format (pipe-delimited):  key | base_name | also_crafting(yes/no)
+# 57 entries; 8 are also crafting materials (also_crafting=yes).
+
+Mission_Item_0183 | Decari Pod | no
+Mission_Item_0184 | Degnous Root | no
+Mission_Item_0186 | Golden Medmon | no
+Mission_Item_0191 | Pitambu | no
+Mission_Item_0192 | Prota | no
+Mission_Item_0195 | Sunset Berry | no
+Mission_Item_0214 | Compboard | no
+harvestable_Armillaria | Bluemoon Fungus | no
+items_commodities_amiantpod | Amiant Pod | no
+items_commodities_amioshiplague | Amioshi Plague | no
+items_commodities_beradom | Beradom | yes
+items_commodities_carinite | Carinite | yes
+items_commodities_carinite_pure | Carinite (Pure) | yes
+items_commodities_carinite_raw | Carinite (Raw) | no
+items_commodities_compboard | Compboard | no
+items_commodities_decaripod | Decari Pod | no
+items_commodities_degnousroot | Degnous Root | no
+items_commodities_dopple | Dopple | no
+items_commodities_feynmaline | Feynmaline | yes
+items_commodities_flareweedstalk | Flareweed Stalk | no
+items_commodities_fotiascrub | Fotia Seedpod | no
+items_commodities_freeze | Freeze | no
+items_commodities_glacosite | Glacosite | yes
+items_commodities_glow | Glow | no
+items_commodities_goldenmedmon | Golden Medmon | yes
+items_commodities_heartofthewoods | Heart of the Woods | no
+items_commodities_jaclium | Jaclium | no
+items_commodities_jaclium_ore | Jaclium (Ore) | no
+items_commodities_janalite | Janalite | yes
+items_commodities_kopionhorn_irradiated | Irradiated Kopion Horn | no
+items_commodities_mala | Mala | no
+items_commodities_marokgem | Marok Gem | no
+items_commodities_pingala | Pingala Seeds | no
+items_commodities_pitambu | Pitambu | no
+items_commodities_prota | Prota | no
+items_commodities_rantadung | Ranta Dung | no
+items_commodities_revenantpod | Revenant Pod | no
+items_commodities_sadaryx | Sadaryx | yes
+items_commodities_saldynium | Saldynium | no
+items_commodities_saldynium_ore | Saldynium (Ore) | no
+items_commodities_stonebugshell | Stone Bug Shell | no
+items_commodities_sunsetberry | Sunset Berries | no
+items_commodities_valakkaregg_irradiated | Irradiated Valakkar Egg | no
+items_commodities_valakkarfang_adult | Valakkar Fang (Adult) | no
+items_commodities_valakkarfang_adult_irradiated | Irradiated Valakkar Fang (Adult) | no
+items_commodities_valakkarfang_apex_irradiated | Irradiated Valakkar Fang (Apex) | no
+items_commodities_valakkarfang_juvenile | Valakkar Fang (Juvenile) | no
+items_commodities_valakkarfang_juvenile_irradiated | Irradiated Valakkar Fang (Juvenile) | no
+items_commodities_valakkarpearl_apex_irradiated | Irradiated Valakkar Pearl | no
+items_commodities_valakkarpearl_apex_irradiated_tier1 | Irradiated Valakkar Pearl (AAA) | no
+items_commodities_valakkarpearl_apex_irradiated_tier2 | Irradiated Valakkar Pearl (AA) | no
+items_commodities_valakkarpearl_apex_irradiated_tier3 | Irradiated Valakkar Pearl (A) | no
+items_commodities_valakkarpearl_apex_irradiated_tier4 | Irradiated Valakkar Pearl (B) | no
+items_commodities_valakkarpearl_apex_irradiated_tier5 | Irradiated Valakkar Pearl (C) | no
+items_commodities_wuotanseed | Wuotan Seed | no
+items_commodities_yormandi_eye | Yormandi Eye | no
+items_commodities_zip | Zip | no

--- a/tests/test_favorite_prefix_whitespace.py
+++ b/tests/test_favorite_prefix_whitespace.py
@@ -1,0 +1,64 @@
+"""Regression tests for the space favourite-prefix round-trip (issue #100).
+
+A favourite is encoded by prepending a configurable prefix to the ship's
+custom value, and the prefix may be a single space (the "invisible"
+sort-to-top marker offered in the Enhancements tab). That value is stored
+verbatim in user.ini, e.g. ``vehicle_NameARGO_Mole= Argo MOLE``.
+
+The bug: parse_ini_file used to ``value.strip()`` on every load, so the
+leading-space prefix was silently deleted when user.ini was read back,
+and the ship showed as "modified" but not favourited. The fix gives
+parse_ini_file a ``strip_values`` flag and reads user.ini with it False.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+from src.parser.ini_parser import load_overrides, parse_ini_file  # noqa: E402
+
+pytestmark = pytest.mark.unit
+
+SPACE = " "
+
+
+def _write(path: Path, text: str) -> Path:
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def test_default_strips_values(tmp_path):
+    p = _write(tmp_path / "base.ini", "k=  padded value  \n")
+    assert parse_ini_file(p)["k"] == "padded value"
+
+
+def test_strip_values_false_preserves_leading_space(tmp_path):
+    p = _write(tmp_path / "user.ini", "vehicle_NameARGO_Mole= Argo MOLE\n")
+    value = parse_ini_file(p, strip_values=False)["vehicle_NameARGO_Mole"]
+    assert value == " Argo MOLE"
+    assert value.startswith(SPACE)  # favourite detection would fire
+
+
+def test_load_overrides_preserves_space_prefix(tmp_path):
+    """load_overrides is the user.ini reader; it must keep the space prefix."""
+    _write(
+        tmp_path / "user.ini",
+        "vehicle_NameARGO_Mole= Argo MOLE\n"
+        "vehicle_NameRSI_Perseus= RSI Perseus\n",
+    )
+    overrides = load_overrides(tmp_path / "user.ini")
+    assert overrides["vehicle_NameARGO_Mole"] == " Argo MOLE"
+    # The whole point: a space-prefixed value is still recognised as a favourite.
+    assert all(v.startswith(SPACE) for v in overrides.values())
+
+
+def test_visible_prefix_unaffected(tmp_path):
+    """A '*' prefix worked before and still works (no whitespace to strip)."""
+    _write(tmp_path / "user.ini", "vehicle_NameARGO_Mole=*Argo MOLE\n")
+    overrides = load_overrides(tmp_path / "user.ini")
+    assert overrides["vehicle_NameARGO_Mole"] == "*Argo MOLE"

--- a/tests/test_favorite_prefix_whitespace.py
+++ b/tests/test_favorite_prefix_whitespace.py
@@ -22,7 +22,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
 
 from src.parser.ini_parser import load_overrides, parse_ini_file  # noqa: E402
 
-pytestmark = pytest.mark.unit
+pytestmark = [pytest.mark.unit, pytest.mark.regression]
 
 SPACE = " "
 


### PR DESCRIPTION
## What

Favourites set with the **space** prefix (the invisible "sort to the top" marker) vanished on reload: the ship came back as "modified" but not favourited, even though `user.ini` still held the favourite.

## Root cause

A favourite is `prefix + name` in the custom value, stored in `user.ini` as e.g. `vehicle_NameARGO_Mole= Argo MOLE`. `parse_ini_file` ran `value.strip()` on every load, which deleted the leading-space prefix, so `custom_value.startswith(" ")` was False after reload. It is **not portable-specific**; any whitespace prefix breaks the same way.

## Fix

- `parse_ini_file` gains a `strip_values` flag (default `True`, unchanged for `base.ini` / enhancements).
- `user.ini` is now read with `strip_values=False` everywhere it is parsed: the `SOURCE_USER` source load, `load_overrides`, the legacy `custom_path`, and the applied-vs-stock diff bootstrap in `user_ini_manager`. So a space-prefixed favourite round-trips verbatim.

## Tests

Adds `tests/test_favorite_prefix_whitespace.py` (4 cases: default still strips, `strip_values=False` preserves the space, `load_overrides` keeps the prefix, visible `*` prefix unaffected). Full suite green except 4 unrelated pre-existing `test_pak_extraction` failures fixed in #108.

Fixes #100.