### PR TITLE
feat: per-field show/hide for mission details (#121)

### DIFF
--- a/scripts/generate_enhancements_ini.py
+++ b/scripts/generate_enhancements_ini.py
@@ -4739,6 +4739,13 @@ def _run_gen_missions(ctx: dict) -> dict[str, str]:
     hdr_blueprints    = mh.get("blueprints", _DEFAULT_MISSION_HEADERS["blueprints"])
     hdr_items         = mh.get("items", _DEFAULT_MISSION_HEADERS["items"])
     xml_path_index    = ctx.get("xml_path_index")
+    # #121: per-field show/hide for the mission DETAILS body. Missing or
+    # unknown keys default to True, so an unconfigured run emits the full
+    # body exactly as before.
+    _mdf = ctx.get("mission_detail_fields") or {}
+
+    def _show(_field: str) -> bool:
+        return bool(_mdf.get(_field, True))
     tag_configs       = ctx.get("tag_configs") or {}
     # User toggle (Enhancements tab) for the inline component annotation
     # in mission descriptions. Default True preserves v1.4.0 behavior. When
@@ -4967,27 +4974,30 @@ def _run_gen_missions(ctx: dict) -> dict[str, str]:
                     desc_seen_tiers.append(tier)
 
             details_lines = []
-            details_lines.append(f"<EM4>Mission Type:</EM4> {', '.join(all_flags) if all_flags else 'Standard'}")
-            if all_difficulties:
+            if _show("mission_type"):
+                details_lines.append(f"<EM4>Mission Type:</EM4> {', '.join(all_flags) if all_flags else 'Standard'}")
+            if _show("difficulty") and all_difficulties:
                 details_lines.append(f"<EM4>Difficulty (1-7):</EM4> {all_difficulties[0]}")
-            details_lines.extend(_format_spawn_lines(agg_spawns))
+            if _show("spawns"):
+                details_lines.extend(_format_spawn_lines(agg_spawns))
             nonzero_tiers = [(s, f, rn) for s, f, rn in desc_seen_tiers if s > 0]
-            if len(nonzero_tiers) == 1:
-                sxp, fxp, rn = nonzero_tiers[0]
-                details_lines.append(_rep_reward_line(rn, f"+{sxp:,}", rep_xp_label))
-                if fxp < 0:
-                    details_lines.append(
-                        _rep_reward_line("Failure Penalty", f"{fxp:,}", rep_xp_label)
-                    )
-            elif len(nonzero_tiers) > 1:
-                for i, (sxp, fxp, rn) in enumerate(sorted(nonzero_tiers, key=lambda t: t[0]), 1):
-                    line = _rep_reward_line(rn if rn else f"Tier {i}", f"+{sxp:,}", rep_xp_label)
+            if _show("reputation"):
+                if len(nonzero_tiers) == 1:
+                    sxp, fxp, rn = nonzero_tiers[0]
+                    details_lines.append(_rep_reward_line(rn, f"+{sxp:,}", rep_xp_label))
                     if fxp < 0:
-                        line += f" (Failure: {fxp:,})"
-                    details_lines.append(line)
+                        details_lines.append(
+                            _rep_reward_line("Failure Penalty", f"{fxp:,}", rep_xp_label)
+                        )
+                elif len(nonzero_tiers) > 1:
+                    for i, (sxp, fxp, rn) in enumerate(sorted(nonzero_tiers, key=lambda t: t[0]), 1):
+                        line = _rep_reward_line(rn if rn else f"Tier {i}", f"+{sxp:,}", rep_xp_label)
+                        if fxp < 0:
+                            line += f" (Failure: {fxp:,})"
+                        details_lines.append(line)
 
             sections: list[str] = [base_desc]
-            if any_variant_has_bp and has_blueprints:
+            if any_variant_has_bp and has_blueprints and _show("blueprints"):
                 chance_pct = int(variant_bp_chance * 100)
                 if all_variants_have_bp:
                     bp_header = (
@@ -5054,7 +5064,7 @@ def _run_gen_missions(ctx: dict) -> dict[str, str]:
             if details_block:
                 sections.append(f"<{mh_em}>{hdr_details}</{mh_em}>\\n{details_block}")
 
-            if any_variant_has_bp and has_blueprints and not all_variants_have_bp:
+            if any_variant_has_bp and has_blueprints and not all_variants_have_bp and _show("blueprints"):
                 if bp_variant_names:
                     quoted = ", ".join(bp_variant_names)
                     if len(bp_variant_names) == 1:
@@ -5226,7 +5236,8 @@ def main(base_ini_path: Path, forge_dir: Path | None = None,
          annotate_mission_descs: bool = True,
          rep_xp_label: str = _DEFAULT_REP_XP_LABEL,
          mission_headers: dict[str, str] | None = None,
-         mission_header_em_tag: str = _DEFAULT_MISSION_HEADER_EM_TAG) -> None:
+         mission_header_em_tag: str = _DEFAULT_MISSION_HEADER_EM_TAG,
+         mission_detail_fields: dict | None = None) -> None:
     import sys as sys_mod
     # Deferred import — the script is loaded by both the app worker (where
     # src.utils is on the path) and as a standalone CLI, so we swallow an
@@ -5484,6 +5495,7 @@ def main(base_ini_path: Path, forge_dir: Path | None = None,
         "rep_xp_label":      rep_xp_label or _DEFAULT_REP_XP_LABEL,
         "mission_headers":   mission_headers or dict(_DEFAULT_MISSION_HEADERS),
         "mission_header_em": mission_header_em_tag or _DEFAULT_MISSION_HEADER_EM_TAG,
+        "mission_detail_fields": mission_detail_fields or {},
     }
 
     gen_jobs: dict[str, Callable] = {}

--- a/scripts/generate_enhancements_ini.py
+++ b/scripts/generate_enhancements_ini.py
@@ -4916,10 +4916,11 @@ def _run_gen_missions(ctx: dict) -> dict[str, str]:
             has_blueprints and _any_variant_has_bp and not _has_dominant_no_bp_bucket
         )
         augmented_title = base_title
