### PR TITLE
fix: stable SmartCitizen.exe name so shortcuts survive updates (#104)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,13 +76,13 @@ jobs:
         run: python scripts/build/build_exe.py
 
       - name: Verify build output
-        # Sanity check the onedir layout — catches regressions where
+        # Sanity check the onedir layout: catches regressions where
         # build_exe.py "succeeds" but doesn't write the expected
-        # SmartCitizen-v{VERSION}/SmartCitizen-v{VERSION}.exe pair.
+        # dist/SmartCitizen/SmartCitizen.exe. The exe name is stable (not
+        # versioned) so installed shortcuts survive version updates (#104).
         shell: pwsh
         run: |
-          $version = (Get-Content VERSION.TXT).Trim()
-          $exe = "dist/SmartCitizen-v${version}/SmartCitizen-v${version}.exe"
+          $exe = "dist/SmartCitizen/SmartCitizen.exe"
           if (-not (Test-Path $exe)) {
             Write-Error "Expected build artifact not found: $exe"
             Get-ChildItem dist -Recurse -Depth 2 | ForEach-Object { Write-Host $_.FullName }
@@ -99,6 +99,6 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: smartcitizen-onedir-${{ github.sha }}
-          path: dist/SmartCitizen-v*/
+          path: dist/SmartCitizen/
           retention-days: 7
           if-no-files-found: error

--- a/installer.iss
+++ b/installer.iss
@@ -44,15 +44,15 @@ SCDirectoryDefaultPath=C:\Program Files\Roberts Space Industries\StarCitizen\LIV
 Type: filesandordirs; Name: "{app}\*"
 
 [Files]
-Source: "dist\SmartCitizen-v{#AppVer}\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
+Source: "dist\SmartCitizen\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
 
 [Icons]
-Name: "{group}\Smart Citizen"; Filename: "{app}\SmartCitizen-v{#AppVer}.exe"
+Name: "{group}\Smart Citizen"; Filename: "{app}\SmartCitizen.exe"
 Name: "{group}\{cm:UninstallProgram,Smart Citizen}"; Filename: "{uninstallexe}"
-Name: "{commondesktop}\Smart Citizen"; Filename: "{app}\SmartCitizen-v{#AppVer}.exe"
+Name: "{commondesktop}\Smart Citizen"; Filename: "{app}\SmartCitizen.exe"
 
 [Run]
-Filename: "{app}\SmartCitizen-v{#AppVer}.exe"; Description: "{cm:LaunchProgram,Smart Citizen}"; Flags: nowait postinstall skipifsilent
+Filename: "{app}\SmartCitizen.exe"; Description: "{cm:LaunchProgram,Smart Citizen}"; Flags: nowait postinstall skipifsilent
 
 [Code]
 var

--- a/scripts/build/BUILD_INSTRUCTIONS.md
+++ b/scripts/build/BUILD_INSTRUCTIONS.md
@@ -61,11 +61,11 @@ This will:
 - Clean previous builds
 - Package the application into a single `.exe` file
 - Include all necessary data files (global.ini)
-- Create `dist/SmartCitizen-v0.1.0.exe`
+- Create the onedir build at `dist/SmartCitizen/` with a stable `SmartCitizen.exe` (the name no longer carries the version, so installed shortcuts survive updates)
 
 **Testing the EXE:**
 ```bash
-dist\SmartCitizen-v0.1.0.exe
+dist\SmartCitizen\SmartCitizen.exe
 ```
 
 ---

--- a/scripts/build/build_all.bat
+++ b/scripts/build/build_all.bat
@@ -31,7 +31,7 @@ echo   - Executable created
 echo.
 
 echo Step 4: Verifying onedir build...
-if exist "dist\SmartCitizen-v*\" (
+if exist "dist\SmartCitizen\" (
     echo   - Build folder exists: OK
 ) else (
     echo   - ERROR: Build folder not found!

--- a/scripts/build/build_exe.py
+++ b/scripts/build/build_exe.py
@@ -109,8 +109,22 @@ _cleanup_build_info()
 
 print()
 
-# Build executable with PyInstaller
-exe_name = f"SmartCitizen-{'Portable-' if portable_mode else ''}v{current_version}"
+# Build executable with PyInstaller.
+# The registry / installer build uses a STABLE exe name (SmartCitizen.exe) so
+# the installed path and the desktop / Start Menu shortcuts survive version
+# updates (#104): a copied or pinned shortcut keeps working because the target
+# no longer changes every release. The portable build keeps the versioned name
+# so the downloadable zip and its folder identify the version at a glance.
+exe_name = (
+    f"SmartCitizen-Portable-v{current_version}" if portable_mode else "SmartCitizen"
+)
+
+# Write PyInstaller's generated .spec into build/ (ephemeral, wiped each run)
+# instead of the repo root, so the stable --name never clobbers the
+# hand-maintained root SmartCitizen.spec or litters the root with per-version
+# spec files.
+spec_path = os.path.join(root_dir, 'build')
+os.makedirs(spec_path, exist_ok=True)
 
 assets_dir   = os.path.join(root_dir, 'assets')
 icon_path    = os.path.join(assets_dir, 'logo.ico')
@@ -133,7 +147,7 @@ common_args = [
     '--add-data', f'{patches_dir}{os.pathsep}patches',
     '--add-data', f'{enhancements_script}{os.pathsep}scripts',
     '--workpath', os.path.join(root_dir, 'build'),
-    '--specpath', root_dir,
+    '--specpath', spec_path,
     '--hidden-import=PyQt6',
     '--hidden-import=src.gui',
     '--hidden-import=src.parser',


### PR DESCRIPTION
Fixes #104.

## The bug
The release build named the executable `SmartCitizen-v{VERSION}.exe`, and the installer pointed the desktop / Start Menu shortcuts at that versioned path (`installer.iss`). Every update changed the exe filename, so a shortcut the user copied or pinned to the taskbar broke on each upgrade. Standard practice (and the reporter's ask) is a stable exe name.

## The fix
Make the registry / installer build emit a stable `SmartCitizen.exe`:

- **build_exe.py**: `exe_name` is `SmartCitizen` for the registry build. The **portable** build keeps `SmartCitizen-Portable-v{VERSION}` so its download zip/folder still identifies the version.
- **build_exe.py**: PyInstaller's generated `.spec` now writes to `build/` instead of the repo root. With a stable `--name`, leaving `--specpath` at the root would overwrite the hand-maintained `SmartCitizen.spec`. Bonus: it stops littering the root with per-version spec files.
- **installer.iss**: source dir, both `[Icons]`, and `[Run]` target `SmartCitizen.exe`. The existing `[InstallDelete] {app}\*` already wipes the old versioned exe on upgrade, and `DefaultDirName` is version-independent, so the upgrade is a clean replace. `OutputBaseFilename` (the Setup download) stays versioned.
- **ci.yml**, **build_all.bat**, **BUILD_INSTRUCTIONS.md**: follow the rename.

## Scope
On `release/2.0.0` (major). An exe rename is the right kind of change for a major version, not a patch.

## Verification status (please read)
- **CI dispatched** against this branch verifies the **build half**: that `build_exe.py` emits `dist/SmartCitizen/SmartCitizen.exe` and the updated verify step passes. Linked in checks.
- **Not yet covered**: the installer side (the `{app}\*` wipe removing the old `SmartCitizen-v1.x.exe`, shortcuts recreating onto the stable target, a clean upgrade-over-old-version). Inno Setup isn't in CI. This needs one real install-over-an-old-version run, ideally folded into the same 2.0.0 install/uninstall pass as #103. **Green CI alone does not mean #104 is shippable.**
- Known: the transition update breaks a pre-existing copied shortcut one last time (its old versioned target is deleted); stable for every update after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
