### PR TITLE
fix: validate SC install paths to reject stale registry values

### DIFF
--- a/installer.iss
+++ b/installer.iss
@@ -617,24 +617,23 @@ end;
 
 function IsValidSCPath(const Path: String): Boolean;
 var
-  ExtPath: String;
+  BasePath: String;
+  LastName: String;
 begin
   { Returns True if Path looks like a valid Star Citizen install path.
     Accepts either:
       - a root containing channel subdirectories (LIVE, PTU, etc.), or
       - a channel path (last component is a channel name like LIVE).
     Guards against stale registry values like 'SmartCitizen 1.4.1'. }
-  ExtPath := Path + '\';
-  if (LowerCase(ExtractFileName(RemoveBackslash(Path))) = 'live') or
-     (LowerCase(ExtractFileName(RemoveBackslash(Path))) = 'ptu') or
-     (LowerCase(ExtractFileName(RemoveBackslash(Path))) = 'eptu') or
-     (LowerCase(ExtractFileName(RemoveBackslash(Path))) = 'hotfix') or
-     (LowerCase(ExtractFileName(RemoveBackslash(Path))) = 'tech-preview') then
+  BasePath := RemoveBackslash(Path) + '\';
+  LastName := LowerCase(ExtractFileName(BasePath));
+  if (LastName = 'live') or (LastName = 'ptu') or (LastName = 'eptu') or
+     (LastName = 'hotfix') or (LastName = 'tech-preview') then
     Result := True
   else
-    Result := DirExists(ExtPath + 'LIVE') or DirExists(ExtPath + 'PTU') or
-              DirExists(ExtPath + 'EPTU') or DirExists(ExtPath + 'HOTFIX') or
-              DirExists(ExtPath + 'TECH-PREVIEW');
+    Result := DirExists(BasePath + 'LIVE') or DirExists(BasePath + 'PTU') or
+              DirExists(BasePath + 'EPTU') or DirExists(BasePath + 'HOTFIX') or
+              DirExists(BasePath + 'TECH-PREVIEW');
 end;
 
 procedure InitializeWizard();
@@ -672,41 +671,27 @@ begin
     channel the app is currently pointed at. The active_channel value is
     ignored here on purpose; the app-side channel switcher handles
     per-channel paths at runtime. }
-  if RegQueryStringValue(HKCU, NewRegPath, 'sc_install_root', SCRoot) and (SCRoot <> '') then
+  if RegQueryStringValue(HKCU, NewRegPath, 'sc_install_root', SCRoot) and (SCRoot <> '') and IsValidSCPath(SCRoot) then
   begin
-    if IsValidSCPath(SCRoot) then
-    begin
-      ActiveChannel := 'LIVE';
-      DefaultPath := SCRoot + '\' + ActiveChannel;
-    end;
+    ActiveChannel := 'LIVE';
+    DefaultPath := SCRoot + '\' + ActiveChannel;
   end;
 
   { Fall back to previously saved sc_directory / game_install_path in the
     NEW node, then the LEGACY node.  Each value is validated to ensure it
     actually looks like a valid SC install path (either ends with a channel
-    name, or contains channel subdirectories). }
+    name, or contains channel subdirectories).  Validation is folded into
+    the condition so a stale value causes fallthrough to the next option. }
   if DefaultPath = '' then
   begin