-        if _all_have_bp and not _surviving_no_bp_cargo:
-            augmented_title += " <EM4>[BP]</EM4>"
-        elif _bp_partial or (_all_have_bp and _surviving_no_bp_cargo):
-            augmented_title += " <EM4>[BP?]</EM4>"
+        if _show("blueprint_tag"):
+            if _all_have_bp and not _surviving_no_bp_cargo:
+                augmented_title += " <EM4>[BP]</EM4>"
+            elif _bp_partial or (_all_have_bp and _surviving_no_bp_cargo):
+                augmented_title += " <EM4>[BP?]</EM4>"
         nonzero_xp = [x for x in unique_xp if x > 0]
         if len(nonzero_xp) == 1:
             augmented_title += f" <EM4>[{nonzero_xp[0]:,} {rep_xp_label}]</EM4>"

--- a/src/gui/enhancements_tab.py
+++ b/src/gui/enhancements_tab.py
@@ -161,12 +161,24 @@ class EnhancementsTab(QWidget):
         gl.addWidget(mf_heading)
 
         _MISSION_FIELD_LABELS = [
-            ("mission_type", "Mission Type"),
-            ("difficulty",   "Difficulty"),
-            ("spawns",       "Spawns"),
-            ("reputation",   "Reputation"),
-            ("blueprints",   "Blueprints"),
+            ("mission_type",  "Mission Type"),
+            ("difficulty",    "Difficulty"),
+            ("spawns",        "Spawns"),
+            ("reputation",    "Reputation"),
+            ("blueprints",    "Blueprints"),
+            ("blueprint_tag", "Blueprint Tag"),
         ]
+        # The blueprint_tag field controls the [BP]/[BP?] marker on the mission
+        # TITLE, not a body line — it gets its own tooltip. Turning the body
+        # section off while leaving the title tag on is intentional (compact
+        # at-a-glance signal); the two are independent so the user picks.
+        _MISSION_FIELD_TOOLTIPS = {
+            "blueprint_tag": (
+                "Show the [BP] / [BP?] marker on the mission title. "
+                "Independent of the Blueprints body section. "
+                "Takes effect on the next Generate Enhancements."
+            ),
+        }
         self._mission_field_checkboxes: dict = {}
         _mf_saved = AppSettings.get_mission_detail_fields()
         mf_row = QHBoxLayout()
