### PR TITLE
feat: Commodity Tagging — Collection flag + configurable forms (#97)

### DIFF
--- a/scripts/generate_enhancements_ini.py
+++ b/scripts/generate_enhancements_ini.py
@@ -3324,6 +3324,74 @@ def _condense_crafted_items(items_list: list[tuple[str, str]]) -> list[str]:
     return lines
 
 
+# Loc keys for items that appear as Collection-mission objectives. These get
+# the Collection flag in their commodity tag (#97). Maintained list (the
+# authoritative ground truth lives in tests/fixtures/collection_items_
+# groundtruth.txt); auto-discovery of these from the DataForge mission graph
+# is a planned follow-up so the list stays current as CIG adds items.
+COLLECTION_ITEM_KEYS: frozenset[str] = frozenset({
+    "Mission_Item_0183", "Mission_Item_0184", "Mission_Item_0186",
+    "Mission_Item_0191", "Mission_Item_0192", "Mission_Item_0195",
+    "Mission_Item_0214", "harvestable_Armillaria",
+    "items_commodities_amiantpod", "items_commodities_amioshiplague",
+    "items_commodities_beradom", "items_commodities_carinite",
+    "items_commodities_carinite_pure", "items_commodities_carinite_raw",
+    "items_commodities_compboard", "items_commodities_decaripod",
+    "items_commodities_degnousroot", "items_commodities_dopple",
+    "items_commodities_feynmaline", "items_commodities_flareweedstalk",
+    "items_commodities_fotiascrub", "items_commodities_freeze",
+    "items_commodities_glacosite", "items_commodities_glow",
+    "items_commodities_goldenmedmon", "items_commodities_heartofthewoods",
+    "items_commodities_jaclium", "items_commodities_jaclium_ore",
+    "items_commodities_janalite", "items_commodities_kopionhorn_irradiated",
+    "items_commodities_mala", "items_commodities_marokgem",
+    "items_commodities_pingala", "items_commodities_pitambu",
+    "items_commodities_prota", "items_commodities_rantadung",
+    "items_commodities_revenantpod", "items_commodities_sadaryx",
+    "items_commodities_saldynium", "items_commodities_saldynium_ore",
+    "items_commodities_stonebugshell", "items_commodities_sunsetberry",
+    "items_commodities_valakkaregg_irradiated",
+    "items_commodities_valakkarfang_adult",
+    "items_commodities_valakkarfang_adult_irradiated",
+    "items_commodities_valakkarfang_apex_irradiated",
+    "items_commodities_valakkarfang_juvenile",
+    "items_commodities_valakkarfang_juvenile_irradiated",
+    "items_commodities_valakkarpearl_apex_irradiated",
+    "items_commodities_valakkarpearl_apex_irradiated_tier1",
+    "items_commodities_valakkarpearl_apex_irradiated_tier2",
+    "items_commodities_valakkarpearl_apex_irradiated_tier3",
+    "items_commodities_valakkarpearl_apex_irradiated_tier4",
+    "items_commodities_valakkarpearl_apex_irradiated_tier5",
+    "items_commodities_wuotanseed", "items_commodities_yormandi_eye",
+    "items_commodities_zip",
+})
+
+
+def _commodity_tag(cfg, *, crafting: bool, collection: bool) -> str:
+    """Render the commodity name tag for the applicable flags, wrapped in EM4.
+
+    Builds the values dict from which flags apply and lets render_tag honour
+    the user's config (element enabled-state, order, separator, style). An
+    item that is both crafting and collection yields e.g. ``<EM4>[CF|
+    Collection]</EM4>``; a single-flag item drops the empty flag and stays
+    ``<EM4>[CF]</EM4>`` / ``<EM4>[Collection]</EM4>``. Returns "" when no flag
+    resolves (e.g. the user disabled both elements)."""
+    values: dict[str, str] = {}
+    if crafting:
+        values["label"] = "Crafting"
+    if collection:
+        values["collection"] = "Collection"
+    if not values:
+        return ""
+    if cfg is not None and render_tag is not None:
+        tag_str = render_tag(cfg, values)
+    else:
+        # Defensive fallback when tag_builder isn't importable.
+        parts = ([("CF")] if crafting else []) + (["Collection"] if collection else [])
+        tag_str = "[" + "|".join(parts) + "]" if parts else ""
+    return f"<EM4>{tag_str}</EM4>" if tag_str else ""
+
+
 def scan_crafting_blueprints(
     bp_dir: Path,
     carryables_dir: Path,
@@ -3425,11 +3493,17 @@ def scan_crafting_blueprints(
             base_name = loc.get(name_key, "")
             if base_name and name_key not in out:
                 cfg = tag_config or DEFAULT_TAG_CONFIGS.get("commodities")
-                tag_str = render_tag(cfg, {"label": "Crafting"}) if cfg else "[CF]"
-                if cfg and getattr(cfg, "placement", "append") == "prepend":
-                    out[name_key] = f"<EM4>{tag_str}</EM4> {base_name}"
+                # Crafting commodity; also flag Collection if it's a
+                # Collection-mission objective → "[CF|Collection]" (#97).
+                tag = _commodity_tag(
+                    cfg, crafting=True, collection=name_key in COLLECTION_ITEM_KEYS,
+                )
+                if not tag:
+                    out[name_key] = base_name
+                elif cfg and getattr(cfg, "placement", "append") == "prepend":
+                    out[name_key] = f"{tag} {base_name}"
                 else:
-                    out[name_key] = f"{base_name} <EM4>{tag_str}</EM4>"
+                    out[name_key] = f"{base_name} {tag}"
 
             base_desc = loc.get(desc_key, "")
             if base_desc and desc_key not in out:
@@ -3441,6 +3515,28 @@ def scan_crafting_blueprints(
             f"(first few: {', '.join(skipped_no_loc[:8])})"
         )
     logger.info(f"Crafting: {len(out)} commodity entries augmented from {len(commodity_items)} commodities")
+
+    # Collection-only items: Collection-mission objectives that are NOT
+    # crafting materials (so the loop above never touched them). Tag them with
+    # the Collection flag alone, e.g. "[Collection]" (#97).
+    cfg = tag_config or DEFAULT_TAG_CONFIGS.get("commodities")
+    collection_only = 0
+    for name_key in COLLECTION_ITEM_KEYS:
+        if name_key in out:
+            continue
+        base_name = loc.get(name_key, "")
+        if not base_name:
+            continue
+        tag = _commodity_tag(cfg, crafting=False, collection=True)
+        if not tag:
+            continue
+        if cfg and getattr(cfg, "placement", "append") == "prepend":
+            out[name_key] = f"{tag} {base_name}"
+        else:
+            out[name_key] = f"{base_name} {tag}"
+        collection_only += 1
+    if collection_only:
+        logger.info(f"Collection: {collection_only} collection-only items tagged")
 
     # Build journal output (separate dict for independent toggling)
     out_journal: dict[str, str] = {}

--- a/scripts/generate_enhancements_ini.py
+++ b/scripts/generate_enhancements_ini.py
@@ -3387,9 +3387,18 @@ def _commodity_tag(cfg, *, crafting: bool, collection: bool) -> str:
         tag_str = render_tag(cfg, values)
     else:
         # Defensive fallback when tag_builder isn't importable.
-        parts = ([("CF")] if crafting else []) + (["Collection"] if collection else [])
+        parts = (["CF"] if crafting else []) + (["Collection"] if collection else [])
         tag_str = "[" + "|".join(parts) + "]" if parts else ""
     return f"<EM4>{tag_str}</EM4>" if tag_str else ""
+
+
+def _place_commodity_tag(base_name: str, tag: str, cfg) -> str:
+    """Combine an item name and its commodity tag per the config's placement
+    (prepend = tag before the name, otherwise after). Shared by the crafting
+    loop and the collection-only pass so the placement rule lives in one spot."""
+    if cfg and getattr(cfg, "placement", "append") == "prepend":
+        return f"{tag} {base_name}"
+    return f"{base_name} {tag}"
 
 
 def scan_crafting_blueprints(
@@ -3498,12 +3507,7 @@ def scan_crafting_blueprints(
                 tag = _commodity_tag(
                     cfg, crafting=True, collection=name_key in COLLECTION_ITEM_KEYS,
                 )
-                if not tag:
-                    out[name_key] = base_name
-                elif cfg and getattr(cfg, "placement", "append") == "prepend":
-                    out[name_key] = f"{tag} {base_name}"
-                else:
-                    out[name_key] = f"{base_name} {tag}"
+                out[name_key] = _place_commodity_tag(base_name, tag, cfg) if tag else base_name
 
             base_desc = loc.get(desc_key, "")
             if base_desc and desc_key not in out:
@@ -3530,10 +3534,7 @@ def scan_crafting_blueprints(
         tag = _commodity_tag(cfg, crafting=False, collection=True)
         if not tag:
             continue
-        if cfg and getattr(cfg, "placement", "append") == "prepend":
-            out[name_key] = f"{tag} {base_name}"
-        else:
-            out[name_key] = f"{base_name} {tag}"
+        out[name_key] = _place_commodity_tag(base_name, tag, cfg)
         collection_only += 1
     if collection_only:
         logger.info(f"Collection: {collection_only} collection-only items tagged")

--- a/src/gui/enhancements_tab.py
+++ b/src/gui/enhancements_tab.py
@@ -728,6 +728,11 @@ class _TagBuilderPage(QWidget):
         ctrl_grid.addWidget(QLabel("Separator:"), 0, 0)
         self.sep_combo = QComboBox()
         for key, label, _ in SEPARATORS:
+            # Commodities can't use "none": with two flags it would mash them
+            # into "[CFCollection]", and get_tag_config force-upgrades a stored
+            # "none" to "pipe", so don't offer it here (#97).
+            if self.category == "commodities" and key == "none":
+                continue
             self.sep_combo.addItem(label, userData=key)
         self._select_combo(self.sep_combo, config.separator)
         self.sep_combo.currentIndexChanged.connect(self._on_sep_changed)

--- a/src/gui/enhancements_tab.py
+++ b/src/gui/enhancements_tab.py
@@ -12,7 +12,7 @@ from PyQt6.QtWidgets import (
 from src.gui.tag_mapping_dialog import TagMappingDialog
 from src.utils.settings import AppSettings
 from src.utils.tag_builder import (
-    CATEGORIES, DEFAULT_MAPPINGS, ELEMENT_LABELS, ENCLOSINGS, MAPPED_KINDS,
+    CATEGORIES, ELEMENT_LABELS, ENCLOSINGS,
     PLACEMENTS, SEPARATORS, STYLES_BY_KIND, TagConfig, default_config,
     render_tag,
 )

--- a/src/gui/enhancements_tab.py
+++ b/src/gui/enhancements_tab.py
@@ -12,7 +12,7 @@ from PyQt6.QtWidgets import (
 from src.gui.tag_mapping_dialog import TagMappingDialog
 from src.utils.settings import AppSettings
 from src.utils.tag_builder import (
-    CATEGORIES, ELEMENT_LABELS, ENCLOSINGS,
+    CATEGORIES, ELEMENT_LABELS, ENCLOSINGS, MAPPED_KIND_NAMES,
     PLACEMENTS, SEPARATORS, STYLES_BY_KIND, TagConfig, default_config,
     render_tag,
 )
@@ -619,7 +619,7 @@ class _ElementRow(QWidget):
         # Only kinds backed by the per-category variant mapping get the
         # mapping-edit button — size and grade are derived from raw values
         # and have nothing user-editable beyond style.
-        if spec.kind in ("class", "ordinance", "damage", "type", "label", "collection"):
+        if spec.kind in MAPPED_KIND_NAMES:
             edit_btn = QPushButton("Edit mapping…")
             _tips = {
                 "ordinance": ("Edit the Short / Medium / Long text used for each tracking "

--- a/src/gui/enhancements_tab.py
+++ b/src/gui/enhancements_tab.py
@@ -25,7 +25,7 @@ _PREVIEW_VALUES: dict[str, dict[str, str]] = {
     "components":   {"class": "Military", "size": "2", "grade": "A", "type": "Shield Generator"},
     "missiles":     {"ordinance": "Infrared", "size": "1"},
     "ship_weapons": {"damage": "Energy",   "size": "2"},
-    "commodities":  {"label": "Crafting"},
+    "commodities":  {"label": "Crafting", "collection": "Collection"},
 }
 _PREVIEW_NAMES: dict[str, str] = {
     "components":   "FR-76",
@@ -552,11 +552,12 @@ class _ElementRow(QWidget):
     # preview row below. Unmapped kinds (size, grade) ignore this and use
     # the static STYLES_BY_KIND labels.
     _SAMPLE_MAPPED_RAW: dict[str, str] = {
-        "class":     "Military",
-        "ordinance": "Infrared",
-        "damage":    "Energy",
-        "type":      "Shield Generator",
-        "label":     "Crafting",
+        "class":      "Military",
+        "ordinance":  "Infrared",
+        "damage":     "Energy",
+        "type":       "Shield Generator",
+        "label":      "Crafting",
+        "collection": "Collection",
     }
 
     def __init__(self, spec, mapping: dict | None = None,
@@ -618,7 +619,7 @@ class _ElementRow(QWidget):
         # Only kinds backed by the per-category variant mapping get the
         # mapping-edit button — size and grade are derived from raw values
         # and have nothing user-editable beyond style.
-        if spec.kind in ("class", "ordinance", "damage", "type", "label"):
+        if spec.kind in ("class", "ordinance", "damage", "type", "label", "collection"):
             edit_btn = QPushButton("Edit mapping…")
             _tips = {
                 "ordinance": ("Edit the Short / Medium / Long text used for each tracking "
@@ -629,6 +630,8 @@ class _ElementRow(QWidget):
                               "type (e.g. Shield Generator → SH / SHLD / Shield)."),
                 "label":     ("Edit the Short / Medium / Long text for the crafting label "
                               "(e.g. Crafting → CF / Craft / Crafting)."),
+                "collection": ("Edit the Short / Medium / Long text for the collection label "
+                               "(e.g. Collection → Col / Collect / Collection)."),
             }
             edit_btn.setToolTip(_tips.get(spec.kind,
                 "Edit the Short / Medium / Long text used for each class "

--- a/src/utils/settings.py
+++ b/src/utils/settings.py
@@ -320,6 +320,13 @@ class AppSettings:
             return default_config(category)
         AppSettings._migrate_tag_config_mapping(category, cfg)
         AppSettings._backfill_new_elements(category, cfg)
+        # 1.5.0: commodities gained a second flag (Collection). A stored
+        # single-element config used separator "none", which would mash the
+        # two flags together as "[CFCollection]". Pipe is the intended joiner,
+        # and the separator was meaningless for the old single-element tag, so
+        # upgrading it is safe (#97).
+        if category == "commodities" and cfg.separator == "none":
+            cfg.separator = "pipe"
         return cfg
 
     @staticmethod

--- a/src/utils/tag_builder.py
+++ b/src/utils/tag_builder.py
@@ -206,6 +206,12 @@ DEFAULT_KIND_MAPPINGS: dict[str, dict[str, tuple[str, str, str]]] = {
     "collection": DEFAULT_COMMODITY_COLLECTION_MAPPING,
 }
 
+# Element kinds whose value resolves through a variant mapping (vs. derived
+# kinds like size/grade). Single source of truth — the renderer and the UI's
+# mapping-edit affordances both key off this so adding a mapped kind only
+# means adding it to DEFAULT_KIND_MAPPINGS above.
+MAPPED_KIND_NAMES: frozenset[str] = frozenset(DEFAULT_KIND_MAPPINGS)
+
 
 # ── Data model ───────────────────────────────────────────────────────────────
 
@@ -372,7 +378,7 @@ def _style_value(kind: str, style: str, raw: str,
             return f"Grade {raw}"
         return raw  # "letter"
 
-    if kind in ("class", "ordinance", "damage", "label", "type", "collection"):
+    if kind in MAPPED_KIND_NAMES:
         variants = mapping.get(raw)
         if variants is None:
             # Unknown raw value — surface it verbatim so the user can edit

--- a/src/utils/tag_builder.py
+++ b/src/utils/tag_builder.py
@@ -35,15 +35,6 @@ CATEGORY_ELEMENT_KINDS: dict[str, tuple[str, ...]] = {
     "commodities":  ("label", "collection"),
 }
 
-# Which element kinds resolve through the per-category `class_mapping` dict.
-# (The mapping field is named `class_mapping` historically but holds the
-# variants for whichever kind the category exposes.)
-MAPPED_KINDS: dict[str, str] = {
-    "components":   "class",
-    "missiles":     "ordinance",
-    "ship_weapons": "damage",
-    "commodities":  "label",
-}
 
 
 # ── Style tables ──────────────────────────────────────────────────────────────
@@ -204,13 +195,6 @@ DEFAULT_COMMODITY_LABEL_MAPPING: dict[str, tuple[str, str, str]] = {
 # <EM4>[…]</EM4> wrapper (e.g. "[CF|Collection]") when an item is both (#97).
 DEFAULT_COMMODITY_COLLECTION_MAPPING: dict[str, tuple[str, str, str]] = {
     "Collection": ("Col", "Collect", "Collection"),
-}
-
-DEFAULT_MAPPINGS: dict[str, dict[str, tuple[str, str, str]]] = {
-    "components":   DEFAULT_COMPONENT_CLASS_MAPPING,
-    "missiles":     DEFAULT_MISSILE_ORDINANCE_MAPPING,
-    "ship_weapons": DEFAULT_SHIP_WEAPON_DAMAGE_MAPPING,
-    "commodities":  DEFAULT_COMMODITY_LABEL_MAPPING,
 }
 
 DEFAULT_KIND_MAPPINGS: dict[str, dict[str, tuple[str, str, str]]] = {

--- a/src/utils/tag_builder.py
+++ b/src/utils/tag_builder.py
@@ -32,7 +32,7 @@ CATEGORY_ELEMENT_KINDS: dict[str, tuple[str, ...]] = {
     "components":   ("class", "size", "grade", "type"),
     "missiles":     ("ordinance", "size"),
     "ship_weapons": ("damage", "size"),
-    "commodities":  ("label",),
+    "commodities":  ("label", "collection"),
 }
 
 # Which element kinds resolve through the per-category `class_mapping` dict.
@@ -85,15 +85,21 @@ STYLES_LABEL: tuple[tuple[str, str], ...] = (
     ("med",   "Medium (Craft)"),
     ("long",  "Long (Crafting)"),
 )
+STYLES_COLLECTION: tuple[tuple[str, str], ...] = (
+    ("short", "Short (Col)"),
+    ("med",   "Medium (Collect)"),
+    ("long",  "Long (Collection)"),
+)
 
 STYLES_BY_KIND: dict[str, tuple[tuple[str, str], ...]] = {
-    "class":     STYLES_CLASS,
-    "size":      STYLES_SIZE,
-    "grade":     STYLES_GRADE,
-    "ordinance": STYLES_ORDINANCE,
-    "damage":    STYLES_DAMAGE,
-    "type":      STYLES_TYPE,
-    "label":     STYLES_LABEL,
+    "class":      STYLES_CLASS,
+    "size":       STYLES_SIZE,
+    "grade":      STYLES_GRADE,
+    "ordinance":  STYLES_ORDINANCE,
+    "damage":     STYLES_DAMAGE,
+    "type":       STYLES_TYPE,
+    "label":      STYLES_LABEL,
+    "collection": STYLES_COLLECTION,
 }
 
 # Human-friendly element kind labels for the UI.
@@ -103,8 +109,9 @@ ELEMENT_LABELS: dict[str, str] = {
     "grade":     "Grade",
     "ordinance": "Ordinance",
     "damage":    "Damage type",
-    "type":      "Type",
-    "label":     "Label",
+    "type":       "Type",
+    "label":      "Label",
+    "collection": "Collection",
 }
 
 
@@ -118,6 +125,7 @@ SEPARATORS: tuple[tuple[str, str, str], ...] = (
     ("underscore", "Underscore ( _ )", "_"),
     ("dot",        "Period ( . )", "."),
     ("slash",      "Slash ( / )", "/"),
+    ("pipe",       "Pipe ( | )",  "|"),
 )
 
 # (key, label, open, close)
@@ -192,6 +200,12 @@ DEFAULT_COMMODITY_LABEL_MAPPING: dict[str, tuple[str, str, str]] = {
     "Crafting": ("CF", "Craft", "Crafting"),
 }
 
+# Collection-mission item flag. Combined with the crafting flag inside one
+# <EM4>[…]</EM4> wrapper (e.g. "[CF|Collection]") when an item is both (#97).
+DEFAULT_COMMODITY_COLLECTION_MAPPING: dict[str, tuple[str, str, str]] = {
+    "Collection": ("Col", "Collect", "Collection"),
+}
+
 DEFAULT_MAPPINGS: dict[str, dict[str, tuple[str, str, str]]] = {
     "components":   DEFAULT_COMPONENT_CLASS_MAPPING,
     "missiles":     DEFAULT_MISSILE_ORDINANCE_MAPPING,
@@ -205,6 +219,7 @@ DEFAULT_KIND_MAPPINGS: dict[str, dict[str, tuple[str, str, str]]] = {
     "ordinance": DEFAULT_MISSILE_ORDINANCE_MAPPING,
     "damage":    DEFAULT_SHIP_WEAPON_DAMAGE_MAPPING,
     "label":     DEFAULT_COMMODITY_LABEL_MAPPING,
+    "collection": DEFAULT_COMMODITY_COLLECTION_MAPPING,
 }
 
 
@@ -314,15 +329,25 @@ DEFAULT_TAG_CONFIGS: dict[str, TagConfig] = {
         enclosing="square",
         class_mapping=dict(DEFAULT_SHIP_WEAPON_DAMAGE_MAPPING),
     ),
-    # Commodities: static crafting label, default `[CF]`.
+    # Commodity tagging: two conditional flags sharing one wrapper. Crafting
+    # ("CF") for crafting materials, Collection ("Collection") for items used
+    # as Collection-mission objectives. When an item is both, render_tag joins
+    # them with the separator, e.g. "[CF|Collection]"; when only one flag
+    # applies, the other's empty value is dropped so a single-flag item stays
+    # "[CF]" or "[Collection]" (#97). Crafting-only output is unchanged from
+    # the pre-1.5.0 single-label default.
     "commodities": TagConfig(
         elements=[
-            ElementSpec("label", True, "short"),
+            ElementSpec("label", True, "short"),       # CF
+            ElementSpec("collection", True, "long"),   # Collection
         ],
-        separator="none",
+        separator="pipe",
         enclosing="square",
         placement="append",
-        class_mapping=dict(DEFAULT_COMMODITY_LABEL_MAPPING),
+        class_mapping={
+            **DEFAULT_COMMODITY_LABEL_MAPPING,
+            **DEFAULT_COMMODITY_COLLECTION_MAPPING,
+        },
     ),
 }
 
@@ -363,7 +388,7 @@ def _style_value(kind: str, style: str, raw: str,
             return f"Grade {raw}"
         return raw  # "letter"
 
-    if kind in ("class", "ordinance", "damage", "label", "type"):
+    if kind in ("class", "ordinance", "damage", "label", "type", "collection"):
         variants = mapping.get(raw)
         if variants is None:
             # Unknown raw value — surface it verbatim so the user can edit

--- a/tests/fixtures/collection_items_groundtruth.txt
+++ b/tests/fixtures/collection_items_groundtruth.txt
@@ -1,0 +1,84 @@
+# Ground-truth fixture for the [Collection] item tagging feature (issue #97).
+#
+# Captured by hand by the maintainer from a LIVE global.ini export (May 2026,
+# ~1.4.2 era). These are the items that appear as objectives in Collection
+# missions and should receive the Collection flag in their display name.
+#
+# Purpose: validate the 1.5.0 generator that auto-discovers Collection-mission
+# items from DataForge. The generated output should flag (at least) every key
+# below. This file encodes the DURABLE part (which items qualify, and whether
+# each is also a crafting material), not a pinned rendered string, because the
+# rendered tag depends on user Tag Builder config.
+#
+# Rendering (the "Commodity Tagging" Tag Builder category, default config):
+#   - collection only          ->  <Name> <EM4>[Collection]</EM4>
+#   - crafting + collection     ->  <Name> <EM4>[CF|Collection]</EM4>
+#   - crafting only (NOT below) ->  <Name> <EM4>[CF]</EM4>   (unchanged today)
+# Collection flag forms (short/medium/long, default long):
+#   Col / Collect / Collection
+# Defaults: flag order CF|Collection, separator "|", emphasis EM4.
+#
+# Key namespaces: Mission_Item_*, items_commodities_*, harvestable_*. The same
+# physical item often has more than one key (e.g. Mission_Item_0183 and
+# items_commodities_decaripod are both "Decari Pod"); the tagger must cover all.
+#
+# Format (pipe-delimited):  key | base_name | also_crafting(yes/no)
+# 57 entries; 8 are also crafting materials (also_crafting=yes).
+
+Mission_Item_0183 | Decari Pod | no
+Mission_Item_0184 | Degnous Root | no
+Mission_Item_0186 | Golden Medmon | no
+Mission_Item_0191 | Pitambu | no
+Mission_Item_0192 | Prota | no
+Mission_Item_0195 | Sunset Berry | no
+Mission_Item_0214 | Compboard | no
+harvestable_Armillaria | Bluemoon Fungus | no
+items_commodities_amiantpod | Amiant Pod | no
+items_commodities_amioshiplague | Amioshi Plague | no
+items_commodities_beradom | Beradom | yes
+items_commodities_carinite | Carinite | yes
+items_commodities_carinite_pure | Carinite (Pure) | yes
+items_commodities_carinite_raw | Carinite (Raw) | no
+items_commodities_compboard | Compboard | no
+items_commodities_decaripod | Decari Pod | no
+items_commodities_degnousroot | Degnous Root | no
+items_commodities_dopple | Dopple | no
+items_commodities_feynmaline | Feynmaline | yes
+items_commodities_flareweedstalk | Flareweed Stalk | no
+items_commodities_fotiascrub | Fotia Seedpod | no
+items_commodities_freeze | Freeze | no
+items_commodities_glacosite | Glacosite | yes
+items_commodities_glow | Glow | no
+items_commodities_goldenmedmon | Golden Medmon | yes
+items_commodities_heartofthewoods | Heart of the Woods | no
+items_commodities_jaclium | Jaclium | no
+items_commodities_jaclium_ore | Jaclium (Ore) | no
+items_commodities_janalite | Janalite | yes
+items_commodities_kopionhorn_irradiated | Irradiated Kopion Horn | no
+items_commodities_mala | Mala | no
+items_commodities_marokgem | Marok Gem | no
+items_commodities_pingala | Pingala Seeds | no
+items_commodities_pitambu | Pitambu | no
+items_commodities_prota | Prota | no
+items_commodities_rantadung | Ranta Dung | no
+items_commodities_revenantpod | Revenant Pod | no
+items_commodities_sadaryx | Sadaryx | yes
+items_commodities_saldynium | Saldynium | no
+items_commodities_saldynium_ore | Saldynium (Ore) | no
+items_commodities_stonebugshell | Stone Bug Shell | no
+items_commodities_sunsetberry | Sunset Berries | no
+items_commodities_valakkaregg_irradiated | Irradiated Valakkar Egg | no
+items_commodities_valakkarfang_adult | Valakkar Fang (Adult) | no
+items_commodities_valakkarfang_adult_irradiated | Irradiated Valakkar Fang (Adult) | no
+items_commodities_valakkarfang_apex_irradiated | Irradiated Valakkar Fang (Apex) | no
+items_commodities_valakkarfang_juvenile | Valakkar Fang (Juvenile) | no
+items_commodities_valakkarfang_juvenile_irradiated | Irradiated Valakkar Fang (Juvenile) | no
+items_commodities_valakkarpearl_apex_irradiated | Irradiated Valakkar Pearl | no
+items_commodities_valakkarpearl_apex_irradiated_tier1 | Irradiated Valakkar Pearl (AAA) | no
+items_commodities_valakkarpearl_apex_irradiated_tier2 | Irradiated Valakkar Pearl (AA) | no
+items_commodities_valakkarpearl_apex_irradiated_tier3 | Irradiated Valakkar Pearl (A) | no
+items_commodities_valakkarpearl_apex_irradiated_tier4 | Irradiated Valakkar Pearl (B) | no
+items_commodities_valakkarpearl_apex_irradiated_tier5 | Irradiated Valakkar Pearl (C) | no
+items_commodities_wuotanseed | Wuotan Seed | no
+items_commodities_yormandi_eye | Yormandi Eye | no
+items_commodities_zip | Zip | no

--- a/tests/test_commodity_tagging.py
+++ b/tests/test_commodity_tagging.py
@@ -1,0 +1,123 @@
+"""Tests for the Commodity Tagging feature (issue #97).
+
+Commodities get a configurable tag with two conditional flags sharing one
+<EM4>[...]</EM4> wrapper: Crafting (CF) and Collection. When an item is both,
+they join with the separator ("[CF|Collection]"); single-flag items drop the
+empty flag and stay "[CF]" / "[Collection]". Crafting-only output is unchanged
+from the pre-1.5.0 single-label default.
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from dataclasses import replace as dc_replace
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO))
+sys.path.insert(0, str(REPO / "src"))
+
+from src.utils.json_settings import JsonSettings  # noqa: E402
+from src.utils.settings import AppSettings  # noqa: E402
+from src.utils.tag_builder import (  # noqa: E402
+    DEFAULT_KIND_MAPPINGS,
+    ElementSpec,
+    default_config,
+    render_tag,
+)
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture(scope="module")
+def gen_module():
+    spec = importlib.util.spec_from_file_location(
+        "generate_enhancements_ini_commodity_test",
+        REPO / "scripts" / "generate_enhancements_ini.py",
+    )
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# ── render_tag with the default commodities config ───────────────────────────
+
+class TestRender:
+    def test_crafting_only(self):
+        cfg = default_config("commodities")
+        assert render_tag(cfg, {"label": "Crafting"}) == "[CF]"
+
+    def test_collection_only(self):
+        cfg = default_config("commodities")
+        assert render_tag(cfg, {"collection": "Collection"}) == "[Collection]"
+
+    def test_both_join_with_pipe(self):
+        cfg = default_config("commodities")
+        assert render_tag(cfg, {"label": "Crafting", "collection": "Collection"}) == "[CF|Collection]"
+
+    def test_collection_short_medium_long(self):
+        assert DEFAULT_KIND_MAPPINGS["collection"]["Collection"] == ("Col", "Collect", "Collection")
+        cfg = default_config("commodities")
+        short = dc_replace(
+            cfg,
+            elements=[ElementSpec("label", True, "short"), ElementSpec("collection", True, "short")],
+        )
+        assert render_tag(short, {"label": "Crafting", "collection": "Collection"}) == "[CF|Col]"
+
+
+# ── generator helper ─────────────────────────────────────────────────────────
+
+class TestCommodityTagHelper:
+    def test_flags(self, gen_module):
+        cfg = default_config("commodities")
+        tag = gen_module._commodity_tag
+        assert tag(cfg, crafting=True, collection=False) == "<EM4>[CF]</EM4>"
+        assert tag(cfg, crafting=False, collection=True) == "<EM4>[Collection]</EM4>"
+        assert tag(cfg, crafting=True, collection=True) == "<EM4>[CF|Collection]</EM4>"
+        assert tag(cfg, crafting=False, collection=False) == ""
+
+
+# ── membership matches the ground-truth fixture (drift guard) ────────────────
+
+class TestMembership:
+    def test_keys_match_fixture(self, gen_module):
+        fixture = REPO / "tests" / "fixtures" / "collection_items_groundtruth.txt"
+        keys = set()
+        for line in fixture.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if not line or line.startswith("#") or "|" not in line:
+                continue
+            keys.add(line.split("|")[0].strip())
+        assert keys == set(gen_module.COLLECTION_ITEM_KEYS)
+        assert len(gen_module.COLLECTION_ITEM_KEYS) == 57
+
+
+# ── saved-config migration ───────────────────────────────────────────────────
+
+class TestMigration:
+    @pytest.fixture
+    def json_backend(self, tmp_path):
+        saved = AppSettings._backend
+        AppSettings._backend = JsonSettings(tmp_path / "config.json")
+        yield
+        AppSettings._backend = saved
+
+    def test_legacy_single_label_config_gains_collection_and_pipe(self, json_backend):
+        # A pre-1.5.0 commodities config: only the label element, separator "none".
+        legacy = (
+            '{"elements":[{"kind":"label","enabled":true,"style":"short"}],'
+            '"separator":"none","enclosing":"square","placement":"append",'
+            '"class_mapping":{"Crafting":["CF","Craft","Crafting"]}}'
+        )
+        AppSettings.settings().setValue("tag_builder/commodities/config", legacy)
+
+        cfg = AppSettings.get_tag_config("commodities")
+
+        kinds = {e.kind for e in cfg.elements}
+        assert "collection" in kinds, "collection element should be backfilled"
+        assert cfg.separator == "pipe", "separator 'none' should upgrade to 'pipe'"
+        # And the combined render now works for a both-flags item.
+        assert render_tag(cfg, {"label": "Crafting", "collection": "Collection"}) == "[CF|Collection]"


### PR DESCRIPTION
## What

Two requests from #97, delivered together as a **Commodity Tagging** feature in the Tag Builder:

1. **Remove the unused separator for commodities** — resolved by giving it a job: commodities is now a multi-flag category, so the separator joins the flags.
2. **Add a `[Collection]` tag** for items used as Collection-mission objectives, with Short / Medium / Long forms like the other Tag Builder elements.

## How it works

The commodities category now has two conditional flags sharing one `<EM4>[...]</EM4>` wrapper:

- **Crafting** (`CF`) — crafting materials (unchanged behavior).
- **Collection** (`Col` / `Collect` / `Collection`, default long) — Collection-mission objectives.

Rendering:
- crafting only → `<EM4>[CF]</EM4>` (identical to pre-1.5.0)
- collection only → `<EM4>[Collection]</EM4>`
- both → `<EM4>[CF|Collection]</EM4>` (pipe-joined; order/separator/forms configurable)

## Changes

- `tag_builder.py`: `collection` element kind + styles + mapping, a `pipe` separator, and the commodities default config (`[label, collection]`, separator `pipe`).
- `settings.py`: existing `_backfill_new_elements` adds the collection element to stored configs; plus a one-line migration upgrading the old `"none"` separator to `"pipe"` so combined tags don't mash to `[CFCollection]`.
- `generate_enhancements_ini.py`: `COLLECTION_ITEM_KEYS` membership (seeded from the ground-truth fixture committed earlier), combined tag in the crafting loop, a collection-only pass for non-crafting items, and `_commodity_tag()` to render the flags.
- `enhancements_tab.py`: the Collection element gets the style dropdown, Edit-mapping button, and live preview, consistent with the other kinds.

## Scope note

Collection membership is a **maintained list** (the 57-item fixture is the ground truth). Auto-discovery of Collection items from the DataForge mission graph is a documented follow-up so the list stays current as CIG adds items — the data is recoverable (the items are referenced by Collection missions), it's just a larger graph-trace than this PR.

## Tests

`tests/test_commodity_tagging.py`: render ([CF] / [Collection] / [CF|Collection], short/med/long), the `_commodity_tag` generator helper, a fixture↔`COLLECTION_ITEM_KEYS` drift guard (57 keys), and the saved-config migration. UI construction smoke-tested headless. Full suite green (only the unrelated pre-existing `test_pak_extraction` failures, fixed in #108).

Fixes #97.