### PR TITLE
fix: first-run IndexError on empty table load (#110)

### DIFF
--- a/src/gui/string_table_model.py
+++ b/src/gui/string_table_model.py
@@ -211,8 +211,15 @@ class StringTableModel(QAbstractTableModel):
         """Map a model row to an index into self._entries."""
         return self._filtered_indices[row]
 
-    def entry_for_row(self, row: int) -> StringEntry:
-        return self._entries[self._filtered_indices[row]]
+    def entry_for_row(self, row: int) -> Optional[StringEntry]:
+        """Return the entry for a model row, or None if the row is out of
+        range. The view can briefly query stale rows after a failed/empty
+        load (first run before extraction, when the loader raises "No
+        sources configured"); an unguarded index there crashed with
+        IndexError (issue #110)."""
+        if 0 <= row < len(self._filtered_indices):
+            return self._entries[self._filtered_indices[row]]
+        return None
 
     def source_row_for_entry_index(self, entry_idx: int) -> Optional[int]:
         """Reverse lookup: entry index -> model row. O(1) via dict."""
@@ -241,7 +248,7 @@ class StringTableModel(QAbstractTableModel):
             return base | Qt.ItemFlag.ItemIsEditable
         if col == COL_STAR:
             entry = self.entry_for_row(index.row())
-            if entry.category != "Ships":
+            if entry is not None and entry.category != "Ships":
                 return Qt.ItemFlag.ItemIsEnabled  # not selectable
         return base
 
@@ -252,6 +259,8 @@ class StringTableModel(QAbstractTableModel):
         row = index.row()
         col = index.column()
         entry = self.entry_for_row(row)
+        if entry is None:
+            return None
         prefix = self._favorite_prefix
 
         # -- display text ---------------------------------------------------
@@ -324,6 +333,8 @@ class StringTableModel(QAbstractTableModel):
             return False
 
         entry = self.entry_for_row(index.row())
+        if entry is None:
+            return False
         new_text = str(value)
         if new_text == entry.custom_value:
             return False

--- a/tests/fixtures/collection_items_groundtruth.txt
+++ b/tests/fixtures/collection_items_groundtruth.txt
@@ -1,0 +1,84 @@
+# Ground-truth fixture for the [Collection] item tagging feature (issue #97).
+#
+# Captured by hand by the maintainer from a LIVE global.ini export (May 2026,
+# ~1.4.2 era). These are the items that appear as objectives in Collection
+# missions and should receive the Collection flag in their display name.
+#
+# Purpose: validate the 1.5.0 generator that auto-discovers Collection-mission
+# items from DataForge. The generated output should flag (at least) every key
+# below. This file encodes the DURABLE part (which items qualify, and whether
+# each is also a crafting material), not a pinned rendered string, because the
+# rendered tag depends on user Tag Builder config.
+#
+# Rendering (the "Commodity Tagging" Tag Builder category, default config):
+#   - collection only          ->  <Name> <EM4>[Collection]</EM4>
+#   - crafting + collection     ->  <Name> <EM4>[CF|Collection]</EM4>
+#   - crafting only (NOT below) ->  <Name> <EM4>[CF]</EM4>   (unchanged today)
+# Collection flag forms (short/medium/long, default long):
+#   Col / Collect / Collection
+# Defaults: flag order CF|Collection, separator "|", emphasis EM4.
+#
+# Key namespaces: Mission_Item_*, items_commodities_*, harvestable_*. The same
+# physical item often has more than one key (e.g. Mission_Item_0183 and
+# items_commodities_decaripod are both "Decari Pod"); the tagger must cover all.
+#
+# Format (pipe-delimited):  key | base_name | also_crafting(yes/no)
+# 57 entries; 8 are also crafting materials (also_crafting=yes).
+
+Mission_Item_0183 | Decari Pod | no
+Mission_Item_0184 | Degnous Root | no
+Mission_Item_0186 | Golden Medmon | no
+Mission_Item_0191 | Pitambu | no
+Mission_Item_0192 | Prota | no
+Mission_Item_0195 | Sunset Berry | no
+Mission_Item_0214 | Compboard | no
+harvestable_Armillaria | Bluemoon Fungus | no
+items_commodities_amiantpod | Amiant Pod | no
+items_commodities_amioshiplague | Amioshi Plague | no
+items_commodities_beradom | Beradom | yes
+items_commodities_carinite | Carinite | yes
+items_commodities_carinite_pure | Carinite (Pure) | yes
+items_commodities_carinite_raw | Carinite (Raw) | no
+items_commodities_compboard | Compboard | no
+items_commodities_decaripod | Decari Pod | no
+items_commodities_degnousroot | Degnous Root | no
+items_commodities_dopple | Dopple | no
+items_commodities_feynmaline | Feynmaline | yes
+items_commodities_flareweedstalk | Flareweed Stalk | no
+items_commodities_fotiascrub | Fotia Seedpod | no
+items_commodities_freeze | Freeze | no
+items_commodities_glacosite | Glacosite | yes
+items_commodities_glow | Glow | no
+items_commodities_goldenmedmon | Golden Medmon | yes
+items_commodities_heartofthewoods | Heart of the Woods | no
+items_commodities_jaclium | Jaclium | no
+items_commodities_jaclium_ore | Jaclium (Ore) | no
+items_commodities_janalite | Janalite | yes
+items_commodities_kopionhorn_irradiated | Irradiated Kopion Horn | no
+items_commodities_mala | Mala | no
+items_commodities_marokgem | Marok Gem | no
+items_commodities_pingala | Pingala Seeds | no
+items_commodities_pitambu | Pitambu | no
+items_commodities_prota | Prota | no
+items_commodities_rantadung | Ranta Dung | no
+items_commodities_revenantpod | Revenant Pod | no
+items_commodities_sadaryx | Sadaryx | yes
+items_commodities_saldynium | Saldynium | no
+items_commodities_saldynium_ore | Saldynium (Ore) | no
+items_commodities_stonebugshell | Stone Bug Shell | no
+items_commodities_sunsetberry | Sunset Berries | no
+items_commodities_valakkaregg_irradiated | Irradiated Valakkar Egg | no
+items_commodities_valakkarfang_adult | Valakkar Fang (Adult) | no
+items_commodities_valakkarfang_adult_irradiated | Irradiated Valakkar Fang (Adult) | no
+items_commodities_valakkarfang_apex_irradiated | Irradiated Valakkar Fang (Apex) | no
+items_commodities_valakkarfang_juvenile | Valakkar Fang (Juvenile) | no
+items_commodities_valakkarfang_juvenile_irradiated | Irradiated Valakkar Fang (Juvenile) | no
+items_commodities_valakkarpearl_apex_irradiated | Irradiated Valakkar Pearl | no
+items_commodities_valakkarpearl_apex_irradiated_tier1 | Irradiated Valakkar Pearl (AAA) | no
+items_commodities_valakkarpearl_apex_irradiated_tier2 | Irradiated Valakkar Pearl (AA) | no
+items_commodities_valakkarpearl_apex_irradiated_tier3 | Irradiated Valakkar Pearl (A) | no
+items_commodities_valakkarpearl_apex_irradiated_tier4 | Irradiated Valakkar Pearl (B) | no
+items_commodities_valakkarpearl_apex_irradiated_tier5 | Irradiated Valakkar Pearl (C) | no
+items_commodities_wuotanseed | Wuotan Seed | no
+items_commodities_yormandi_eye | Yormandi Eye | no
+items_commodities_zip | Zip | no

--- a/tests/test_string_table_model_bounds.py
+++ b/tests/test_string_table_model_bounds.py
@@ -23,7 +23,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
 from src.gui.string_table_model import StringTableModel  # noqa: E402
 from src.models.string_model import StringEntry  # noqa: E402
 
-pytestmark = pytest.mark.unit
+pytestmark = [pytest.mark.unit, pytest.mark.regression]
 
 
 def _model(entries, filtered):
@@ -61,3 +61,14 @@ def test_just_out_of_range_returns_none():
     e = _entry()
     m = _model([e], [0])
     assert m.entry_for_row(1) is None
+
+
+def test_negative_control_raw_index_would_raise():
+    """Negative control for #110: the raw index entry_for_row used to do
+    (``self._filtered_indices[row]``) still raises IndexError on an empty
+    model — proving the danger is real — while the guarded entry_for_row
+    neutralizes it by returning None."""
+    m = _model([], [])
+    with pytest.raises(IndexError):
+        _ = m._filtered_indices[0]
+    assert m.entry_for_row(0) is None

--- a/tests/test_string_table_model_bounds.py
+++ b/tests/test_string_table_model_bounds.py
@@ -1,0 +1,63 @@
+"""Regression test for issue #110.
+
+StringTableModel.entry_for_row must not raise IndexError on an out-of-range
+row. The view can briefly query stale rows after a failed/empty load (first
+run before extraction, when the loader raises "No sources configured"), which
+crashed with `IndexError: list index out of range` in flags()/entry_for_row().
+
+Uses StringTableModel.__new__ to exercise the pure bounds logic without a
+QApplication, keeping the suite Qt-free (widgets/workers are manually tested
+per tests/CLAUDE.md). entry_for_row touches only the two plain list attrs, so
+bypassing the QObject constructor is safe here.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+from src.gui.string_table_model import StringTableModel  # noqa: E402
+from src.models.string_model import StringEntry  # noqa: E402
+
+pytestmark = pytest.mark.unit
+
+
+def _model(entries, filtered):
+    m = StringTableModel.__new__(StringTableModel)  # bypass QObject init (no QApplication)
+    m._entries = entries
+    m._filtered_indices = filtered
+    return m
+
+
+def _entry() -> StringEntry:
+    return StringEntry(
+        key="vehicle_NameX",
+        source_file="global",
+        category="Ships",
+        original_value="X",
+        custom_value="",
+        status="Unmodified",
+    )
+
+
+def test_empty_model_returns_none_instead_of_indexerror():
+    m = _model([], [])
+    assert m.entry_for_row(0) is None
+    assert m.entry_for_row(5) is None
+    assert m.entry_for_row(-1) is None
+
+
+def test_in_range_row_returns_entry():
+    e = _entry()
+    m = _model([e], [0])
+    assert m.entry_for_row(0) is e
+
+
+def test_just_out_of_range_returns_none():
+    e = _entry()
+    m = _model([e], [0])
+    assert m.entry_for_row(1) is None


### PR DESCRIPTION
## What

On a fresh install, before extraction has produced `base.ini`, `FileLoaderWorker` fails with `ValueError: No sources configured` and the strings table is left empty. The view can still query a stale row, and `StringTableModel.entry_for_row` indexed `_filtered_indices[row]` with no bounds check, crashing with `IndexError: list index out of range` in `flags()`.

## Fix

- `entry_for_row` now returns `Optional[StringEntry]`, `None` when the row is out of range.
- `flags()`, `data()`, and `setData()` handle `None` gracefully (safe flags / return `None` / no-op edit).

## Tests

`tests/test_string_table_model_bounds.py` exercises the bounds logic without a `QApplication` (via `__new__`), per the suite's Qt-free convention.

Fixes #110.