### PR TITLE
fix: keep newly chosen SC install root when switching install locations

### DIFF
--- a/src/utils/settings.py
+++ b/src/utils/settings.py
@@ -1786,9 +1786,16 @@ class AppSettings:
         consistent without manual bookkeeping at each call site.
         """
         AppSettings.settings().setValue(AppSettings.SC_INSTALL_ROOT, path)
-        AppSettings.set_game_install_path(
-            AppSettings.get_channel_install_path() if path else ""
+        # Compose the active-channel path from the value we were just handed,
+        # NOT via get_channel_install_path()/get_sc_install_root(). That getter
+        # runs a cross-check against the still-stale GAME_INSTALL_PATH and, when
+        # the user switches install locations (e.g. C: default → D:), reverts
+        # SC_INSTALL_ROOT back to the old root before we get a chance to refresh
+        # the legacy key — silently discarding the path the user just picked.
+        channel_path = (
+            str(Path(path) / AppSettings.get_active_channel()) if path else ""
         )
+        AppSettings.set_game_install_path(channel_path)
 
     @staticmethod
     def get_available_channels() -> list[str]:

--- a/tests/test_sc_install_root.py
+++ b/tests/test_sc_install_root.py
@@ -138,6 +138,68 @@ class TestInstallRootCrossCheck:
         assert result == r"D:\Games\StarCitizen"
 
 
+class TestSetInstallRootSwitchesLocation:
+    """Regression: switching the install root to a new drive must stick.
+
+    set_sc_install_root() used to refresh GAME_INSTALL_PATH by reading back
+    through get_channel_install_path() -> get_sc_install_root(), whose
+    cross-check compares the just-set root against the *still-stale* legacy
+    GAME_INSTALL_PATH and reverts to the old location. The form field showed
+    the new path while P4K extraction kept using the old one.
+    """
+
+    @pytest.mark.regression
+    def test_switch_from_c_to_d_persists_new_root(self, json_backend):
+        """Pick D: while a stale C: install is stored -> D: wins, not C:."""
+        # Pre-existing default-location install on C:.
+        json_backend.setValue(
+            AppSettings.SC_INSTALL_ROOT,
+            r"C:\Program Files\Roberts Space Industries\StarCitizen",
+        )
+        json_backend.setValue(
+            AppSettings.GAME_INSTALL_PATH,
+            r"C:\Program Files\Roberts Space Industries\StarCitizen\LIVE",
+        )
+
+        # User browses to their real install on D:.
+        new_root = r"D:\Games\StarCitizen"
+        AppSettings.set_sc_install_root(new_root)
+
+        assert os.path.normcase(AppSettings.get_sc_install_root()) == os.path.normcase(
+            new_root
+        )
+        # The legacy key (used by P4K extraction) must follow to D:, not C:.
+        assert os.path.normcase(
+            AppSettings.get_game_install_path()
+        ) == os.path.normcase(r"D:\Games\StarCitizen\LIVE")
+
+    @pytest.mark.regression
+    def test_switch_respects_active_channel(self, json_backend):
+        """The synced legacy path uses the active channel, not a hardcoded LIVE."""
+        json_backend.setValue(
+            AppSettings.SC_INSTALL_ROOT, r"C:\Old\StarCitizen"
+        )
+        json_backend.setValue(
+            AppSettings.GAME_INSTALL_PATH, r"C:\Old\StarCitizen\LIVE"
+        )
+        AppSettings.set_active_channel("PTU")
+
+        AppSettings.set_sc_install_root(r"D:\New\StarCitizen")
+
+        assert os.path.normcase(
+            AppSettings.get_game_install_path()
+        ) == os.path.normcase(r"D:\New\StarCitizen\PTU")
+
+    def test_empty_path_clears_legacy_key(self, json_backend):
+        """Clearing the root clears the synced legacy path too."""
+        json_backend.setValue(AppSettings.SC_INSTALL_ROOT, r"D:\Games\StarCitizen")
+        json_backend.setValue(
+            AppSettings.GAME_INSTALL_PATH, r"D:\Games\StarCitizen\LIVE"
+        )
+        AppSettings.set_sc_install_root("")
+        assert json_backend.value(AppSettings.GAME_INSTALL_PATH, "") == ""
+
+
 class TestIsValidScRoot:
     """Tests for the _is_valid_sc_root path validation helper."""
 


### PR DESCRIPTION
## What

`set_sc_install_root()` could silently discard a freshly chosen install
root and revert to the previous one, breaking setup for anyone whose Star
Citizen install isn't at the C: default.

## Symptom

Browse to the correct SC install root (e.g. on D:). The path shows in the
Config-tab field, but the Channel dropdown doesn't populate, the warning
"LIVE isn't installed under this root — pick another channel" appears, and
P4K extraction reads the old (C:) location.

## Root cause

`set_sc_install_root()` refreshed the legacy `GAME_INSTALL_PATH` by reading
back through `get_channel_install_path()` → `get_sc_install_root()`. That
getter runs a cross-check that trusts `GAME_INSTALL_PATH` over a disagreeing
`SC_INSTALL_ROOT`. At that instant `GAME_INSTALL_PATH` still holds the *old*
value, so the cross-check treats the new root as the mistake and reverts
`SC_INSTALL_ROOT` back to the stale location (persisting the revert).

## Fix

Compose the active-channel path from the value passed into the setter
instead of reading it back through the cross-checking getter. Both keys are
written to the new location, so the cross-check never sees a transient
disagreement.

## Tests

Adds `TestSetInstallRootSwitchesLocation` to `tests/test_sc_install_root.py`:
C:→D: switch persists the new root, the synced legacy path respects the
active channel, and the empty path clears the legacy key. The two switch
tests fail on `main` and pass with the fix. Full suite: 742 passed, 16 skipped.

## Note on target branch

The branching model targets the active `release/X.Y.Z` branch, but none is
open post-2.0.0, so this targets `main`. Happy to retarget to a release
branch when one opens — it's a patch-scope bug fix.
