### PR TITLE
fix: hide untranslated languages (Spanish stub) from the selector

### DIFF
--- a/src/gui/config_tab.py
+++ b/src/gui/config_tab.py
@@ -879,6 +879,12 @@ class ConfigTab(QWidget):
                 self.language_combo.addItem(lang.replace("_", " ").title(), userData=lang)
             current = AppSettings.get_selected_language()
             idx = self.language_combo.findData(current)
+            if idx < 0:
+                # The persisted language is no longer offered (e.g. an
+                # untranslated stub that is now hidden). Fall back to the
+                # default so the combo and the stored setting stay in sync.
+                AppSettings.set_selected_language(AppSettings.DEFAULT_LANGUAGE)
+                idx = self.language_combo.findData(AppSettings.DEFAULT_LANGUAGE)
             if idx >= 0:
                 self.language_combo.setCurrentIndex(idx)
         finally:

--- a/src/utils/settings.py
+++ b/src/utils/settings.py
@@ -327,12 +327,50 @@ class AppSettings:
 
     @staticmethod
     def get_available_languages() -> list:
-        """Return sorted list of language names found in the bundled languages/ dir."""
+        """Return sorted language names that are usable in the UI.
+
+        A folder under languages/ is offered only if it ships a non-empty
+        ui.json (at least one translated string); DEFAULT_LANGUAGE (English,
+        the base) is always included. This hides stub languages whose ui.json
+        exists but carries no translations: selecting one would render the
+        whole UI in English and read as broken. The untranslated Spanish
+        placeholder is the motivating case.
+        """
         lang_dir = AppSettings.get_languages_dir()
         if not lang_dir.exists():
             return [AppSettings.DEFAULT_LANGUAGE]
-        names = sorted(d.name for d in lang_dir.iterdir() if d.is_dir())
-        return names if names else [AppSettings.DEFAULT_LANGUAGE]
+        names = []
+        for d in sorted(lang_dir.iterdir()):
+            if not d.is_dir():
+                continue
+            if (d.name == AppSettings.DEFAULT_LANGUAGE
+                    or AppSettings._ui_json_has_translations(d / "ui.json")):
+                names.append(d.name)
+        if AppSettings.DEFAULT_LANGUAGE not in names:
+            names.append(AppSettings.DEFAULT_LANGUAGE)
+        return sorted(names) if names else [AppSettings.DEFAULT_LANGUAGE]
+
+    @staticmethod
+    def _ui_json_has_translations(ui_json_path) -> bool:
+        """True if *ui_json_path* exists and holds at least one translation
+        string. The ``_comment`` metadata field is ignored at every level, so
+        a stub file carrying only a comment counts as empty. Used to keep
+        untranslated languages out of the selector."""
+        import json
+        try:
+            if not ui_json_path.exists():
+                return False
+            with ui_json_path.open(encoding="utf-8") as fh:
+                data = json.load(fh)
+        except (OSError, ValueError):
+            return False
+
+        def _leaf_count(node) -> int:
+            if isinstance(node, dict):
+                return sum(_leaf_count(v) for k, v in node.items() if k != "_comment")
+            return 1
+
+        return isinstance(data, dict) and _leaf_count(data) > 0
 
     @staticmethod
     def get_language_global_ini_path(language: str | None = None) -> "Path | None":

--- a/tests/test_available_languages.py
+++ b/tests/test_available_languages.py
@@ -1,0 +1,67 @@
+"""get_available_languages() hides untranslated stub languages.
+
+A languages/<lang>/ui.json that exists but carries no translation keys (only
+a `_comment`, like the Spanish placeholder) must not appear in the selector:
+selecting it would render the whole UI in English and read as broken. English
+(the base) is always offered, even if its own file were a stub.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+from utils.settings import AppSettings  # noqa: E402
+
+pytestmark = [pytest.mark.unit, pytest.mark.regression]
+
+
+def _make_lang(root: Path, name: str, ui: dict) -> None:
+    d = root / name
+    d.mkdir(parents=True)
+    (d / "ui.json").write_text(json.dumps(ui), encoding="utf-8")
+
+
+@pytest.fixture
+def langs_root(tmp_path, monkeypatch):
+    root = tmp_path / "languages"
+    root.mkdir()
+    monkeypatch.setattr(AppSettings, "get_languages_dir", staticmethod(lambda: root))
+    return root
+
+
+def test_untranslated_stub_is_hidden(langs_root):
+    _make_lang(langs_root, "english", {"toolbar": {"apply": "Apply"}})
+    _make_lang(langs_root, "french", {"toolbar": {"apply": "Appliquer"}})
+    _make_lang(langs_root, "spanish", {"_comment": "TODO: translate"})  # stub
+
+    avail = AppSettings.get_available_languages()
+    assert "spanish" not in avail
+    assert avail == ["english", "french"]
+
+
+def test_english_always_offered_even_if_its_own_file_is_a_stub(langs_root):
+    _make_lang(langs_root, "english", {"_comment": "base lives in code"})
+    assert AppSettings.get_available_languages() == ["english"]
+
+
+def test_missing_ui_json_is_hidden(langs_root):
+    _make_lang(langs_root, "english", {"toolbar": {"apply": "Apply"}})
+    (langs_root / "german").mkdir()  # folder with no ui.json at all
+
+    avail = AppSettings.get_available_languages()
+    assert "german" not in avail
+    assert avail == ["english"]
+
+
+def test_nested_only_comment_counts_as_empty(langs_root):
+    _make_lang(langs_root, "english", {"toolbar": {"apply": "Apply"}})
+    # A file with structure but no real strings (only comments) is still empty.
+    _make_lang(langs_root, "italian", {"_comment": "wip", "toolbar": {"_comment": "wip"}})
+
+    assert "italian" not in AppSettings.get_available_languages()


### PR DESCRIPTION
Found during the open-issue triage: switching the UI language to Spanish did nothing. Cause is not a missing file but an empty one.

## Diagnosis
`languages/spanish/ui.json` exists but has **0 of 214** strings translated (just a `_comment`). When selected, `set_language("spanish")` loads the English base, overlays an empty file, and the whole UI stays English, so it reads as broken. French and Portuguese-BR are ~94% translated and work fine.

| Language | translated | offered now |
|---|---|---|
| english (base) | 214 | yes |
| french | 203 / 214 | yes |
| portuguese_br | 203 / 214 | yes |
| spanish | 0 / 214 | **hidden** |

(Per your preference to avoid AI translations, this PR does **not** fill in Spanish; it just stops offering it until someone translates it.)

## Change
- `get_available_languages()` offers a language only if its `ui.json` carries at least one real string. English is always offered. When Spanish is translated later, it reappears automatically with no code change.
- Config tab self-heals a stale selection: if the persisted language is no longer offered (a user who'd picked Spanish before), it falls back to English so the combo and the stored setting agree.
- 4 new tests: stub hidden, missing `ui.json` hidden, nested comment-only counts as empty, English always offered.

## Verification
- Full suite: 665 passed, 16 skipped.
- Real bundle now resolves to `['english', 'french', 'portuguese_br']`.
- CI dispatched against this branch (linked in checks).

On `release/2.0.0` (the i18n feature lives here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
