### PR TITLE
fix: guard installer data/cache page prefills against stale paths (#120)

### DIFF
--- a/installer.iss
+++ b/installer.iss
@@ -101,6 +101,64 @@ begin
   Result := ExpandConstant('{%USERPROFILE}\Documents\Smart Citizen');
 end;
 
+function HasVersionedAppSegment(const Path: String): Boolean;
+var
+  Remaining, Seg, Low, Rest: String;
+  P: Integer;
+begin
+  { True if any path segment is the app name followed by a version-like
+    token, e.g. 'SmartCitizen-v1.4.1' or 'Smart Citizen 1.4.1'. The data and
+    cache defaults have always been the unversioned 'Smart Citizen', so a
+    version suffix only ever comes from an old install layout, never a real
+    folder choice. Case-insensitive; checks every segment so a versioned
+    segment mid-path is caught too. Issue #120. }
+  Result := False;
+  Remaining := Path;
+  while Remaining <> '' do
+  begin
+    P := Pos('\', Remaining);
+    if P = 0 then
+    begin
+      Seg := Remaining;
+      Remaining := '';
+    end
+    else
+    begin
+      Seg := Copy(Remaining, 1, P - 1);
+      Remaining := Copy(Remaining, P + 1, MaxInt);
+    end;
+    Low := LowerCase(Seg);
+    if Pos('smartcitizen', Low) = 1 then
+      Rest := Copy(Low, Length('smartcitizen') + 1, MaxInt)
+    else if Pos('smart citizen', Low) = 1 then
+      Rest := Copy(Low, Length('smart citizen') + 1, MaxInt)
+    else
+      Continue;
+    { Strip a leading separator / 'v' so '-v1.4.1', ' 1.4.1', '_v2.0' match,
+      while 'Smart Citizen' (no suffix) and 'SmartCitizenVault' do not. }
+    while (Rest <> '') and ((Rest[1] = ' ') or (Rest[1] = '-') or
+          (Rest[1] = '_') or (Rest[1] = 'v')) do
+      Rest := Copy(Rest, 2, MaxInt);
+    if (Rest <> '') and (Rest[1] >= '0') and (Rest[1] <= '9') then
+    begin
+      Result := True;
+      Exit;
+    end;
+  end;
+end;
+
+function IsStalePrefill(const Path: String): Boolean;
+begin
+  { A saved data/cache path should NOT be used as the wizard prefill when it
+    no longer exists on disk, or it points at a versioned app folder left
+    over from an old install. Either way the page falls back to the default.
+    Defensive guard for issue #120: the reported stale 'SmartCitizen 1.4.1'
+    value was confirmed to live in the SC-install-path keys (fixed in #119),
+    but the data/cache pages read separate keys with no equivalent check, so
+    this hardens them against any stale versioned value reaching the prefill. }
+  Result := (not DirExists(Path)) or HasVersionedAppSegment(Path);
+end;
+
 function GetUninstallString(): String;
 var
   sUnInstPath: String;
@@ -776,9 +834,11 @@ begin
   );
   DataDirPage.Add('');
 
-  { Pre-fill: existing override > OneDrive suggestion > Documents default. }
+  { Pre-fill: existing override > OneDrive suggestion > Documents default.
+    A stale value (missing folder or versioned leftover) falls through to
+    the default rather than prefilling a bad path. Issue #120. }
   if RegQueryStringValue(HKCU, NewRegPath, 'user_data_dir', SavedDataDir) and
-     (SavedDataDir <> '') then
+     (SavedDataDir <> '') and not IsStalePrefill(SavedDataDir) then
     DataDirPage.Values[0] := SavedDataDir
   else if IsDocsOnOneDrive() then
     DataDirPage.Values[0] := SuggestLocalDataDir()
@@ -819,7 +879,7 @@ begin
     branch because LOCALAPPDATA is the OneDrive-safe location by
     definition (it's machine-local, never roamed). }
   if RegQueryStringValue(HKCU, NewRegPath, 'cache_dir', SavedDataDir) and
-     (SavedDataDir <> '') then
+     (SavedDataDir <> '') and not IsStalePrefill(SavedDataDir) then
     CacheDirPage.Values[0] := SavedDataDir
   else
     CacheDirPage.Values[0] := GetLocalCacheDefault();


### PR DESCRIPTION
Addresses #120.

## What this does

Hardens the installer's **Data Location** and **DataForge Cache** wizard pages against prefilling a stale path. Both pages read their saved value (`user_data_dir` / `cache_dir`) from the registry and previously used it on a non-empty check alone.

#119 already added `IsValidSCPath` to reject stale values like `SmartCitizen 1.4.1` on the SC-directory page, but that guard checks for Star Citizen channel subdirectories (LIVE, PTU, ...). It **cannot** be reused on these two pages: a data/cache folder never contains channels, so it would reject every valid path.

So this adds a targeted guard:

- `HasVersionedAppSegment(path)` returns true when any path segment is the app name followed by a version-like token: `SmartCitizen 1.4.1`, `SmartCitizen-v1.4.1`, `Smart Citizen 2.0.0`, case-insensitive, mid-path included. The unversioned `Smart Citizen` default and lookalikes (`SmartCitizenVault`, `Smart Citizenship`) are kept.
- `IsStalePrefill(path)` rejects a saved value when it no longer exists on disk **or** matches that versioned pattern. The page then falls back to its default.

## Honest scoping

This is defensive hardening, not a confirmed live gap. Investigation found:

- The data/cache defaults (`SuggestLocalDataDir`, `GetLocalCacheDefault`) were **never** versioned, in any release back to 0.9.2; they've always been the unversioned `Smart Citizen`.
- #119's own commit message confirms the reported `SmartCitizen 1.4.1` value lived in the **SC-install-path** registry keys (which #119 fixed), not `user_data_dir` / `cache_dir`.

So the original symptom was most likely the #119-fixed SC-path value. This guard closes the gap on these two pages regardless of where a stale value might originate, so they can't independently surface one.

## Verification

- `ISCC` compiles the `[Code]` section clean (the only compile error is the expected missing `dist\` build output at the `[Files]` stage, unrelated to this change).
- No Python changed, so the test suite is unaffected.
- The matcher logic was ported to Python and run against 9 edge cases: versioned variants (space / `-v` / `_v` / mid-path) rejected; the valid `Smart Citizen` default, its subpaths, `SmartCitizenVault`, `Smart Citizenship`, and a real SC install path all kept.

Note: there is no automated test path for Inno Setup Pascal, so the logic check above is the coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