-    if RegQueryStringValue(HKCU, NewRegPath, 'sc_directory', SavedPath) and (SavedPath <> '') then
-    begin
-      if IsValidSCPath(SavedPath) then
-        DefaultPath := SavedPath
-    end
-    else if RegQueryStringValue(HKCU, NewRegPath, 'game_install_path', SavedPath) and (SavedPath <> '') then
-    begin
-      if IsValidSCPath(SavedPath) then
-        DefaultPath := SavedPath
-    end
-    else if RegQueryStringValue(HKCU, LegacyRegPath, 'sc_directory', SavedPath) and (SavedPath <> '') then
-    begin
-      if IsValidSCPath(SavedPath) then
-        DefaultPath := SavedPath
-    end
-    else if RegQueryStringValue(HKCU, LegacyRegPath, 'game_install_path', SavedPath) and (SavedPath <> '') then
-    begin
-      if IsValidSCPath(SavedPath) then
-        DefaultPath := SavedPath
-    end
+    if RegQueryStringValue(HKCU, NewRegPath, 'sc_directory', SavedPath) and (SavedPath <> '') and IsValidSCPath(SavedPath) then
+      DefaultPath := SavedPath
+    else if RegQueryStringValue(HKCU, NewRegPath, 'game_install_path', SavedPath) and (SavedPath <> '') and IsValidSCPath(SavedPath) then
+      DefaultPath := SavedPath
+    else if RegQueryStringValue(HKCU, LegacyRegPath, 'sc_directory', SavedPath) and (SavedPath <> '') and IsValidSCPath(SavedPath) then
+      DefaultPath := SavedPath
+    else if RegQueryStringValue(HKCU, LegacyRegPath, 'game_install_path', SavedPath) and (SavedPath <> '') and IsValidSCPath(SavedPath) then
+      DefaultPath := SavedPath
     else if DirExists('C:\Program Files\Roberts Space Industries\StarCitizen\LIVE') then
       DefaultPath := 'C:\Program Files\Roberts Space Industries\StarCitizen\LIVE'
     else if DirExists('C:\Program Files (x86)\Roberts Space Industries\StarCitizen\LIVE') then

--- a/installer.iss
+++ b/installer.iss
@@ -615,6 +615,28 @@ begin
   end;
 end;
 
+function IsValidSCPath(const Path: String): Boolean;
+var
+  ExtPath: String;
+begin
+  { Returns True if Path looks like a valid Star Citizen install path.
+    Accepts either:
+      - a root containing channel subdirectories (LIVE, PTU, etc.), or
+      - a channel path (last component is a channel name like LIVE).
+    Guards against stale registry values like 'SmartCitizen 1.4.1'. }
+  ExtPath := Path + '\';
+  if (LowerCase(ExtractFileName(RemoveBackslash(Path))) = 'live') or
+     (LowerCase(ExtractFileName(RemoveBackslash(Path))) = 'ptu') or
+     (LowerCase(ExtractFileName(RemoveBackslash(Path))) = 'eptu') or
+     (LowerCase(ExtractFileName(RemoveBackslash(Path))) = 'hotfix') or
+     (LowerCase(ExtractFileName(RemoveBackslash(Path))) = 'tech-preview') then
+    Result := True
+  else
+    Result := DirExists(ExtPath + 'LIVE') or DirExists(ExtPath + 'PTU') or
+              DirExists(ExtPath + 'EPTU') or DirExists(ExtPath + 'HOTFIX') or
+              DirExists(ExtPath + 'TECH-PREVIEW');
+end;
+
 procedure InitializeWizard();
 var
   NewRegPath: String;
@@ -652,22 +674,39 @@ begin
     per-channel paths at runtime. }
   if RegQueryStringValue(HKCU, NewRegPath, 'sc_install_root', SCRoot) and (SCRoot <> '') then
   begin
-    ActiveChannel := 'LIVE';
-    DefaultPath := SCRoot + '\' + ActiveChannel;
+    if IsValidSCPath(SCRoot) then
+    begin
+      ActiveChannel := 'LIVE';
+      DefaultPath := SCRoot + '\' + ActiveChannel;
+    end;
   end;
 
   { Fall back to previously saved sc_directory / game_install_path in the
-    NEW node, then the LEGACY node. }
+    NEW node, then the LEGACY node.  Each value is validated to ensure it
+    actually looks like a valid SC install path (either ends with a channel
+    name, or contains channel subdirectories). }
   if DefaultPath = '' then
   begin
     if RegQueryStringValue(HKCU, NewRegPath, 'sc_directory', SavedPath) and (SavedPath <> '') then
-      DefaultPath := SavedPath
+    begin
+      if IsValidSCPath(SavedPath) then
+        DefaultPath := SavedPath
+    end
     else if RegQueryStringValue(HKCU, NewRegPath, 'game_install_path', SavedPath) and (SavedPath <> '') then
-      DefaultPath := SavedPath
+    begin
+      if IsValidSCPath(SavedPath) then
+        DefaultPath := SavedPath
+    end
     else if RegQueryStringValue(HKCU, LegacyRegPath, 'sc_directory', SavedPath) and (SavedPath <> '') then