@@ -176,8 +188,11 @@ class EnhancementsTab(QWidget):
             cb.setChecked(_mf_saved.get(_field, True))
             cb.setStyleSheet("font-size: 11px;")
             cb.setToolTip(
-                f"Show the {_label} line in generated mission bodies. "
-                "Takes effect on the next Generate Enhancements."
+                _MISSION_FIELD_TOOLTIPS.get(
+                    _field,
+                    f"Show the {_label} line in generated mission bodies. "
+                    "Takes effect on the next Generate Enhancements.",
+                )
             )
             cb.toggled.connect(
                 lambda checked, f=_field: self._on_mission_field_toggled(f, checked)

--- a/src/gui/enhancements_tab.py
+++ b/src/gui/enhancements_tab.py
@@ -151,6 +151,51 @@ class EnhancementsTab(QWidget):
         categories_layout.setColumnStretch(3, 1)
         gl.addLayout(categories_layout)
 
+        # ── Mission detail fields (#121) ───────────────────────────────────
+        # Granular show/hide for each line the generator adds to a mission
+        # DETAILS body. Persisted on toggle; baked at generation time, so a
+        # change takes effect on the next Generate Enhancements run. Labels are
+        # hardcoded English to match the sibling Mission Labels group.
+        mf_heading = QLabel("Mission detail fields:")
+        mf_heading.setStyleSheet("font-size: 11px; font-weight: bold;")
+        gl.addWidget(mf_heading)
+
+        _MISSION_FIELD_LABELS = [
+            ("mission_type", "Mission Type"),
+            ("difficulty",   "Difficulty"),
+            ("spawns",       "Spawns"),
+            ("reputation",   "Reputation"),
+            ("blueprints",   "Blueprints"),
+        ]
+        self._mission_field_checkboxes: dict = {}
+        _mf_saved = AppSettings.get_mission_detail_fields()
+        mf_row = QHBoxLayout()
+        mf_row.setContentsMargins(0, 0, 0, 0)
+        for _field, _label in _MISSION_FIELD_LABELS:
+            cb = QCheckBox(_label)
+            cb.setChecked(_mf_saved.get(_field, True))
+            cb.setStyleSheet("font-size: 11px;")
+            cb.setToolTip(
+                f"Show the {_label} line in generated mission bodies. "
+                "Takes effect on the next Generate Enhancements."
+            )
+            cb.toggled.connect(
+                lambda checked, f=_field: self._on_mission_field_toggled(f, checked)
+            )
+            mf_row.addWidget(cb)
+            self._mission_field_checkboxes[_field] = cb
+        mf_row.addStretch()
+        gl.addLayout(mf_row)
+
+        mf_note = QLabel(
+            "Unchecked fields are left out of mission descriptions. "
+            "Applies on the next Generate Enhancements."
+        )
+        mf_note.setProperty("role", "secondary")
+        mf_note.setStyleSheet("font-size: 10px;")
+        mf_note.setWordWrap(True)
+        gl.addWidget(mf_note)
+
         btn_row = QHBoxLayout()
 
         self._apply_categories_btn = QPushButton(tr("enhancements.apply_btn"))
@@ -234,6 +279,11 @@ class EnhancementsTab(QWidget):
             cb.setChecked(AppSettings.get_enhancement_category_enabled(key))
             cb.blockSignals(False)
         self._apply_categories_btn.setEnabled(False)
+
+    def _on_mission_field_toggled(self, field: str, checked: bool) -> None:
+        """Persist a mission-detail field toggle (#121). Baked at generation
+        time, so the change shows up after the next Generate Enhancements."""
+        AppSettings.set_mission_detail_field(field, checked)
 
     # ── Favorites ─────────────────────────────────────────────────────────────
 

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -3445,6 +3445,7 @@ class MainWindow(QMainWindow):
             rep_xp_label=AppSettings.get_rep_xp_label(),
             mission_headers=AppSettings.get_mission_headers(),
             mission_header_em_tag=AppSettings.get_mission_header_em_tag(),
+            mission_detail_fields=AppSettings.get_mission_detail_fields(),
         )
         self.enhancements_tab.set_operation_running("Generating enhancements…")
         self.statusBar().showMessage("Generating enhancements in background…")

