### PR TITLE
WIP: cargo mission info — root-cause + implementation plan (#102)

### DIFF
--- a/docs/dev/cargo-mission-info-plan.md
+++ b/docs/dev/cargo-mission-info-plan.md
@@ -1,0 +1,89 @@
+# Plan: cargo missions missing mission information (#102)
+
+Status: **investigation + plan** (not yet implemented). Unlike the other
+1.5.0 fix PRs, this one captures the root-cause analysis and the intended fix
+so the implementation can be done and validated against real data with care.
+Producing *wrong* mission XP/rep is worse than the current missing-info state,
+so this deserves a deliberate, fixture-backed implementation rather than a
+rushed change.
+
+## Symptom
+
+Most Cargo / delivery missions show no mission-information block (rep tier, XP,
+etc.) in their description. Reporter (Narull) saw details on ~3 of 39 cargo
+missions. Confirmed still present on 1.4.2.
+
+## What we already know
+
+- Cargo/delivery missions are defined in `missionbroker/pu_missions`
+  (~1,311 of 2,558 reference cargo/haul/delivery/freight), **not** in
+  `contracts/contractgenerator`. Only a handful have a contractgenerator
+  entry, which is why only those few get enriched. (This is the #95/#102
+  split finding.)
+- The mission XP/rep block is added by the pu_missions augmentation pass in
+  `_run_gen_missions` (`scripts/generate_enhancements_ini.py`). A mission is
+  **skipped** when `_extract_mission_xp(root, reputation_lookup) <= 0`
+  (the `no_rep_data` bucket — the generator log shows ~645 skipped).
+- The cargo missions **do** carry rep data inline, e.g.:
+  ```xml
+  <SReputationAmountParams factionReputation="…" reputationScope="…"
+                           reward="36d5786c-5258-48ca-a3b8-fefb5838e143" />
+  ```
+  The `reward` attribute is a UUID reference (not a direct amount).
+- `_extract_mission_xp` resolves that UUID via `reputation_lookup[uuid]`.
+- The referenced reward definition **exists** in the very dir the lookup
+  builder scans:
+  `reputation/rewards/missionrewards_reputation/reputationrewardamount_positive_xs.xml`
+  → `<SReputationRewardAmount … reputationAmount="500"
+     __ref="36d5786c-5258-48ca-a3b8-fefb5838e143" />`
+- Yet `_build_reputation` reports only **54** definitions loaded, and 645
+  missions still skip. So the gap is: **the reward UUIDs these cargo missions
+  reference are not ending up in `reputation_lookup`.**
+
+## The open question to answer first
+
+Determine *why* the cargo missions' reward UUIDs miss `reputation_lookup`.
+Two candidate causes (confirm with the LIVE cache before coding):
+
+1. **Coverage:** `_build_reputation` (line ~5196) keys/filters reward records
+   in a way that drops the `reputationrewardamount_*` family (e.g. only a
+   subset of `__type`/editorName, or a different sub-path), so the cargo
+   reward UUIDs never enter the lookup even though the files are scanned.
+2. **Indirection:** the cargo `reward` UUID points at an intermediate record
+   (a per-scope wrapper) that itself references the `reputationrewardamount_*`
+   leaf, so a single-hop lookup misses it and a second resolve hop is needed.
+
+A 20-minute sweep of the LIVE cache (map the 645 skipped missions' reward
+UUIDs → which records define them → whether `_build_reputation` includes those
+records) settles which cause it is.
+
+## Proposed fix
+
+- Extend `_build_reputation` so every `SReputationRewardAmount` under
+  `missionrewards_reputation` (keyed by `__ref` → `reputationAmount`) is in the
+  lookup, plus any one-hop indirection the cargo rewards use.
+- With the lookup complete, `_extract_mission_xp` returns a positive value for
+  the cargo missions, the `no_rep_data` skip no longer fires, and the existing
+  augmentation emits their mission-information block. **No change to the
+  per-mission output format** — only lookup coverage.
+
+## Validation (must-have before merge)
+
+- The existing ground-truth diagnostics already exist for exactly this:
+  `scripts/diff_mission_rewards_channels.py`, `scripts/diff_bp_*` and the
+  `kraken_*` / `missions_*.csv` fixtures. Use them to confirm:
+  - the ~645 previously-skipped cargo missions now carry XP/rep,
+  - the XP values match known-good missions (no regression to the 54 that
+    already resolved),
+  - no mission that should stay un-augmented suddenly gains a bogus value.
+- Add a unit test that feeds a fabricated cargo mission XML (inline
+  `missionResultReputationRewards` → reward UUID) plus a minimal reward-def
+  set through `_extract_mission_xp` / the augmentation and asserts the
+  mission is no longer skipped.
+
+## Why this is a separate, careful change
+
+The fix is small in code but high-blast-radius in output: it changes the
+mission-rewards INI for hundreds of missions. It must be validated against the
+ground-truth fixtures so we don't ship incorrect XP/rep, which would be a worse
+regression than the missing block this issue reports.

--- a/tests/fixtures/collection_items_groundtruth.txt
+++ b/tests/fixtures/collection_items_groundtruth.txt
@@ -1,0 +1,84 @@
+# Ground-truth fixture for the [Collection] item tagging feature (issue #97).
+#
+# Captured by hand by the maintainer from a LIVE global.ini export (May 2026,
+# ~1.4.2 era). These are the items that appear as objectives in Collection
+# missions and should receive the Collection flag in their display name.
+#
+# Purpose: validate the 1.5.0 generator that auto-discovers Collection-mission
+# items from DataForge. The generated output should flag (at least) every key
+# below. This file encodes the DURABLE part (which items qualify, and whether
+# each is also a crafting material), not a pinned rendered string, because the
+# rendered tag depends on user Tag Builder config.
+#
+# Rendering (the "Commodity Tagging" Tag Builder category, default config):
+#   - collection only          ->  <Name> <EM4>[Collection]</EM4>
+#   - crafting + collection     ->  <Name> <EM4>[CF|Collection]</EM4>
+#   - crafting only (NOT below) ->  <Name> <EM4>[CF]</EM4>   (unchanged today)
+# Collection flag forms (short/medium/long, default long):
+#   Col / Collect / Collection
+# Defaults: flag order CF|Collection, separator "|", emphasis EM4.
+#
+# Key namespaces: Mission_Item_*, items_commodities_*, harvestable_*. The same
+# physical item often has more than one key (e.g. Mission_Item_0183 and
+# items_commodities_decaripod are both "Decari Pod"); the tagger must cover all.
+#
+# Format (pipe-delimited):  key | base_name | also_crafting(yes/no)
+# 57 entries; 8 are also crafting materials (also_crafting=yes).
+
+Mission_Item_0183 | Decari Pod | no
+Mission_Item_0184 | Degnous Root | no
+Mission_Item_0186 | Golden Medmon | no
+Mission_Item_0191 | Pitambu | no
+Mission_Item_0192 | Prota | no
+Mission_Item_0195 | Sunset Berry | no
+Mission_Item_0214 | Compboard | no
+harvestable_Armillaria | Bluemoon Fungus | no
+items_commodities_amiantpod | Amiant Pod | no
+items_commodities_amioshiplague | Amioshi Plague | no
+items_commodities_beradom | Beradom | yes
+items_commodities_carinite | Carinite | yes
+items_commodities_carinite_pure | Carinite (Pure) | yes
+items_commodities_carinite_raw | Carinite (Raw) | no
+items_commodities_compboard | Compboard | no
+items_commodities_decaripod | Decari Pod | no
+items_commodities_degnousroot | Degnous Root | no
+items_commodities_dopple | Dopple | no
+items_commodities_feynmaline | Feynmaline | yes
+items_commodities_flareweedstalk | Flareweed Stalk | no
+items_commodities_fotiascrub | Fotia Seedpod | no
+items_commodities_freeze | Freeze | no
+items_commodities_glacosite | Glacosite | yes
+items_commodities_glow | Glow | no
+items_commodities_goldenmedmon | Golden Medmon | yes
+items_commodities_heartofthewoods | Heart of the Woods | no
+items_commodities_jaclium | Jaclium | no
+items_commodities_jaclium_ore | Jaclium (Ore) | no
+items_commodities_janalite | Janalite | yes
+items_commodities_kopionhorn_irradiated | Irradiated Kopion Horn | no
+items_commodities_mala | Mala | no
+items_commodities_marokgem | Marok Gem | no
+items_commodities_pingala | Pingala Seeds | no
+items_commodities_pitambu | Pitambu | no
+items_commodities_prota | Prota | no
+items_commodities_rantadung | Ranta Dung | no
+items_commodities_revenantpod | Revenant Pod | no
+items_commodities_sadaryx | Sadaryx | yes
+items_commodities_saldynium | Saldynium | no
+items_commodities_saldynium_ore | Saldynium (Ore) | no
+items_commodities_stonebugshell | Stone Bug Shell | no
+items_commodities_sunsetberry | Sunset Berries | no
+items_commodities_valakkaregg_irradiated | Irradiated Valakkar Egg | no
+items_commodities_valakkarfang_adult | Valakkar Fang (Adult) | no
+items_commodities_valakkarfang_adult_irradiated | Irradiated Valakkar Fang (Adult) | no
+items_commodities_valakkarfang_apex_irradiated | Irradiated Valakkar Fang (Apex) | no
+items_commodities_valakkarfang_juvenile | Valakkar Fang (Juvenile) | no
+items_commodities_valakkarfang_juvenile_irradiated | Irradiated Valakkar Fang (Juvenile) | no
+items_commodities_valakkarpearl_apex_irradiated | Irradiated Valakkar Pearl | no
+items_commodities_valakkarpearl_apex_irradiated_tier1 | Irradiated Valakkar Pearl (AAA) | no
+items_commodities_valakkarpearl_apex_irradiated_tier2 | Irradiated Valakkar Pearl (AA) | no
+items_commodities_valakkarpearl_apex_irradiated_tier3 | Irradiated Valakkar Pearl (A) | no
+items_commodities_valakkarpearl_apex_irradiated_tier4 | Irradiated Valakkar Pearl (B) | no
+items_commodities_valakkarpearl_apex_irradiated_tier5 | Irradiated Valakkar Pearl (C) | no
+items_commodities_wuotanseed | Wuotan Seed | no
+items_commodities_yormandi_eye | Yormandi Eye | no
+items_commodities_zip | Zip | no


### PR DESCRIPTION
## Heads up: this PR is a plan, not a completed fix

The other five 1.5.0 PRs in this batch (#110, #101, #98, #103, #97) are complete, tested fixes. **This one is deliberately a draft investigation + implementation plan.** #102 changes the mission-rewards output for hundreds of missions, and shipping *wrong* XP/rep would be worse than the missing block the issue reports, so it needs a fixture-validated implementation rather than a rushed change late in a long batch.

## What's in it

`docs/dev/cargo-mission-info-plan.md` — the full root-cause analysis and the fix plan:

- Cargo/delivery missions live in `missionbroker/pu_missions` (not `contractgenerator`), so the contractgenerator-based enrichment never covers them.
- They carry inline `missionResultReputationRewards` whose `reward` UUIDs are **not** landing in `reputation_lookup`, so `_extract_mission_xp` returns 0 and the augmentation pass skips them as `no_rep_data` (~645 missions).
- The referenced reward definitions **do exist** under `reputation/rewards/missionrewards_reputation` (e.g. `36d5786c… → reputationAmount=500`), but only 54 load into the lookup.
- Fix direction: complete `reputation_lookup` coverage (and any one-hop indirection), so the existing augmentation emits the info block for cargo missions with **no change to the output format**.
- Validation plan using the existing `diff_mission_rewards_channels.py` / `kraken` / `missions_*.csv` ground-truth tooling, plus a unit test.

## Why not just implement it now

The remaining open question (exactly why those reward UUIDs miss the lookup: coverage vs. one-hop indirection) needs a real-data sweep of the LIVE cache and validation against the ground-truth fixtures. I'd rather hand you a precise, correct plan than a generator change I couldn't fully validate. Happy to implement from this plan as the next focused task.

Addresses #102.