### PR TITLE
[#151] generator: stop mission titles showing full detail body

### DIFF
--- a/scripts/generate_enhancements_ini.py
+++ b/scripts/generate_enhancements_ini.py
@@ -19,6 +19,7 @@ Usage:
 
 import io
 import logging
+import os
 import pickle
 import re
 import sys
@@ -5008,7 +5009,14 @@ def _run_gen_missions(ctx: dict) -> dict[str, str]:
         unique_desc_keys: list[str] = []
         for v in variants:
             dk = v[3]
-            if dk and dk not in unique_desc_keys:
+            # #151: a contract whose Description loc-key collides with its
+            # Title key (CIG data quirk, e.g. eckhart_defendship_MRT
+            # "Stop Attack") must never have the MISSION DETAILS / blueprint
+            # body written onto the title — for a [BP] mission that body
+            # clobbers the enhanced title with the full block in-game. The
+            # title keeps its [BP]/XP tags (written above); the body is
+            # dropped because there is no distinct key to hold it.
+            if dk and dk != title_key and dk not in unique_desc_keys:
                 unique_desc_keys.append(dk)
 
         for desc_key in unique_desc_keys:

--- a/tests/test_mission_title_desc_collision.py
+++ b/tests/test_mission_title_desc_collision.py
@@ -1,0 +1,119 @@
+"""Regression guard for #151: mission titles showing the full detail body.
+
+A few CIG contracts (e.g. ``eckhart_defendship_MRT_title_001`` — the
+"Stop Attack" missions) point their Description ContractStringParam at the
+*same* loc key as their Title. When such a mission also awards blueprints,
+``_run_gen_missions`` used to write the MISSION DETAILS / POTENTIAL
+BLUEPRINTS body onto that shared key — clobbering the enhanced title with
+the full block in-game. The fix excludes a mission's own title key from the
+description-key set, so the title keeps only its ``[BP]`` / XP tags.
+
+The no-blueprint collision was already handled by the "skip shared desc_key"
+guard; this test locks the blueprint path, which the old guard missed.
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.unit, pytest.mark.regression]
+
+
+@pytest.fixture(scope="module")
+def gen_module():
+    repo_root = Path(__file__).resolve().parent.parent
+    script_path = repo_root / "scripts" / "generate_enhancements_ini.py"
+    spec = importlib.util.spec_from_file_location(
+        "generate_enhancements_ini_collision_test", script_path
+    )
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_POOL_UUID = "11111111-1111-1111-1111-111111111111"
+_BP_UUID = "22222222-2222-2222-2222-222222222222"
+_ENTITY_UUID = "33333333-3333-3333-3333-333333333333"
+_SHARED_KEY = "eckhart_defendship_MRT_title_001"
+
+# Contract whose Title and Description both point at the same loc key, with a
+# blueprint reward so contract_has_bp becomes True — the exact #151 trigger.
+_CONTRACT_GEN_XML = f"""\
+<?xml version="1.0" encoding="utf-8"?>
+<ContractGenerator>
+  <ContractGeneratorHandler_List debugName="Stanton_DefendShip">
+    <Contract debugName="Stanton_StopAttack" notForRelease="0" minStanding="">
+      <ContractStringParam param="Title" value="@{_SHARED_KEY}" />
+      <ContractStringParam param="Description" value="@{_SHARED_KEY}" />
+      <BlueprintRewards blueprintPool="{_POOL_UUID}" chance="1" />
+    </Contract>
+  </ContractGeneratorHandler_List>
+</ContractGenerator>
+"""
+
+_BP_RECORD_XML = f"""\
+<?xml version="1.0" encoding="utf-8"?>
+<CraftingBlueprintRecord __ref="{_BP_UUID}">
+  <CraftingProcess_Creation entityClass="{_ENTITY_UUID}" />
+</CraftingBlueprintRecord>
+"""
+
+_POOL_RECORD_XML = f"""\
+<?xml version="1.0" encoding="utf-8"?>
+<BlueprintPoolRecord __ref="{_POOL_UUID}">
+  <BlueprintReward blueprintRecord="{_BP_UUID}" />
+</BlueprintPoolRecord>
+"""
+
+
+def _build_records_tree(tmp_path: Path) -> Path:
+    records = tmp_path / "records"
+    contractgen = records / "contracts" / "contractgenerator"
+    bp_dir = records / "crafting" / "blueprints" / "crafting"
+    pool_dir = records / "crafting" / "blueprintrewards"
+    for d in (contractgen, bp_dir, pool_dir):
+        d.mkdir(parents=True)
+    (contractgen / "gen.xml").write_text(_CONTRACT_GEN_XML, encoding="utf-8")
+    (bp_dir / "bp_craft_test.xml").write_text(_BP_RECORD_XML, encoding="utf-8")
+    (pool_dir / "bp_rewards_test.xml").write_text(_POOL_RECORD_XML, encoding="utf-8")
+    return records
+
+
+def _run(gen_module, tmp_path):
+    records = _build_records_tree(tmp_path)
+    ctx = {
+        "records": records,
+        "forge_dir": tmp_path / "forge",
+        "loc": {_SHARED_KEY: "Stop Attack on High-Profile Client"},
+        "entity_names": {_ENTITY_UUID: "Test Component"},
+        "reputation_lookup": {},
+    }
+    return gen_module._run_gen_missions(ctx)
+
+
+class TestTitleDescCollision:
+    def test_blueprint_pool_resolves(self, gen_module, tmp_path):
+        """Guard the fixture itself: the contract must actually award a
+        blueprint, otherwise the no-BP path would mask the regression."""
+        out = _run(gen_module, tmp_path)
+        assert _SHARED_KEY in out
+        assert "[BP]" in out[_SHARED_KEY], (
+            "fixture must produce a [BP] mission — the #151 bug only fires on "
+            "the blueprint path"
+        )
+
+    def test_title_keeps_tags(self, gen_module, tmp_path):
+        out = _run(gen_module, tmp_path)
+        assert out[_SHARED_KEY].startswith("Stop Attack on High-Profile Client")
+
+    def test_title_not_clobbered_by_body(self, gen_module, tmp_path):
+        out = _run(gen_module, tmp_path)
+        value = out[_SHARED_KEY]
+        assert "MISSION DETAILS" not in value, (
+            "#151: the description body must never overwrite a colliding title"
+        )
+        assert "POTENTIAL BLUEPRINTS" not in value


### PR DESCRIPTION
## Summary
- Fix mission titles rendering the full MISSION DETAILS / blueprint body instead of just an enhanced title. A few CIG contracts (e.g. `eckhart_defendship_MRT_title_001`, the "Stop Attack" missions) point their Description `ContractStringParam` at the **same** loc key as their Title; when such a mission also awards blueprints, `_run_gen_missions` wrote the body onto the shared key and clobbered the title. Closes #151.
- The fix excludes a mission's own `title_key` from the description-key set, so a title is never overwritten by a description body. The title keeps its `[BP]`/XP tags; the body is dropped because there's no distinct key to hold it. The no-blueprint collision was already handled by the existing "skip shared desc_key" guard — this covers the blueprint path it missed.
- Incidental: add the missing `import os`. The `_get_default_forge_dir` fallback referenced `os.environ` but `os` was never imported, crashing the module on any non-Windows run (invisible on Windows CI, where the fallback is dead code). Needed to import the module under test off-Windows; correct on its own merits.

## Testing Checklist
- [x] PR is scoped to one concern (single bug fix + its test)
- [x] `pytest tests/` passes locally (175 generator tests; collision repro fails without the fix, passes with it)
- [ ] App launches: `python src/main.py`
- [ ] Affected user-facing flow exercised manually (Extract → regenerate enhancements → check a "Stop Attack" mission title in the table)
- [x] User-facing strings, `docs/HELP.md`, `docs/ABOUT.md`, and `src/gui/coach_mark.py` reviewed for drift (none — generator-internal output change)
- [x] New non-exempt code has matching test coverage in `tests/`
- [x] Target branch is the active `release/2.1.0`, not `main`
- [x] No direct `QSettings` calls, no hard-coded column indices, no `QProgressBar.setValue()` from workers
- [x] If new enhancement category: `CATEGORY_SUBTREES` and `DATAFORGE_KEEP_SUBPATHS` both updated (n/a — no new category)
- [x] `VERSION.TXT` matches the active release branch (2.1.0)

## Testing performed
- Added `tests/test_mission_title_desc_collision.py`, which builds a minimal `records/` tree reproducing a `[BP]` mission whose Title and Description loc-keys collide, calls `_run_gen_missions`, and asserts the title keeps its `[BP]` tag and contains neither `MISSION DETAILS` nor `POTENTIAL BLUEPRINTS`.
- Verified the test **fails on the pre-fix code** (title becomes `Stop Attack on High-Profile Client\n\n<EM3>POTENTIAL BLUEPRINTS</EM3>...<EM3>MISSION DETAILS</EM3>...`) and **passes with the fix**.
- `pytest tests/test_missions.py tests/test_not_for_release.py tests/test_blueprint_pools.py tests/test_mission_variant_tuple.py tests/test_mission_engagement.py tests/test_spawn_classifier.py tests/test_mission_title_desc_collision.py` → 175 passed. (Other suites' collection errors are the Linux `winreg` limitation, green on Windows CI.)

## Post-merge QA
- [ ] App launches from a clean checkout of `release/2.1.0`
- [ ] On a real SC install (note channel), filter the strings table on "Stop Attack" and confirm the affected mission titles show only an enhanced title (with `[BP]`/XP tag), not the full detail block
- [ ] A normal mission with a distinct description key still gets its full MISSION DETAILS / POTENTIAL BLUEPRINTS body
- [ ] Tutorial coach-marks unaffected (no UI controls moved)

---
🤖 PR description generated with [Claude Code](https://claude.com/claude-code) and reviewed by @Osiris-DevWorks

---
_Generated by [Claude Code](https://claude.ai/code/session_01D8js85Xpq68DoWuFyLErgk)_