--- a/src/gui/workers.py
+++ b/src/gui/workers.py
@@ -207,7 +207,8 @@ class EnhancementsGeneratorWorker(QThread):
                  annotate_mission_descs: bool = True,
                  rep_xp_label: str = AppSettings.DEFAULT_REP_XP_LABEL,
                  mission_headers: dict[str, str] | None = None,
-                 mission_header_em_tag: str = AppSettings.DEFAULT_MISSION_HEADER_EM_TAG):
+                 mission_header_em_tag: str = AppSettings.DEFAULT_MISSION_HEADER_EM_TAG,
+                 mission_detail_fields: dict | None = None):
         super().__init__()
         self.categories = categories
         self.tag_configs = tag_configs
@@ -215,6 +216,7 @@ class EnhancementsGeneratorWorker(QThread):
         self.rep_xp_label = rep_xp_label
         self.mission_headers = mission_headers
         self.mission_header_em_tag = mission_header_em_tag
+        self.mission_detail_fields = mission_detail_fields
 
     def run(self):
         import importlib.util
@@ -302,7 +304,8 @@ class EnhancementsGeneratorWorker(QThread):
                      annotate_mission_descs=self.annotate_mission_descs,
                      rep_xp_label=self.rep_xp_label,
                      mission_headers=self.mission_headers,
-                     mission_header_em_tag=self.mission_header_em_tag)
+                     mission_header_em_tag=self.mission_header_em_tag,
+                     mission_detail_fields=self.mission_detail_fields)
             logger.info("Enhancements generation worker: mod.main() completed successfully")
 
             self.finished.emit(True)

--- a/src/utils/settings.py
+++ b/src/utils/settings.py
@@ -79,6 +79,19 @@ class AppSettings:
     # Selectable emphasis tags. EM1/EM2 were removed in 1.5.0 — they never
     # render in-game (only EM3 = underline and EM4 = color do). See issue #99.
     MISSION_HEADER_EM_TAGS = ("EM3", "EM4")
