### PR TITLE
Revert direct-pushed #148 scaffolding from release/2.1.0

### DIFF
--- a/notes-remove-before-release.txt
+++ b/notes-remove-before-release.txt
@@ -1,6 +1,0 @@
-NOTES — REMOVE BEFORE RELEASE
-==============================
-
-scripts/generate_enhancements_ini.py
-  - Line 3880: EARNABLE_SHIP_NAME_OVERRIDES dict (commented out — fill in vehicle_Name* keys before uncommenting)
-  - Line 5704: out_ships.update(EARNABLE_SHIP_NAME_OVERRIDES) merge call (commented out — uncomment once dict is filled in)

--- a/scripts/generate_enhancements_ini.py
+++ b/scripts/generate_enhancements_ini.py
@@ -3871,39 +3871,6 @@ def enhancements_weapon(root: ET.Element, ammo_lookup: dict[str, ET.Element],
     return "\\n".join(lines)
 
 
-# ── Earnable ship name overrides ─────────────────────────────────────────────
-# One-off vehicle_Name* renames for ships that are only earnable in-game
-# (not purchasable from the pledge store), where the default name doesn't
-# distinguish them from a store variant. Keys are exact loc keys from base.ini.
-# Merged into ships_desc_enhancements.ini at write time.
-#
-# EARNABLE_SHIP_NAME_OVERRIDES: dict[str, str] = {
-#     "vehicle_Name???_???": "",  # placeholder 1
-#     "vehicle_Name???_???": "",  # placeholder 2
-#     "vehicle_Name???_???": "",  # placeholder 3
-#     "vehicle_Name???_???": "",  # placeholder 4
-#     "vehicle_Name???_???": "",  # placeholder 5
-#     "vehicle_Name???_???": "",  # placeholder 6
-#     "vehicle_Name???_???": "",  # placeholder 7
-#     "vehicle_Name???_???": "",  # placeholder 8
-#     "vehicle_Name???_???": "",  # placeholder 9
-#     "vehicle_Name???_???": "",  # placeholder 10
-#     "vehicle_Name???_???": "",  # placeholder 11
-#     "vehicle_Name???_???": "",  # placeholder 12
-#     "vehicle_Name???_???": "",  # placeholder 13
-#     "vehicle_Name???_???": "",  # placeholder 14
-#     "vehicle_Name???_???": "",  # placeholder 15
-#     "vehicle_Name???_???": "",  # placeholder 16
-#     "vehicle_Name???_???": "",  # placeholder 17
-#     "vehicle_Name???_???": "",  # placeholder 18
-#     "vehicle_Name???_???": "",  # placeholder 19
-#     "vehicle_Name???_???": "",  # placeholder 20
-#     "vehicle_Name???_???": "",  # placeholder 21
-#     "vehicle_Name???_???": "",  # placeholder 22
-#     "vehicle_Name???_???": "",  # placeholder 23
-#     "vehicle_Name???_???": "",  # placeholder 24
-# }
-
 # ── Ship enhancements (DataForge-based) ──────────────────────────────────────────────
 
 def _extract_item_size(cls: str) -> str | None:
@@ -5701,7 +5668,6 @@ def main(base_ini_path: Path, forge_dir: Path | None = None,
     logger.info("Writing output files…")
     _flush()
     if _want("ship_descs"):
-        # out_ships.update(EARNABLE_SHIP_NAME_OVERRIDES)  # uncomment once keys are filled in
         write_ini(output_dir / "ships_desc_enhancements.ini",       out_ships)
     if _want("component_descs"):
         write_ini(output_dir / "components_desc_enhancements.ini",  out_components)


### PR DESCRIPTION
Backs out `5413f6d` ("Initial implementation of ship name standardization"), which was **pushed directly to `release/2.1.0` without a PR**.

## Why revert

- **Process.** The branching model requires changes to land on the active release branch through reviewed PRs. This commit bypassed that gate (no PR, author = committer = the pusher).
- **Scope.** #148 is not `next-release`-labeled, so Ship Name Standardization is outside the 2.1.0 scope.
- **State.** The code is inert scaffolding anyway: a commented-out `EARNABLE_SHIP_NAME_OVERRIDES` placeholder dict (24 `vehicle_Name???_???` stubs) plus a commented-out merge call in `scripts/generate_enhancements_ini.py`, and a `notes-remove-before-release.txt` reminder file that must not ship.

## What this removes

- `notes-remove-before-release.txt` (deleted)
- The `EARNABLE_SHIP_NAME_OVERRIDES` block + merge-call comment in `scripts/generate_enhancements_ini.py`

Net: 2 files changed, 40 deletions. No behavior change (everything reverted was commented out).

The work itself isn't lost - it's preserved in `5413f6d` and tracked on #148, and can return through a normal PR when it's ready and in scope for a release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)