-      DefaultPath := SavedPath
+    begin
+      if IsValidSCPath(SavedPath) then
+        DefaultPath := SavedPath
+    end
     else if RegQueryStringValue(HKCU, LegacyRegPath, 'game_install_path', SavedPath) and (SavedPath <> '') then
-      DefaultPath := SavedPath
+    begin
+      if IsValidSCPath(SavedPath) then
+        DefaultPath := SavedPath
+    end
     else if DirExists('C:\Program Files\Roberts Space Industries\StarCitizen\LIVE') then
       DefaultPath := 'C:\Program Files\Roberts Space Industries\StarCitizen\LIVE'
     else if DirExists('C:\Program Files (x86)\Roberts Space Industries\StarCitizen\LIVE') then

--- a/src/utils/settings.py
+++ b/src/utils/settings.py
@@ -9,6 +9,24 @@ import winreg
 logger = logging.getLogger(__name__)
 
 
+def _is_valid_sc_root(path: str) -> bool:
+    """Return True if *path* looks like a valid Star Citizen install root.
+
+    Checks whether the directory contains at least one channel subfolder
+    (LIVE, PTU, EPTU, HOTFIX, TECH-PREVIEW).  This guards against stale
+    registry values like ``SmartCitizen 1.4.1`` being returned as the
+    install root.
+    """
+    try:
+        p = Path(path)
+        if not p.is_dir():
+            return False
+        return any((p / ch).is_dir() for ch in (
+            "LIVE", "PTU", "EPTU", "HOTFIX", "TECH-PREVIEW"
+        ))
+    except (OSError, ValueError):
+        return False
+
 class AppSettings:
     """Wrapper around QSettings for application configuration."""
 
@@ -529,7 +547,14 @@ class AppSettings:
         # Legacy path stored under the old key.
         saved = AppSettings.settings().value(AppSettings.GAME_INSTALL_PATH, "")
         if saved:
-            return saved
+            saved_path = Path(saved)
+            if saved_path.name.upper() in (c.upper() for c in AppSettings.AVAILABLE_CHANNELS):
+                # Ends with a channel name — trust it.
+                return saved
+            # Doesn't end with a channel name — might be a stale root.
+            # Only trust it if it actually contains channel subdirs.
+            if _is_valid_sc_root(saved):
+                return saved
 
         # Installer-written registry key (older flow).
         try:
@@ -538,8 +563,13 @@ class AppSettings:
             sc_directory, _ = winreg.QueryValueEx(registry_key, 'sc_directory')
             winreg.CloseKey(registry_key)
             if sc_directory:
-                AppSettings.settings().setValue(AppSettings.GAME_INSTALL_PATH, sc_directory)
-                return sc_directory
+                sc_path = Path(sc_directory)
+                if sc_path.name.upper() in (c.upper() for c in AppSettings.AVAILABLE_CHANNELS):
+                    AppSettings.settings().setValue(AppSettings.GAME_INSTALL_PATH, sc_directory)
+                    return sc_directory
+                if _is_valid_sc_root(sc_directory):
+                    AppSettings.settings().setValue(AppSettings.GAME_INSTALL_PATH, sc_directory)
+                    return sc_directory
         except (WindowsError, OSError):
             pass
 
@@ -1461,7 +1491,7 @@ class AppSettings:
                     AppSettings.settings().setValue(AppSettings.SC_INSTALL_ROOT, derived_root)
                     return derived_root
 
-        if saved:
+        if saved and _is_valid_sc_root(saved):
             return saved
 
         # Derive from the legacy per-channel path if it's set.
@@ -1469,7 +1499,8 @@ class AppSettings:
             legacy_path = Path(legacy)
             if legacy_path.name.upper() in (c.upper() for c in AppSettings.AVAILABLE_CHANNELS):
                 return str(legacy_path.parent)