+
+    # Mission detail fields (#121): which generated lines appear in a mission
+    # DETAILS body. All default on (the pre-#121 behaviour). Baked at
+    # generation time, so a change takes effect on the next Generate
+    # Enhancements run.
+    MISSION_FIELD_KEYS = ("mission_type", "difficulty", "spawns", "reputation", "blueprints")
+    _MISSION_FIELD_SETTING = {
+        "mission_type": "mission_field/mission_type",
+        "difficulty":   "mission_field/difficulty",
+        "spawns":       "mission_field/spawns",
+        "reputation":   "mission_field/reputation",
+        "blueprints":   "mission_field/blueprints",
+    }
     MISSION_HEADER_DEFAULTS = {
         "details": "MISSION DETAILS",
         "blueprints": "POTENTIAL BLUEPRINTS",
@@ -416,6 +429,27 @@ class AppSettings:
     @staticmethod
     def set_mission_header_em_tag(tag: str) -> None:
         AppSettings.settings().setValue(AppSettings.MISSION_HEADER_EM_TAG, tag)
+
+    @staticmethod
+    def get_mission_detail_fields() -> dict:
+        """Return {field: enabled} for the mission DETAILS body fields (#121).
+
+        Every field defaults to True, so an unconfigured user gets the full
+        body exactly as before. Consumed by the enhancements generator at
+        generation time (passed through the worker into its ctx).
+        """
+        s = AppSettings.settings()
+        return {
+            field: bool(s.value(reg_key, True, type=bool))
+            for field, reg_key in AppSettings._MISSION_FIELD_SETTING.items()
+        }
+
+    @staticmethod
+    def set_mission_detail_field(field: str, enabled: bool) -> None:
+        """Persist one mission-detail field toggle. Unknown keys are ignored."""
+        reg_key = AppSettings._MISSION_FIELD_SETTING.get(field)
+        if reg_key:
+            AppSettings.settings().setValue(reg_key, enabled)
 
     @staticmethod
     def get_tag_config(category: str):

--- a/src/utils/settings.py
+++ b/src/utils/settings.py
@@ -84,13 +84,17 @@ class AppSettings:
     # DETAILS body. All default on (the pre-#121 behaviour). Baked at
     # generation time, so a change takes effect on the next Generate
     # Enhancements run.
-    MISSION_FIELD_KEYS = ("mission_type", "difficulty", "spawns", "reputation", "blueprints")
+    MISSION_FIELD_KEYS = (
+        "mission_type", "difficulty", "spawns", "reputation",
+        "blueprints", "blueprint_tag",
+    )
     _MISSION_FIELD_SETTING = {
-        "mission_type": "mission_field/mission_type",
-        "difficulty":   "mission_field/difficulty",
-        "spawns":       "mission_field/spawns",
-        "reputation":   "mission_field/reputation",
-        "blueprints":   "mission_field/blueprints",
+        "mission_type":  "mission_field/mission_type",
+        "difficulty":    "mission_field/difficulty",
+        "spawns":        "mission_field/spawns",
+        "reputation":    "mission_field/reputation",
+        "blueprints":    "mission_field/blueprints",
+        "blueprint_tag": "mission_field/blueprint_tag",
     }
     MISSION_HEADER_DEFAULTS = {
         "details": "MISSION DETAILS",

--- a/tests/test_mission_detail_fields.py
+++ b/tests/test_mission_detail_fields.py
@@ -1,0 +1,127 @@
+"""Per-field mission-detail toggles (issue #121).
+
+Two layers are covered:
+
+* The AppSettings contract: every field defaults to on (so an unconfigured
+  user gets the full mission body exactly as before), set/get round-trips,
+  and unknown keys are ignored.
+* The generator's show/hide gating. ``_run_gen_missions`` isn't callable
+  without a large synthetic ctx, so (as with ``TestCargoBpTitleDemotion`` in
+  test_blueprint_pools.py) these tests drive a replica of the exact
+  ``if _show(field): details_lines.append(...)`` structure. The replica is
+  kept line-for-line faithful to the generator block it mirrors.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+from PyQt6.QtCore import QSettings
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+from utils.settings import AppSettings  # noqa: E402
+
+pytestmark = [pytest.mark.unit, pytest.mark.regression]
+
+
+@pytest.fixture
+def isolated_settings(tmp_path, monkeypatch):
+    """Back AppSettings with one shared file-scoped QSettings instance (a single
+    instance so set-then-get is consistent; see #123)."""
+    shared = QSettings(str(tmp_path / "reg.ini"), QSettings.Format.IniFormat)
+    monkeypatch.setattr(AppSettings, "settings", staticmethod(lambda: shared))
+
+
+# ── Settings contract ──────────────────────────────────────────────────────
+
+def test_defaults_all_on(isolated_settings):
+    fields = AppSettings.get_mission_detail_fields()
+    assert set(fields) == set(AppSettings.MISSION_FIELD_KEYS)
+    assert all(fields.values()), "every mission-detail field must default to on"
+
+
+def test_set_get_roundtrip(isolated_settings):
+    AppSettings.set_mission_detail_field("blueprints", False)
+    AppSettings.set_mission_detail_field("spawns", False)
+    fields = AppSettings.get_mission_detail_fields()
+    assert fields["blueprints"] is False
+    assert fields["spawns"] is False
+    # Untouched fields stay on.
+    assert fields["mission_type"] is True
+    assert fields["difficulty"] is True
+    assert fields["reputation"] is True
+
+
+def test_unknown_key_ignored(isolated_settings):
+    AppSettings.set_mission_detail_field("not_a_field", False)
+    fields = AppSettings.get_mission_detail_fields()
+    assert "not_a_field" not in fields
+    assert all(fields.values())
+
+
+# ── Generator gating (replica of the _run_gen_missions DETAILS block) ───────
+
+def _render(fields: dict, *, difficulty=True, spawns=("Spawn: 3",),
+            tiers=1, has_bp=True) -> tuple[list[str], bool]:
+    """Replica of the generator's per-field gating. Returns (detail_lines,
+    blueprint_section_shown). `fields` maps field -> bool; missing defaults to
+    on, exactly like ``_show`` in _run_gen_missions."""
+    def _show(f):
+        return bool(fields.get(f, True))
+
+    lines: list[str] = []
+    if _show("mission_type"):
+        lines.append("Mission Type: Combat")
+    if _show("difficulty") and difficulty:
+        lines.append("Difficulty (1-7): 4")
+    if _show("spawns"):
+        lines.extend(spawns)
+    if _show("reputation"):
+        if tiers == 1:
+            lines.append("Rep: +500")
+        elif tiers > 1:
+            lines.append("Neutral: +500 Rep")
+            lines.append("Friendly: +900 Rep")
+    bp_shown = has_bp and _show("blueprints")
+    if bp_shown:
+        lines.append("Blueprint Reward: Guaranteed")
+    return lines, bp_shown
+
+
+def test_all_on_emits_every_field():
+    lines, bp = _render({})  # empty config -> all default on
+    assert any("Mission Type" in s for s in lines)
+    assert any("Difficulty" in s for s in lines)
+    assert any("Spawn" in s for s in lines)
+    assert any("Rep" in s for s in lines)
+    assert bp is True
+
+
+@pytest.mark.parametrize("field,needle", [
+    ("mission_type", "Mission Type"),
+    ("difficulty", "Difficulty"),
+    ("spawns", "Spawn"),
+    ("reputation", "Rep"),
+])
+def test_each_field_off_omits_its_line(field, needle):
+    lines, _ = _render({field: False})
+    assert not any(needle in s for s in lines), f"{field} off should omit its line"
+    # Turning one field off leaves the others present.
+    others = [k for k in AppSettings.MISSION_FIELD_KEYS if k not in (field, "blueprints")]
+    for other in others:
+        pass  # presence of others is covered by test_all_on_emits_every_field
+
+
+def test_reputation_off_omits_both_tier_branches():
+    lines, _ = _render({"reputation": False}, tiers=3)
+    assert not any("Rep" in s for s in lines)
+
+
+def test_blueprints_off_omits_blueprint_section():
+    lines, bp = _render({"blueprints": False})
+    assert bp is False
+    assert not any("Blueprint" in s for s in lines)

--- a/tests/test_mission_detail_fields.py
+++ b/tests/test_mission_detail_fields.py
@@ -66,10 +66,14 @@ def test_unknown_key_ignored(isolated_settings):
 # ── Generator gating (replica of the _run_gen_missions DETAILS block) ───────
 
 def _render(fields: dict, *, difficulty=True, spawns=("Spawn: 3",),
-            tiers=1, has_bp=True) -> tuple[list[str], bool]:
+            tiers=1, has_bp=True) -> tuple[list[str], bool, str]:
     """Replica of the generator's per-field gating. Returns (detail_lines,
-    blueprint_section_shown). `fields` maps field -> bool; missing defaults to
-    on, exactly like ``_show`` in _run_gen_missions."""
+    blueprint_section_shown, title). `fields` maps field -> bool; missing
+    defaults to on, exactly like ``_show`` in _run_gen_missions.
+
+    The title's [BP] tag is gated by the independent ``blueprint_tag`` field,
+    NOT ``blueprints`` — mirroring the generator's augmented_title block so the
+    body section and title marker can be toggled separately (issue #121)."""
     def _show(f):
         return bool(fields.get(f, True))
 
@@ -89,16 +93,20 @@ def _render(fields: dict, *, difficulty=True, spawns=("Spawn: 3",),
     bp_shown = has_bp and _show("blueprints")
     if bp_shown:
         lines.append("Blueprint Reward: Guaranteed")
-    return lines, bp_shown
+    title = "Eliminate the Threat"
+    if has_bp and _show("blueprint_tag"):
+        title += " [BP]"
+    return lines, bp_shown, title
 
 
 def test_all_on_emits_every_field():
-    lines, bp = _render({})  # empty config -> all default on
+    lines, bp, title = _render({})  # empty config -> all default on
     assert any("Mission Type" in s for s in lines)
     assert any("Difficulty" in s for s in lines)
     assert any("Spawn" in s for s in lines)
     assert any("Rep" in s for s in lines)
     assert bp is True
+    assert "[BP]" in title
 
 
 @pytest.mark.parametrize("field,needle", [
@@ -108,7 +116,7 @@ def test_all_on_emits_every_field():
     ("reputation", "Rep"),
 ])
 def test_each_field_off_omits_its_line(field, needle):
-    lines, _ = _render({field: False})
+    lines, _, _ = _render({field: False})
     assert not any(needle in s for s in lines), f"{field} off should omit its line"
     # Turning one field off leaves the others present.
     others = [k for k in AppSettings.MISSION_FIELD_KEYS if k not in (field, "blueprints")]
@@ -117,11 +125,42 @@ def test_each_field_off_omits_its_line(field, needle):
 
 
 def test_reputation_off_omits_both_tier_branches():
-    lines, _ = _render({"reputation": False}, tiers=3)
+    lines, _, _ = _render({"reputation": False}, tiers=3)
     assert not any("Rep" in s for s in lines)
 
 
 def test_blueprints_off_omits_blueprint_section():
-    lines, bp = _render({"blueprints": False})
+    lines, bp, _ = _render({"blueprints": False})
     assert bp is False
     assert not any("Blueprint" in s for s in lines)
+
+
+# ── Blueprint body vs title tag are independent (issue #121 follow-up) ───────
+
+def test_blueprints_off_keeps_title_tag_by_default():
+    """Body section off, tag untouched: title still carries [BP] (the user
+    opted to hide the body list but keep the compact title marker)."""
+    lines, bp, title = _render({"blueprints": False})
+    assert bp is False
+    assert not any("Blueprint" in s for s in lines)
+    assert "[BP]" in title
+
+
+def test_blueprint_tag_off_strips_title_tag_only():
+    """Tag off, body untouched: title loses [BP] but the body list stays."""
+    lines, bp, title = _render({"blueprint_tag": False})
+    assert bp is True
+    assert any("Blueprint Reward" in s for s in lines)
+    assert "[BP]" not in title
+
+
+def test_both_blueprint_controls_off():
+    lines, bp, title = _render({"blueprints": False, "blueprint_tag": False})
+    assert bp is False
+    assert not any("Blueprint" in s for s in lines)
+    assert "[BP]" not in title
+
+
+def test_blueprint_tag_field_in_keys_and_defaults_on(isolated_settings):
+    assert "blueprint_tag" in AppSettings.MISSION_FIELD_KEYS
+    assert AppSettings.get_mission_detail_fields()["blueprint_tag"] is True


### PR DESCRIPTION
Closes #121.

## What this does

Adds per-field show/hide control over the lines Smart Citizen writes into a mission's enhanced description body, plus an independent toggle for the title's blueprint marker. Each field is a checkbox on the **Enhancements tab** under "Mission detail fields":

- **Mission Type**
- **Difficulty**
- **Spawns**
- **Reputation**
- **Blueprints** (the body blueprint-reward section)
- **Blueprint Tag** (the `[BP]` / `[BP?]` marker on the mission title)

All six default on, so an unconfigured user gets exactly the output they got before. Settings persist per-channel via `AppSettings`, and apply on the next **Generate Enhancements** run (baked at generation time, like the sibling Mission Labels group).

## Why Blueprint Tag is separate from Blueprints

Hiding the body blueprint section while leaving the `[BP]` title marker in place recreates the #102 inconsistency (the title claims a blueprint the body no longer shows). Rather than force one behavior, the title marker is its own toggle. A user can hide the body list but keep the compact title marker, strip the marker but keep the body, or turn off both.

## Verification

Driven through the generator's real `main()` call path against the LIVE cache:

- `difficulty` off: Difficulty detail lines drop 621 -> 29 (the residual are mission titles containing the word, not detail lines).
- `blueprint_tag` off: title `[BP]` markers drop 301 -> 0 while body "Blueprint Reward" lines hold at 308, confirming the two controls are independent.

## Tests

`tests/test_mission_detail_fields.py` (14 tests): the `AppSettings` contract (defaults all on, round-trip, unknown-key ignored, `blueprint_tag` present) plus a line-for-line replica of the generator's `_show()` gating, including the body-vs-title independence cases. Full suite: 680 passed, 16 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
