### PR TITLE
fix: Config tab squishes under display scaling (#98)

### DIFF
--- a/src/gui/config_tab.py
+++ b/src/gui/config_tab.py
@@ -7,7 +7,7 @@ from datetime import datetime
 from PyQt6.QtWidgets import (
     QWidget, QVBoxLayout, QHBoxLayout, QGroupBox, QLineEdit,
     QPushButton, QLabel, QFileDialog, QMessageBox, QComboBox,
-    QCheckBox,
+    QCheckBox, QScrollArea, QFrame,
 )
 from PyQt6.QtCore import pyqtSignal, QTimer
 
@@ -51,7 +51,13 @@ class ConfigTab(QWidget):
         self.setup_ui()
 
     def setup_ui(self):
-        layout = QVBoxLayout(self)
+        # Build into an inner content widget that a QScrollArea hosts, so the
+        # tab degrades gracefully on short viewports (e.g. a 4K TV with
+        # Windows display scaling, which gives the app a small logical height
+        # and previously squished the Config tab — #98). The wrap is added at
+        # the end of this method.
+        content = QWidget()
+        layout = QVBoxLayout(content)
         layout.setContentsMargins(16, 16, 16, 16)
         layout.setSpacing(12)
 
@@ -367,6 +373,23 @@ class ConfigTab(QWidget):
         layout.addWidget(tools_group)
 
         layout.addStretch()
+
+        # Host the content in a scroll area. MainWindow adds the tab widget
+        # with stretch=1, so the scroll area fills the tab and this does NOT
+        # reintroduce the tab-switch resize that got the 1.4.x Enhancements
+        # scroll-area attempt reverted (#65). Keep the frame and viewport
+        # background clear so the themed background shows through rather than
+        # the scroll area painting its own Base colour.
+        scroll = QScrollArea()
+        scroll.setWidgetResizable(True)
+        scroll.setFrameShape(QFrame.Shape.NoFrame)
+        scroll.viewport().setAutoFillBackground(False)
+        content.setAutoFillBackground(False)
+        scroll.setWidget(content)
+
+        outer = QVBoxLayout(self)
+        outer.setContentsMargins(0, 0, 0, 0)
+        outer.addWidget(scroll)
 
     # ── Theme ────────────────────────────────────────────────────────────────
 

--- a/tests/fixtures/collection_items_groundtruth.txt
+++ b/tests/fixtures/collection_items_groundtruth.txt
@@ -1,0 +1,84 @@
+# Ground-truth fixture for the [Collection] item tagging feature (issue #97).
+#
+# Captured by hand by the maintainer from a LIVE global.ini export (May 2026,
+# ~1.4.2 era). These are the items that appear as objectives in Collection
+# missions and should receive the Collection flag in their display name.
+#
+# Purpose: validate the 1.5.0 generator that auto-discovers Collection-mission
+# items from DataForge. The generated output should flag (at least) every key
+# below. This file encodes the DURABLE part (which items qualify, and whether
+# each is also a crafting material), not a pinned rendered string, because the
+# rendered tag depends on user Tag Builder config.
+#
+# Rendering (the "Commodity Tagging" Tag Builder category, default config):
+#   - collection only          ->  <Name> <EM4>[Collection]</EM4>
+#   - crafting + collection     ->  <Name> <EM4>[CF|Collection]</EM4>
+#   - crafting only (NOT below) ->  <Name> <EM4>[CF]</EM4>   (unchanged today)
+# Collection flag forms (short/medium/long, default long):
+#   Col / Collect / Collection
+# Defaults: flag order CF|Collection, separator "|", emphasis EM4.
+#
+# Key namespaces: Mission_Item_*, items_commodities_*, harvestable_*. The same
+# physical item often has more than one key (e.g. Mission_Item_0183 and
+# items_commodities_decaripod are both "Decari Pod"); the tagger must cover all.
+#
+# Format (pipe-delimited):  key | base_name | also_crafting(yes/no)
+# 57 entries; 8 are also crafting materials (also_crafting=yes).
+
+Mission_Item_0183 | Decari Pod | no
+Mission_Item_0184 | Degnous Root | no
+Mission_Item_0186 | Golden Medmon | no
+Mission_Item_0191 | Pitambu | no
+Mission_Item_0192 | Prota | no
+Mission_Item_0195 | Sunset Berry | no
+Mission_Item_0214 | Compboard | no
+harvestable_Armillaria | Bluemoon Fungus | no
+items_commodities_amiantpod | Amiant Pod | no
+items_commodities_amioshiplague | Amioshi Plague | no
+items_commodities_beradom | Beradom | yes
+items_commodities_carinite | Carinite | yes
+items_commodities_carinite_pure | Carinite (Pure) | yes
+items_commodities_carinite_raw | Carinite (Raw) | no
+items_commodities_compboard | Compboard | no
+items_commodities_decaripod | Decari Pod | no
+items_commodities_degnousroot | Degnous Root | no
+items_commodities_dopple | Dopple | no
+items_commodities_feynmaline | Feynmaline | yes
+items_commodities_flareweedstalk | Flareweed Stalk | no
+items_commodities_fotiascrub | Fotia Seedpod | no
+items_commodities_freeze | Freeze | no
+items_commodities_glacosite | Glacosite | yes
+items_commodities_glow | Glow | no
+items_commodities_goldenmedmon | Golden Medmon | yes
+items_commodities_heartofthewoods | Heart of the Woods | no
+items_commodities_jaclium | Jaclium | no
+items_commodities_jaclium_ore | Jaclium (Ore) | no
+items_commodities_janalite | Janalite | yes
+items_commodities_kopionhorn_irradiated | Irradiated Kopion Horn | no
+items_commodities_mala | Mala | no
+items_commodities_marokgem | Marok Gem | no
+items_commodities_pingala | Pingala Seeds | no
+items_commodities_pitambu | Pitambu | no
+items_commodities_prota | Prota | no
+items_commodities_rantadung | Ranta Dung | no
+items_commodities_revenantpod | Revenant Pod | no
+items_commodities_sadaryx | Sadaryx | yes
+items_commodities_saldynium | Saldynium | no
+items_commodities_saldynium_ore | Saldynium (Ore) | no
+items_commodities_stonebugshell | Stone Bug Shell | no
+items_commodities_sunsetberry | Sunset Berries | no
+items_commodities_valakkaregg_irradiated | Irradiated Valakkar Egg | no
+items_commodities_valakkarfang_adult | Valakkar Fang (Adult) | no
+items_commodities_valakkarfang_adult_irradiated | Irradiated Valakkar Fang (Adult) | no
+items_commodities_valakkarfang_apex_irradiated | Irradiated Valakkar Fang (Apex) | no
+items_commodities_valakkarfang_juvenile | Valakkar Fang (Juvenile) | no
+items_commodities_valakkarfang_juvenile_irradiated | Irradiated Valakkar Fang (Juvenile) | no
+items_commodities_valakkarpearl_apex_irradiated | Irradiated Valakkar Pearl | no
+items_commodities_valakkarpearl_apex_irradiated_tier1 | Irradiated Valakkar Pearl (AAA) | no
+items_commodities_valakkarpearl_apex_irradiated_tier2 | Irradiated Valakkar Pearl (AA) | no
+items_commodities_valakkarpearl_apex_irradiated_tier3 | Irradiated Valakkar Pearl (A) | no
+items_commodities_valakkarpearl_apex_irradiated_tier4 | Irradiated Valakkar Pearl (B) | no
+items_commodities_valakkarpearl_apex_irradiated_tier5 | Irradiated Valakkar Pearl (C) | no
+items_commodities_wuotanseed | Wuotan Seed | no
+items_commodities_yormandi_eye | Yormandi Eye | no
+items_commodities_zip | Zip | no


### PR DESCRIPTION
## What

Under Windows display scaling on a large display (e.g. a 4K TV, the "make text readable" zoom), the app gets a small logical height and the Config tab's sections (appearance, channel, sources, SC path, P4K, data dir, cache dir, buttons) squished with no way to reach the lower ones. The Enhancements tab had the same issue and was fixed in 1.4.2; the Config tab was never given the same treatment (#98).

## Fix

Host the Config tab content in a `QScrollArea` (`setWidgetResizable(True)`) so it scrolls instead of compressing.

Two lessons from the #65 history (where a naive scroll-area wrap on the Enhancements tab was reverted) are addressed here:
- **Tab-switch resize:** MainWindow adds the `QTabWidget` with `stretch=1`, so the scroll area fills the tab and does not drive the tab widget's size from content `sizeHint`.
- **Background paint:** frame shape is `NoFrame` and the viewport `autoFillBackground` is off, so the themed background shows through instead of the scroll area's own Base colour.

## Verification

GUI, so manually tested per the repo convention. Confirmed by headless construction (offscreen Qt) that the tab hosts a resizable `QScrollArea` with the content widget set. **Please visually verify under display scaling on both light and dark themes** (that's the exact condition from the report).

Fixes #98.