-            return legacy  # assume it was already a root
+            if _is_valid_sc_root(legacy):
+                return legacy
 
         for candidate in [
             r"C:\Program Files\Roberts Space Industries\StarCitizen",

--- a/src/utils/settings.py
+++ b/src/utils/settings.py
@@ -27,6 +27,21 @@ def _is_valid_sc_root(path: str) -> bool:
     except (OSError, ValueError):
         return False
 
+
+def _path_ends_in_channel(path: str) -> bool:
+    """Return True if *path*'s last component is a recognised channel name.
+
+    Used to distinguish per-channel paths (``...\\LIVE``) from install roots
+    (``...\\StarCitizen``).  Case-insensitive match against
+    :data:`AppSettings.AVAILABLE_CHANNELS`.
+    """
+    try:
+        name = Path(path).name.upper()
+    except (OSError, ValueError):
+        return False
+    return name in {c.upper() for c in AppSettings.AVAILABLE_CHANNELS}
+
+
 class AppSettings:
     """Wrapper around QSettings for application configuration."""
 
@@ -548,7 +563,7 @@ class AppSettings:
         saved = AppSettings.settings().value(AppSettings.GAME_INSTALL_PATH, "")
         if saved:
             saved_path = Path(saved)
-            if saved_path.name.upper() in (c.upper() for c in AppSettings.AVAILABLE_CHANNELS):
+            if _path_ends_in_channel(saved):
                 # Ends with a channel name — trust it.
                 return saved
             # Doesn't end with a channel name — might be a stale root.
@@ -564,7 +579,7 @@ class AppSettings:
             winreg.CloseKey(registry_key)
             if sc_directory:
                 sc_path = Path(sc_directory)
-                if sc_path.name.upper() in (c.upper() for c in AppSettings.AVAILABLE_CHANNELS):
+                if _path_ends_in_channel(sc_directory):
                     AppSettings.settings().setValue(AppSettings.GAME_INSTALL_PATH, sc_directory)
                     return sc_directory
                 if _is_valid_sc_root(sc_directory):
@@ -1481,7 +1496,7 @@ class AppSettings:
         legacy = AppSettings.settings().value(AppSettings.GAME_INSTALL_PATH, "")
         if saved and legacy:
             legacy_path = Path(legacy)
-            if legacy_path.name.upper() in (c.upper() for c in AppSettings.AVAILABLE_CHANNELS):
+            if _path_ends_in_channel(legacy):
                 derived_root = str(legacy_path.parent)
                 if os.path.normcase(derived_root) != os.path.normcase(saved):
                     logger.info(
@@ -1497,7 +1512,7 @@ class AppSettings:
         # Derive from the legacy per-channel path if it's set.
         if legacy:
             legacy_path = Path(legacy)
-            if legacy_path.name.upper() in (c.upper() for c in AppSettings.AVAILABLE_CHANNELS):
+            if _path_ends_in_channel(legacy):
                 return str(legacy_path.parent)
             if _is_valid_sc_root(legacy):
                 return legacy

--- a/tests/test_sc_install_root.py
+++ b/tests/test_sc_install_root.py
@@ -53,11 +53,18 @@ class TestInstallRootCrossCheck:
         expected = r"D:\NewLocation\StarCitizen"
         assert os.path.normcase(result) == os.path.normcase(expected)
 
-    def test_only_sc_install_root_set(self, json_backend):
-        """Only SC_INSTALL_ROOT set (no GAME_INSTALL_PATH) -- returns SC_INSTALL_ROOT."""
+    def test_only_sc_install_root_set(self, json_backend, monkeypatch):
+        """Only SC_INSTALL_ROOT set (no GAME_INSTALL_PATH) -- returns SC_INSTALL_ROOT.
+
+        Mocks _is_valid_sc_root to return True since this test exercises the
+        cross-check logic, not path validation (which is tested separately).
+        """
         root = r"E:\RSI\StarCitizen"
         json_backend.setValue(AppSettings.SC_INSTALL_ROOT, root)
         # GAME_INSTALL_PATH not set (defaults to "")
+
+        # Mock validation to return True -- test focuses on cross-check, not validation
+        monkeypatch.setattr("src.utils.settings._is_valid_sc_root", lambda p: True)
 
         result = AppSettings.get_sc_install_root()
         assert result == root
@@ -107,9 +114,16 @@ class TestInstallRootCrossCheck:
 
     def test_game_path_without_channel_suffix_used_as_root(self, json_backend, monkeypatch):
         """GAME_INSTALL_PATH that doesn't end in a channel name is treated
-        as the root itself when SC_INSTALL_ROOT is not set."""
+        as the root itself when SC_INSTALL_ROOT is not set.
+
+        Mocks _is_valid_sc_root to return True since this test exercises the
+        cross-check logic, not path validation (which is tested separately).
+        """
         json_backend.remove(AppSettings.SC_INSTALL_ROOT)
         json_backend.setValue(AppSettings.GAME_INSTALL_PATH, r"D:\Games\StarCitizen")
+
+        # Mock validation to return True -- test focuses on cross-check, not validation
+        monkeypatch.setattr("src.utils.settings._is_valid_sc_root", lambda p: True)
 
         # Block filesystem auto-detection
         original_exists = Path.exists
@@ -122,3 +136,58 @@ class TestInstallRootCrossCheck:
 
         result = AppSettings.get_sc_install_root()
         assert result == r"D:\Games\StarCitizen"
+
+
+class TestIsValidScRoot:
+    """Tests for the _is_valid_sc_root path validation helper."""
+
+    def test_nonexistent_path_returns_false(self):
+        """A path that doesn't exist should return False."""
+        from src.utils.settings import _is_valid_sc_root
+        assert _is_valid_sc_root(r"C:\Nonexistent\Path") is False
+
+    def test_path_without_channel_subdirs_returns_false(self):
+        """A directory without LIVE/PTU/etc. subdirs should return False."""
+        from src.utils.settings import _is_valid_sc_root
+        # Use a directory that exists but has no channel subdirs
+        assert _is_valid_sc_root(r"C:\Windows") is False
+
+    def test_stale_registry_value_rejected(self, tmp_path):
+        """A stale value like 'SmartCitizen 1.4.1' should be rejected."""
+        from src.utils.settings import _is_valid_sc_root
+        # Create a directory that looks like a stale app install
+        stale_dir = tmp_path / "SmartCitizen 1.4.1"
+        stale_dir.mkdir()
+        assert _is_valid_sc_root(str(stale_dir)) is False
+
+    def test_valid_root_with_live_subdir(self, tmp_path):
+        """A root with LIVE subdir should be accepted."""
+        from src.utils.settings import _is_valid_sc_root
+        root = tmp_path / "StarCitizen"
+        root.mkdir()
+        (root / "LIVE").mkdir()
+        assert _is_valid_sc_root(str(root)) is True
+
+    def test_valid_root_with_multiple_channels(self, tmp_path):
+        """A root with multiple channel subdirs should be accepted."""
+        from src.utils.settings import _is_valid_sc_root
+        root = tmp_path / "StarCitizen"
+        root.mkdir()
+        (root / "LIVE").mkdir()
+        (root / "PTU").mkdir()
+        assert _is_valid_sc_root(str(root)) is True
+
+    def test_channel_path_not_root(self, tmp_path):
+        """A channel path (ending in LIVE) is not a valid root."""
+        from src.utils.settings import _is_valid_sc_root
+        # _is_valid_sc_root checks for channel SUBDIRS, so a channel
+        # path itself is NOT a valid root (it has no subdirs named LIVE)
+        channel = tmp_path / "StarCitizen" / "LIVE"
+        channel.mkdir(parents=True)
+        assert _is_valid_sc_root(str(channel)) is False
+
+    def test_invalid_path_string_returns_false(self):
+        """An invalid path string should return False without crashing."""
+        from src.utils.settings import _is_valid_sc_root
+        assert _is_valid_sc_root("") is False
+        assert _is_valid_sc_root("not_a_path|with invalid chars") is False

--- a/tests/test_sc_install_root.py
+++ b/tests/test_sc_install_root.py
@@ -191,3 +191,55 @@ class TestIsValidScRoot:
         from src.utils.settings import _is_valid_sc_root
         assert _is_valid_sc_root("") is False
         assert _is_valid_sc_root("not_a_path|with invalid chars") is False
+
+    @pytest.mark.regression
+    def test_stale_sc_install_root_dropped_by_getter(self, tmp_path, json_backend, monkeypatch):
+        """End-to-end: SC_INSTALL_ROOT pointing at a directory with no channel
+        subdirs is rejected by get_sc_install_root() and falls through.
+
+        Regression for the 'SmartCitizen 1.4.1' stale-registry bug."""
+        # Simulate the stale registry value: a dir that exists but has no
+        # channel subdirectories
+        stale_dir = tmp_path / "SmartCitizen 1.4.1"
+        stale_dir.mkdir()
+        json_backend.setValue(AppSettings.SC_INSTALL_ROOT, str(stale_dir))
+        json_backend.remove(AppSettings.GAME_INSTALL_PATH)
+
+        # Block filesystem auto-detection so the test doesn't accidentally
+        # find a real SC install on the test machine
+        original_exists = Path.exists
+
+        def _fake_exists(self):
+            s = str(self)
+            if "Roberts Space Industries" in s:
+                return False
+            return original_exists(self)
+
+        monkeypatch.setattr(Path, "exists", _fake_exists)
+
+        result = AppSettings.get_sc_install_root()
+        # The stale value must be rejected, falling through to '' (no auto-detect)
+        assert result == ""
+
+    @pytest.mark.regression
+    def test_stale_game_install_path_dropped_by_getter(self, tmp_path, json_backend, monkeypatch):
+        """End-to-end: GAME_INSTALL_PATH pointing at a stale dir (no channel subdirs)
+        is rejected by get_sc_install_root() when SC_INSTALL_ROOT is unset."""
+        stale_dir = tmp_path / "SmartCitizen 1.4.1"
+        stale_dir.mkdir()
+        json_backend.remove(AppSettings.SC_INSTALL_ROOT)
+        json_backend.setValue(AppSettings.GAME_INSTALL_PATH, str(stale_dir))
+
+        original_exists = Path.exists
+
+        def _fake_exists(self):
+            s = str(self)
+            if "Roberts Space Industries" in s:
+                return False
+            return original_exists(self)
+
+        monkeypatch.setattr(Path, "exists", _fake_exists)
+
+        result = AppSettings.get_sc_install_root()
+        # The stale value must be rejected, falling through to ''
+        assert result == ""


### PR DESCRIPTION
## Problem

Stale registry values like `SmartCitizen 1.4.1` are returned as the SC install root, causing the app to show wrong default paths in the Config tab.

**Root cause**: `get_sc_install_root()` and `get_game_install_path()` return raw registry values without checking they actually contain Star Citizen channel subdirectories (LIVE, PTU, EPTU, HOTFIX, TECH-PREVIEW).

## Fix

### src/utils/settings.py
- Added `_is_valid_sc_root(path)` helper that validates a path contains at least one channel subdirectory
- Fixed `get_sc_install_root()`: validate saved `SC_INSTALL_ROOT` and legacy `GAME_INSTALL_PATH` before returning them
- Fixed `get_game_install_path()`: validate legacy `GAME_INSTALL_PATH` and registry `sc_directory` before returning them

### installer.iss
- Added `IsValidSCPath(Path)` function that accepts both channel paths (ending in LIVE/PTU/etc.) and root paths (containing channel subdirectories)
- Wrapped all 5 registry reads in `InitializeWizard()` with validation guards

### tests/test_sc_install_root.py
- Updated 2 existing tests to mock `_is_valid_sc_root` (they test cross-check logic, not validation)
- Added 7 new unit tests for `_is_valid_sc_root()` edge cases (nonexistent paths, stale values, valid roots, invalid strings)

## Behavior Change

| Scenario | Before | After |
|----------|--------|-------|
| Registry has `SmartCitizen 1.4.1` | Returned as install root | Rejected, falls through to auto-detect |
| Registry has valid root (e.g. `StarCitizen` with LIVE inside) | Returned | Returned (unchanged) |
| Registry has channel path (ends in LIVE) | Returned | Returned (unchanged) |

## Verification

Fix is correct, minimal, and achieves the goal without breaking valid installations.

All callers handle empty string returns gracefully - no regressions for valid paths.

CI compatibility: tests updated, no new dependencies, PyInstaller build unaffected.

Merge compatibility: verified clean merge into PR #118 (2.0 branch). The 2.0 branch modifies `settings.py` in non-overlapping regions (i18n/language support only). Both PRs insert code at module level after the logger line but as independent additions (different symbols), so Git auto-merges cleanly. No changes needed in `installer.iss` or `test_sc_install_root.py` on the 2.0 branch.
