### PR TITLE
fix: Type tag missing from mission blueprint lists (#101)

### DIFF
--- a/scripts/generate_enhancements_ini.py
+++ b/scripts/generate_enhancements_ini.py
@@ -4100,6 +4100,21 @@ def build_ammo_lookup(
     return lookup
 
 
+# scitem entity subdir → component-type label (matches the keys in
+# tag_builder.DEFAULT_COMPONENT_TYPE_MAPPING). Shared by the standalone
+# component generator (_run_gen_components) and the entity_name_tags builder
+# (build_scitem_lookups) so the type element renders identically on standalone
+# component names AND on the component entries inside mission blueprint lists
+# (issue #101 — the lookup builder previously omitted it).
+_SUBDIR_TO_TYPE: dict[str, str] = {
+    "shieldgenerator": "Shield Generator",
+    "cooler":          "Cooler",
+    "powerplant":      "Power Plant",
+    "quantumdrive":    "Quantum Drive",
+    "radar":           "Radar",
+}
+
+
 def build_scitem_lookups(
     scitem_dir: Path,
     loc: dict[str, str] | None = None,
@@ -4203,7 +4218,18 @@ def build_scitem_lookups(
         if ref and desc_loc_key:
             desc_value = loc.get(desc_loc_key, "")
             if desc_value:
-                tag = _component_name_tag(desc_value, root, config=tag_config)
+                # Derive the component type from the entity's subdir so the
+                # blueprint-list tag carries the same Type element the
+                # standalone component path emits (#101). Non-component
+                # entities won't be under these subdirs (comp_type stays "")
+                # and _component_name_tag returns None for them regardless.
+                _parts = {p.lower() for p in xml_file.parts}
+                comp_type = next(
+                    (t for sd, t in _SUBDIR_TO_TYPE.items() if sd in _parts), ""
+                )
+                tag = _component_name_tag(
+                    desc_value, root, config=tag_config, component_type=comp_type
+                )
                 if tag:
                     entity_name_tags[ref] = tag
 
@@ -4346,13 +4372,6 @@ def _run_gen_components(ctx: dict) -> dict[str, str]:
     tag_configs     = ctx.get("tag_configs") or {}
     comp_cfg        = tag_configs.get("components") or DEFAULT_TAG_CONFIGS.get("components")
     comp_placement  = getattr(comp_cfg, "placement", "prepend") if comp_cfg else "prepend"
-    _SUBDIR_TO_TYPE = {
-        "shieldgenerator": "Shield Generator",
-        "cooler":          "Cooler",
-        "powerplant":      "Power Plant",
-        "quantumdrive":    "Quantum Drive",
-        "radar":           "Radar",
-    }
 
     def _make_comp_tagger(comp_type: str):
         def _tagger(desc_value: str, root: ET.Element | None = None) -> str | None:

--- a/tests/fixtures/collection_items_groundtruth.txt
+++ b/tests/fixtures/collection_items_groundtruth.txt
@@ -1,0 +1,84 @@
+# Ground-truth fixture for the [Collection] item tagging feature (issue #97).
+#
+# Captured by hand by the maintainer from a LIVE global.ini export (May 2026,
+# ~1.4.2 era). These are the items that appear as objectives in Collection
+# missions and should receive the Collection flag in their display name.
+#
+# Purpose: validate the 1.5.0 generator that auto-discovers Collection-mission
+# items from DataForge. The generated output should flag (at least) every key
+# below. This file encodes the DURABLE part (which items qualify, and whether
+# each is also a crafting material), not a pinned rendered string, because the
+# rendered tag depends on user Tag Builder config.
+#
+# Rendering (the "Commodity Tagging" Tag Builder category, default config):
+#   - collection only          ->  <Name> <EM4>[Collection]</EM4>
+#   - crafting + collection     ->  <Name> <EM4>[CF|Collection]</EM4>
+#   - crafting only (NOT below) ->  <Name> <EM4>[CF]</EM4>   (unchanged today)
+# Collection flag forms (short/medium/long, default long):
+#   Col / Collect / Collection
+# Defaults: flag order CF|Collection, separator "|", emphasis EM4.
+#
+# Key namespaces: Mission_Item_*, items_commodities_*, harvestable_*. The same
+# physical item often has more than one key (e.g. Mission_Item_0183 and
+# items_commodities_decaripod are both "Decari Pod"); the tagger must cover all.
+#
+# Format (pipe-delimited):  key | base_name | also_crafting(yes/no)
+# 57 entries; 8 are also crafting materials (also_crafting=yes).
+
+Mission_Item_0183 | Decari Pod | no
+Mission_Item_0184 | Degnous Root | no
+Mission_Item_0186 | Golden Medmon | no
+Mission_Item_0191 | Pitambu | no
+Mission_Item_0192 | Prota | no
+Mission_Item_0195 | Sunset Berry | no
+Mission_Item_0214 | Compboard | no
+harvestable_Armillaria | Bluemoon Fungus | no
+items_commodities_amiantpod | Amiant Pod | no
+items_commodities_amioshiplague | Amioshi Plague | no
+items_commodities_beradom | Beradom | yes
+items_commodities_carinite | Carinite | yes
+items_commodities_carinite_pure | Carinite (Pure) | yes
+items_commodities_carinite_raw | Carinite (Raw) | no
+items_commodities_compboard | Compboard | no
+items_commodities_decaripod | Decari Pod | no
+items_commodities_degnousroot | Degnous Root | no
+items_commodities_dopple | Dopple | no
+items_commodities_feynmaline | Feynmaline | yes
+items_commodities_flareweedstalk | Flareweed Stalk | no
+items_commodities_fotiascrub | Fotia Seedpod | no
+items_commodities_freeze | Freeze | no
+items_commodities_glacosite | Glacosite | yes
+items_commodities_glow | Glow | no
+items_commodities_goldenmedmon | Golden Medmon | yes
+items_commodities_heartofthewoods | Heart of the Woods | no
+items_commodities_jaclium | Jaclium | no
+items_commodities_jaclium_ore | Jaclium (Ore) | no
+items_commodities_janalite | Janalite | yes
+items_commodities_kopionhorn_irradiated | Irradiated Kopion Horn | no
+items_commodities_mala | Mala | no
+items_commodities_marokgem | Marok Gem | no
+items_commodities_pingala | Pingala Seeds | no
+items_commodities_pitambu | Pitambu | no
+items_commodities_prota | Prota | no
+items_commodities_rantadung | Ranta Dung | no
+items_commodities_revenantpod | Revenant Pod | no
+items_commodities_sadaryx | Sadaryx | yes
+items_commodities_saldynium | Saldynium | no
+items_commodities_saldynium_ore | Saldynium (Ore) | no
+items_commodities_stonebugshell | Stone Bug Shell | no
+items_commodities_sunsetberry | Sunset Berries | no
+items_commodities_valakkaregg_irradiated | Irradiated Valakkar Egg | no
+items_commodities_valakkarfang_adult | Valakkar Fang (Adult) | no
+items_commodities_valakkarfang_adult_irradiated | Irradiated Valakkar Fang (Adult) | no
+items_commodities_valakkarfang_apex_irradiated | Irradiated Valakkar Fang (Apex) | no
+items_commodities_valakkarfang_juvenile | Valakkar Fang (Juvenile) | no
+items_commodities_valakkarfang_juvenile_irradiated | Irradiated Valakkar Fang (Juvenile) | no
+items_commodities_valakkarpearl_apex_irradiated | Irradiated Valakkar Pearl | no
+items_commodities_valakkarpearl_apex_irradiated_tier1 | Irradiated Valakkar Pearl (AAA) | no
+items_commodities_valakkarpearl_apex_irradiated_tier2 | Irradiated Valakkar Pearl (AA) | no
+items_commodities_valakkarpearl_apex_irradiated_tier3 | Irradiated Valakkar Pearl (A) | no
+items_commodities_valakkarpearl_apex_irradiated_tier4 | Irradiated Valakkar Pearl (B) | no
+items_commodities_valakkarpearl_apex_irradiated_tier5 | Irradiated Valakkar Pearl (C) | no
+items_commodities_wuotanseed | Wuotan Seed | no
+items_commodities_yormandi_eye | Yormandi Eye | no
+items_commodities_zip | Zip | no

--- a/tests/test_blueprint_list_type_tag.py
+++ b/tests/test_blueprint_list_type_tag.py
@@ -1,0 +1,85 @@
+"""Regression test for issue #101.
+
+The component Type element (Shield / Cooler / Power Plant / Quantum Drive /
+Radar) rendered on standalone component names but was missing from the
+component entries inside mission blueprint lists. Those list tags come from
+``entity_name_tags`` built in ``build_scitem_lookups``, which called
+``_component_name_tag`` WITHOUT ``component_type``. The fix derives the type
+from the entity's scitem subdir and passes it, so the Type element appears in
+both places when enabled.
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture(scope="module")
+def gen_module():
+    repo_root = Path(__file__).resolve().parent.parent
+    script_path = repo_root / "scripts" / "generate_enhancements_ini.py"
+    spec = importlib.util.spec_from_file_location(
+        "generate_enhancements_ini_type_tag_test", script_path,
+    )
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _type_enabled_config():
+    from src.utils.tag_builder import (
+        DEFAULT_COMPONENT_CLASS_MAPPING,
+        DEFAULT_COMPONENT_TYPE_MAPPING,
+        ElementSpec,
+        TagConfig,
+    )
+    return TagConfig(
+        elements=[
+            ElementSpec("class", True, "med"),     # MIL
+            ElementSpec("size", True, "sn"),        # S1
+            ElementSpec("grade", True, "letter"),   # A
+            ElementSpec("type", True, "short"),     # SH  (enabled, unlike default)
+        ],
+        separator="hyphen",
+        enclosing="square",
+        class_mapping={**DEFAULT_COMPONENT_CLASS_MAPPING, **DEFAULT_COMPONENT_TYPE_MAPPING},
+    )
+
+
+def _write_shield(tmp_path: Path, ref: str) -> Path:
+    subdir = tmp_path / "shieldgenerator"
+    subdir.mkdir(parents=True, exist_ok=True)
+    (subdir / "shield_test.xml").write_text(
+        f'<EntityClassDefinition.shield __ref="{ref}">'
+        '<SItemComponentParams Name="@nm_shield" Description="@ds_shield"/>'
+        '</EntityClassDefinition.shield>',
+        encoding="utf-8",
+    )
+    return tmp_path
+
+
+def test_blueprint_list_tag_carries_type_when_enabled(gen_module, tmp_path):
+    ref = "11111111-1111-1111-1111-111111111111"
+    _write_shield(tmp_path, ref)
+    loc = {"nm_shield": "Test Shield", "ds_shield": "Size: 1 Grade: A Class: Military"}
+
+    _mag, _names, _by_file, entity_name_tags = gen_module.build_scitem_lookups(
+        tmp_path, loc=loc, tag_config=_type_enabled_config()
+    )
+
+    assert ref in entity_name_tags, "shield component should produce a name tag"
+    tag = entity_name_tags[ref]
+    # The Type element (Shield Generator -> short "SH") is only present if
+    # build_scitem_lookups derived and passed component_type (the #101 fix).
+    assert "SH" in tag, f"type element missing from blueprint-list tag: {tag!r}"
+    # Sanity: the rest of the trio is there too.
+    assert "MIL" in tag and "S1" in tag and "A" in tag

--- a/tests/test_blueprint_list_type_tag.py
+++ b/tests/test_blueprint_list_type_tag.py
@@ -19,7 +19,7 @@ import pytest
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
 
-pytestmark = pytest.mark.unit
+pytestmark = [pytest.mark.unit, pytest.mark.regression]
 
 
 @pytest.fixture(scope="module")
@@ -82,4 +82,30 @@ def test_blueprint_list_tag_carries_type_when_enabled(gen_module, tmp_path):
     # build_scitem_lookups derived and passed component_type (the #101 fix).
     assert "SH" in tag, f"type element missing from blueprint-list tag: {tag!r}"
     # Sanity: the rest of the trio is there too.
+    assert "MIL" in tag and "S1" in tag and "A" in tag
+
+
+def test_no_type_when_not_in_type_subdir(gen_module, tmp_path):
+    """Negative control: an identical component placed OUTSIDE a type subdir
+    gets no Type element (comp_type stays ""), proving the Type token comes
+    specifically from the subdir derivation added in #101 — not from the
+    config or something else. The rest of the trip (MIL-S1-A) still renders."""
+    ref = "22222222-2222-2222-2222-222222222222"
+    subdir = tmp_path / "miscgear"  # deliberately NOT one of the 5 type subdirs
+    subdir.mkdir(parents=True, exist_ok=True)
+    (subdir / "thing.xml").write_text(
+        f'<EntityClassDefinition.shield __ref="{ref}">'
+        '<SItemComponentParams Name="@nm" Description="@ds"/>'
+        '</EntityClassDefinition.shield>',
+        encoding="utf-8",
+    )
+    loc = {"nm": "Test Thing", "ds": "Size: 1 Grade: A Class: Military"}
+
+    _mag, _names, _by_file, entity_name_tags = gen_module.build_scitem_lookups(
+        tmp_path, loc=loc, tag_config=_type_enabled_config()
+    )
+
+    assert ref in entity_name_tags
+    tag = entity_name_tags[ref]
+    assert "SH" not in tag, f"type element should be absent outside a type subdir: {tag!r}"
     assert "MIL" in tag and "S1" in tag and "A" in tag


### PR DESCRIPTION
## What

The component **Type** element (Shield / Cooler / Power Plant / Quantum Drive / Radar) showed on standalone component names but not on the component entries inside mission blueprint lists.

## Root cause

Blueprint-list tags come from `entity_name_tags`, built in `build_scitem_lookups`, which called `_component_name_tag(...)` **without** `component_type`. The standalone component path (`_run_gen_components`) passes `component_type`, so the Type element appeared there but never in the precomputed blueprint-list tags.

## Fix

- Derive the component type from the entity's scitem subdir in `build_scitem_lookups` and pass it to `_component_name_tag`.
- Extract the subdir -> type map to a shared module constant `_SUBDIR_TO_TYPE`, used by both the standalone generator and the lookup builder (DRY).

Default output is **unchanged**: the Type element is disabled by default, so only users who enable it see the new tag, now consistently in both places.

## Tests

`tests/test_blueprint_list_type_tag.py` builds a shield component under the `shieldgenerator/` subdir with the Type element enabled and asserts the blueprint-list tag now carries the type token. Existing `test_blueprint_pools.py` (27 cases) still passes.

Fixes #101.