### PR TITLE
fix: bundle languages/ so the frozen UI shows text, not raw keys

### DIFF
--- a/scripts/build/build_exe.py
+++ b/scripts/build/build_exe.py
@@ -132,6 +132,7 @@ about_file   = os.path.join(root_dir, 'docs', 'ABOUT.md')
 help_file    = os.path.join(root_dir, 'docs', 'HELP.md')
 legal_file   = os.path.join(root_dir, 'docs', 'LEGAL.md')
 patches_dir  = os.path.join(root_dir, 'patches')
+languages_dir = os.path.join(root_dir, 'languages')
 enhancements_script = os.path.join(root_dir, 'scripts', 'generate_enhancements_ini.py')
 
 common_args = [
@@ -145,6 +146,11 @@ common_args = [
     '--add-data', f'{legal_file}{os.pathsep}docs',
     '--add-data', f'{assets_dir}{os.pathsep}assets',
     '--add-data', f'{patches_dir}{os.pathsep}patches',
+    # UI translation files. Without this the frozen app can't resolve any
+    # tr() key (get_resource_path misses languages/<lang>/ui.json), so the
+    # whole UI renders raw keys like 'branding.title'. Mirrors the
+    # ('languages', 'languages') entry in SmartCitizen.spec.
+    '--add-data', f'{languages_dir}{os.pathsep}languages',
     '--add-data', f'{enhancements_script}{os.pathsep}scripts',
     '--workpath', os.path.join(root_dir, 'build'),
     '--specpath', spec_path,


### PR DESCRIPTION
## The bug

The installed 2.0.0 build showed raw i18n keys everywhere (`branding.title`, `toolbar.apply_btn`, ...) instead of translated text.

## Cause

`scripts/build/build_exe.py` (the build path the release checklist uses to produce the installer) never added the `languages/` directory to its PyInstaller `--add-data` list. So the frozen app shipped with **no** `ui.json`. At runtime `get_resource_path("languages/<lang>/ui.json")` missed, `i18n._load_file` returned `{}`, and every `tr()` call fell back to the bare key, rendering the whole UI as dot-keys.

The i18n feature (#30) added `('languages', 'languages')` to `SmartCitizen.spec`, but `build_exe.py` carries its own separate `--add-data` list and was never updated. The two bundling lists drifted. This is a frozen-only failure, so it doesn't show in `python src/main.py` (dev reads `languages/` straight from the source tree).

## Fix

Add the matching `--add-data` entry to `build_exe.py`. The two lists (spec and build script) are now identical again: VERSION, docs×3, assets, patches, **languages**, scripts.

## Verification

Built the onedir with `build_exe.py` and confirmed the files now land in the bundle:

```
dist/SmartCitizen/_internal/languages/english/ui.json
dist/SmartCitizen/_internal/languages/french/ui.json
dist/SmartCitizen/_internal/languages/portuguese_br/ui.json
dist/SmartCitizen/_internal/languages/spanish/ui.json
```

These resolve through `get_resource_path` (`_MEIPASS/languages/...`) the same way the already-working `patches/` and `assets/` bundles do, so `set_language()` loads `ui.json` and `tr()` resolves keys.

## Note

This is a release blocker: every frozen 2.0.0 build before this is unusable (raw keys). It should land before any further tester installer artifacts are cut from this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
