### PR TITLE
fix: correct #119 get_available_channels test (real fix; #123 squashed the wrong commit)

### DIFF
--- a/tests/test_channel_layout.py
+++ b/tests/test_channel_layout.py
@@ -266,9 +266,15 @@ class TestAvailableChannels:
     def test_empty_list_when_root_set_but_no_channels_installed(
         self, isolated_qsettings, tmp_path
     ):
-        empty_root = tmp_path / "empty_sc"
-        empty_root.mkdir()
-        AppSettings.set_sc_install_root(str(empty_root))
+        # The root must look like a real SC install so get_sc_install_root()
+        # accepts it: as of #119 it validates that the saved root contains at
+        # least one channel subdir, else it rejects the value and falls through
+        # to auto-detect. Create the LIVE channel folder but no Data.p4k inside,
+        # so the root is valid yet no channel is actually installed, which
+        # makes get_available_channels() filter everything out.
+        sc_root = tmp_path / "StarCitizen"
+        (sc_root / "LIVE").mkdir(parents=True)
+        AppSettings.set_sc_install_root(str(sc_root))
         assert AppSettings.get_available_channels() == []
 
 


### PR DESCRIPTION
## What this fixes

`release/1.5.0` carries a broken test: `test_channel_layout.py::TestAvailableChannels::test_empty_list_when_root_set_but_no_channels_installed`. #119 added `_is_valid_sc_root()` to `get_sc_install_root()` (a saved root is only honored if it contains a channel subdir), but this test still set a bare, channel-less temp dir, so post-#119 the root is rejected, `get_sc_install_root()` falls through to auto-detect, and `get_available_channels()` returns all channels instead of `[]`. It is deterministic, not flaky.

This was meant to land via #123, but the squash merge captured the wrong commit (an abandoned fixture-theory change, `2c59625`, instead of the real fix `a200b55`), so the bug is still here. This PR cherry-picks the real fix.

## The fix

Make the test root valid under #119: give it a `LIVE` folder with no `Data.p4k`, so the root is accepted yet no channel is actually installed, and `get_available_channels()` filters to `[]`. Test-only change.

## Verification

All 30 `test_channel_layout.py` tests pass. `ci.yml` doesn't auto-run on PRs into the release branch, so I dispatched it manually against this branch (linked in checks).

## Note
Please **merge, don't squash** here, or double-check the merged commit content. #123's squash is what put the wrong commit on the branch in the first place.
