### PR TITLE
feat: migrate user data when the data folder changes (#103)

### DIFF
--- a/src/gui/config_tab.py
+++ b/src/gui/config_tab.py
@@ -13,6 +13,7 @@ from PyQt6.QtCore import pyqtSignal, QTimer
 
 from src.gui.theme import AVAILABLE_THEMES, THEME_LIGHT, THEME_DARK, THEME_SCLE, THEME_ODW
 from src.utils.settings import AppSettings
+from src.utils.user_ini_manager import migrate_user_data_dir
 
 logger = logging.getLogger(__name__)
 
@@ -468,8 +469,44 @@ class ConfigTab(QWidget):
         self.data_dir_input.setText(os.path.normpath(str(new_dir)))
         if new_dir != current_dir:
             logger.info(f"Smart Citizen data folder changed: {current_dir} → {new_dir}")
+            self._maybe_migrate_data(current_dir, new_dir)
             self._refresh_p4k_status()
             self.data_dir_changed.emit(str(new_dir))
+
+    def _maybe_migrate_data(self, old_dir, new_dir) -> None:
+        """Offer to copy existing data (overrides, backups, cached strings)
+        from the previous data folder into the new one, so favourites and
+        edits follow the move instead of being left behind (issue #103).
+        Copies (never overwrites), so the originals remain as a safety net."""
+        try:
+            old_path = Path(old_dir)
+            if not old_path.exists() or not any(old_path.iterdir()):
+                return
+        except OSError:
+            return
+        reply = QMessageBox.question(
+            self,
+            "Move Your Data?",
+            "Copy your existing Smart Citizen data (overrides, backups, cached "
+            f"strings) from\n\n{old_dir}\n\nto the new folder\n\n{new_dir}?\n\n"
+            "Files already in the new folder are kept, and the originals are "
+            "left in place.",
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+            QMessageBox.StandardButton.Yes,
+        )
+        if reply != QMessageBox.StandardButton.Yes:
+            return
+        try:
+            count = migrate_user_data_dir(old_dir, new_dir)
+            QMessageBox.information(
+                self, "Data Migrated",
+                f"Copied {count} file(s) into the new data folder.",
+            )
+        except Exception as e:  # pragma: no cover - defensive UI guard
+            logger.exception(f"Data migration failed: {e}")
+            QMessageBox.warning(
+                self, "Migration Failed", f"Could not migrate your data:\n{e}"
+            )
 
     def _browse_data_dir(self):
         start_dir = self.data_dir_input.text().strip() or str(AppSettings.get_user_data_dir())
@@ -487,6 +524,7 @@ class ConfigTab(QWidget):
         self.data_dir_input.setText(os.path.normpath(str(new_dir)))
         if new_dir != current_dir:
             logger.info(f"Smart Citizen data folder reset to default: {new_dir}")
+            self._maybe_migrate_data(current_dir, new_dir)
             self._refresh_p4k_status()
             self.data_dir_changed.emit(str(new_dir))
 

--- a/src/utils/user_ini_manager.py
+++ b/src/utils/user_ini_manager.py
@@ -1,5 +1,6 @@
 """User INI persistence and import utilities."""
 import logging
+import shutil
 from datetime import datetime
 from pathlib import Path
 from typing import Dict, List, Optional
@@ -9,6 +10,45 @@ from src.parser.ini_parser import parse_ini_file
 from src.utils.perf import timed
 
 logger = logging.getLogger(__name__)
+
+
+def migrate_user_data_dir(old_root: "str | Path", new_root: "str | Path") -> int:
+    """Copy user data from ``old_root`` into ``new_root`` after the user moves
+    the Smart Citizen data folder (issue #103).
+
+    Copies every file under ``old_root`` to the matching path under
+    ``new_root``, **merging** rather than overwriting: any file that already
+    exists at the destination is left untouched, so data already in the new
+    location always wins. The originals are left in place (copy, not move),
+    so a mistaken move is recoverable.
+
+    Returns the number of files copied. A no-op (returns 0) when the old root
+    is missing or resolves to the same directory as the new root.
+    """
+    old_root = Path(old_root)
+    new_root = Path(new_root)
+    try:
+        if not old_root.exists() or old_root.resolve() == new_root.resolve():
+            return 0
+    except OSError:
+        return 0
+
+    copied = 0
+    for src in old_root.rglob("*"):
+        if src.is_dir():
+            continue
+        rel = src.relative_to(old_root)
+        dest = new_root / rel
+        if dest.exists():
+            continue  # never clobber data already present in the new location
+        try:
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(src, dest)
+            copied += 1
+        except OSError as e:
+            logger.warning(f"Could not migrate {src} -> {dest}: {e}")
+    logger.info(f"Migrated {copied} file(s) from {old_root} to {new_root}")
+    return copied
 
 
 def reset_user_ini(user_ini_path: Path, backup: bool = True) -> Optional[Path]:

--- a/src/utils/user_ini_manager.py
+++ b/src/utils/user_ini_manager.py
@@ -24,19 +24,36 @@ def migrate_user_data_dir(old_root: "str | Path", new_root: "str | Path") -> int
 
     Returns the number of files copied. A no-op (returns 0) when the old root
     is missing or resolves to the same directory as the new root.
+
+    Handles the case where the new folder is nested inside the old one: the
+    file list is snapshotted before any copy (so freshly-written files can't
+    be fed back into a lazy walk), and any source already under the
+    destination is skipped (so the new folder's own contents aren't recursively
+    re-copied into themselves).
     """
     old_root = Path(old_root)
     new_root = Path(new_root)
     try:
-        if not old_root.exists() or old_root.resolve() == new_root.resolve():
-            return 0
+        old_resolved = old_root.resolve()
+        new_resolved = new_root.resolve()
     except OSError:
+        return 0
+    if not old_root.exists() or old_resolved == new_resolved:
         return 0
 
     copied = 0
-    for src in old_root.rglob("*"):
+    # Snapshot up front — if new_root is nested in old_root, copying into it
+    # mid-walk would otherwise let a lazy rglob re-yield the new files.
+    for src in list(old_root.rglob("*")):
         if src.is_dir():
             continue
+        # Skip anything already under the destination (the new-inside-old
+        # case), so we don't recursively re-copy the new folder's contents.
+        try:
+            src.resolve().relative_to(new_resolved)
+            continue  # src is inside new_root → leave it alone
+        except (ValueError, OSError):
+            pass  # not under new_root → migrate it
         rel = src.relative_to(old_root)
         dest = new_root / rel
         if dest.exists():

--- a/tests/fixtures/collection_items_groundtruth.txt
+++ b/tests/fixtures/collection_items_groundtruth.txt
@@ -1,0 +1,84 @@
+# Ground-truth fixture for the [Collection] item tagging feature (issue #97).
+#
+# Captured by hand by the maintainer from a LIVE global.ini export (May 2026,
+# ~1.4.2 era). These are the items that appear as objectives in Collection
+# missions and should receive the Collection flag in their display name.
+#
+# Purpose: validate the 1.5.0 generator that auto-discovers Collection-mission
+# items from DataForge. The generated output should flag (at least) every key
+# below. This file encodes the DURABLE part (which items qualify, and whether
+# each is also a crafting material), not a pinned rendered string, because the
+# rendered tag depends on user Tag Builder config.
+#
+# Rendering (the "Commodity Tagging" Tag Builder category, default config):
+#   - collection only          ->  <Name> <EM4>[Collection]</EM4>
+#   - crafting + collection     ->  <Name> <EM4>[CF|Collection]</EM4>
+#   - crafting only (NOT below) ->  <Name> <EM4>[CF]</EM4>   (unchanged today)
+# Collection flag forms (short/medium/long, default long):
+#   Col / Collect / Collection
+# Defaults: flag order CF|Collection, separator "|", emphasis EM4.
+#
+# Key namespaces: Mission_Item_*, items_commodities_*, harvestable_*. The same
+# physical item often has more than one key (e.g. Mission_Item_0183 and
+# items_commodities_decaripod are both "Decari Pod"); the tagger must cover all.
+#
+# Format (pipe-delimited):  key | base_name | also_crafting(yes/no)
+# 57 entries; 8 are also crafting materials (also_crafting=yes).
+
+Mission_Item_0183 | Decari Pod | no
+Mission_Item_0184 | Degnous Root | no
+Mission_Item_0186 | Golden Medmon | no
+Mission_Item_0191 | Pitambu | no
+Mission_Item_0192 | Prota | no
+Mission_Item_0195 | Sunset Berry | no
+Mission_Item_0214 | Compboard | no
+harvestable_Armillaria | Bluemoon Fungus | no
+items_commodities_amiantpod | Amiant Pod | no
+items_commodities_amioshiplague | Amioshi Plague | no
+items_commodities_beradom | Beradom | yes
+items_commodities_carinite | Carinite | yes
+items_commodities_carinite_pure | Carinite (Pure) | yes
+items_commodities_carinite_raw | Carinite (Raw) | no
+items_commodities_compboard | Compboard | no
+items_commodities_decaripod | Decari Pod | no
+items_commodities_degnousroot | Degnous Root | no
+items_commodities_dopple | Dopple | no
+items_commodities_feynmaline | Feynmaline | yes
+items_commodities_flareweedstalk | Flareweed Stalk | no
+items_commodities_fotiascrub | Fotia Seedpod | no
+items_commodities_freeze | Freeze | no
+items_commodities_glacosite | Glacosite | yes
+items_commodities_glow | Glow | no
+items_commodities_goldenmedmon | Golden Medmon | yes
+items_commodities_heartofthewoods | Heart of the Woods | no
+items_commodities_jaclium | Jaclium | no
+items_commodities_jaclium_ore | Jaclium (Ore) | no
+items_commodities_janalite | Janalite | yes
+items_commodities_kopionhorn_irradiated | Irradiated Kopion Horn | no
+items_commodities_mala | Mala | no
+items_commodities_marokgem | Marok Gem | no
+items_commodities_pingala | Pingala Seeds | no
+items_commodities_pitambu | Pitambu | no
+items_commodities_prota | Prota | no
+items_commodities_rantadung | Ranta Dung | no
+items_commodities_revenantpod | Revenant Pod | no
+items_commodities_sadaryx | Sadaryx | yes
+items_commodities_saldynium | Saldynium | no
+items_commodities_saldynium_ore | Saldynium (Ore) | no
+items_commodities_stonebugshell | Stone Bug Shell | no
+items_commodities_sunsetberry | Sunset Berries | no
+items_commodities_valakkaregg_irradiated | Irradiated Valakkar Egg | no
+items_commodities_valakkarfang_adult | Valakkar Fang (Adult) | no
+items_commodities_valakkarfang_adult_irradiated | Irradiated Valakkar Fang (Adult) | no
+items_commodities_valakkarfang_apex_irradiated | Irradiated Valakkar Fang (Apex) | no
+items_commodities_valakkarfang_juvenile | Valakkar Fang (Juvenile) | no
+items_commodities_valakkarfang_juvenile_irradiated | Irradiated Valakkar Fang (Juvenile) | no
+items_commodities_valakkarpearl_apex_irradiated | Irradiated Valakkar Pearl | no
+items_commodities_valakkarpearl_apex_irradiated_tier1 | Irradiated Valakkar Pearl (AAA) | no
+items_commodities_valakkarpearl_apex_irradiated_tier2 | Irradiated Valakkar Pearl (AA) | no
+items_commodities_valakkarpearl_apex_irradiated_tier3 | Irradiated Valakkar Pearl (A) | no
+items_commodities_valakkarpearl_apex_irradiated_tier4 | Irradiated Valakkar Pearl (B) | no
+items_commodities_valakkarpearl_apex_irradiated_tier5 | Irradiated Valakkar Pearl (C) | no
+items_commodities_wuotanseed | Wuotan Seed | no
+items_commodities_yormandi_eye | Yormandi Eye | no
+items_commodities_zip | Zip | no

--- a/tests/test_user_data_dir_migration.py
+++ b/tests/test_user_data_dir_migration.py
@@ -1,0 +1,66 @@
+"""Tests for migrate_user_data_dir (issue #103).
+
+When the user moves the Smart Citizen data folder, their existing overrides /
+backups / cached strings should follow the move instead of being left behind.
+The helper copies (merge, never overwrite) so data already in the new location
+wins and the originals survive as a safety net.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+from src.utils.user_ini_manager import migrate_user_data_dir  # noqa: E402
+
+pytestmark = pytest.mark.unit
+
+
+def _seed(root: Path) -> None:
+    (root / "LIVE").mkdir(parents=True)
+    (root / "LIVE" / "user.ini").write_text("vehicle_NameX= My Ship\n", encoding="utf-8")
+    (root / "LIVE" / "backups").mkdir()
+    (root / "LIVE" / "backups" / "global.ini.bak").write_text("backup", encoding="utf-8")
+
+
+def test_copies_all_files_to_new_location(tmp_path):
+    old = tmp_path / "old"
+    new = tmp_path / "new"
+    _seed(old)
+
+    copied = migrate_user_data_dir(old, new)
+
+    assert copied == 2
+    assert (new / "LIVE" / "user.ini").read_text(encoding="utf-8") == "vehicle_NameX= My Ship\n"
+    assert (new / "LIVE" / "backups" / "global.ini.bak").exists()
+    # originals are left in place (copy, not move)
+    assert (old / "LIVE" / "user.ini").exists()
+
+
+def test_never_overwrites_existing_destination_files(tmp_path):
+    old = tmp_path / "old"
+    new = tmp_path / "new"
+    _seed(old)
+    # Pre-existing data in the new location must win.
+    (new / "LIVE").mkdir(parents=True)
+    (new / "LIVE" / "user.ini").write_text("KEEP ME", encoding="utf-8")
+
+    copied = migrate_user_data_dir(old, new)
+
+    assert (new / "LIVE" / "user.ini").read_text(encoding="utf-8") == "KEEP ME"
+    assert (new / "LIVE" / "backups" / "global.ini.bak").exists()  # non-conflicting file still copied
+    assert copied == 1
+
+
+def test_noop_when_same_dir(tmp_path):
+    old = tmp_path / "d"
+    _seed(old)
+    assert migrate_user_data_dir(old, old) == 0
+
+
+def test_noop_when_old_missing(tmp_path):
+    assert migrate_user_data_dir(tmp_path / "does_not_exist", tmp_path / "new") == 0

--- a/tests/test_user_data_dir_migration.py
+++ b/tests/test_user_data_dir_migration.py
@@ -64,3 +64,21 @@ def test_noop_when_same_dir(tmp_path):
 
 def test_noop_when_old_missing(tmp_path):
     assert migrate_user_data_dir(tmp_path / "does_not_exist", tmp_path / "new") == 0
+
+
+def test_new_nested_inside_old_terminates_without_recursion(tmp_path):
+    """If the new folder is a subdirectory of the old one, the migration must
+    copy the old data once and not recursively re-copy into ever-deeper
+    nesting (the lazy-walk trap)."""
+    old = tmp_path / "old"
+    _seed(old)                 # old/LIVE/user.ini + old/LIVE/backups/global.ini.bak
+    new = old / "moved"        # new is INSIDE old
+
+    copied = migrate_user_data_dir(old, new)
+
+    # The two seeded files land under new exactly once.
+    assert copied == 2
+    assert (new / "LIVE" / "user.ini").exists()
+    assert (new / "LIVE" / "backups" / "global.ini.bak").exists()
+    # No pathological deeper nesting (new/moved/… must not exist).
+    assert not (new / "moved").exists()


### PR DESCRIPTION
## What

When the user moves the Smart Citizen data folder, their existing overrides / backups / cached strings stayed behind in the old location, so favourites and edits appeared to vanish. This adds a migration step.

## Changes

- `migrate_user_data_dir(old, new)` in `user_ini_manager.py`: copies every file from the old data folder into the new one, **merging** (never overwriting a file already present in the new location) and leaving the originals in place as a safety net.
- The Config tab offers it via a confirmation prompt whenever the data folder is changed (`_save_data_dir`) or reset to default (`_reset_data_dir`).

## Scope note (the other half of #103)

#103 also asks that the data-folder location survive uninstall -> reinstall. That half is installer-side: the installer already **reads** the `user_data_dir` override, and the Inno uninstall only cleans `\cache` (not `user.ini` / backups), so the QSettings override should already persist. The reported loss most likely came from a portable-vs-installer location difference. Confirming/fixing it needs the real uninstall/reinstall cycle (Inno Setup), which can't be exercised here, so it's left as a follow-up. This PR delivers the explicitly-requested "migrate the previous directory's contents" behavior.

## Tests

`tests/test_user_data_dir_migration.py` (copies all files, never overwrites existing, no-op on same dir / missing source). Config tab construction smoke-tested headless.

Addresses #103.