### PR TITLE
Add CODEOWNERS (owner gate for release PRs)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,11 @@
+# Code owners for Smart Citizen.
+#
+# @Osiris-DevWorks owns the entire tree, so every pull request requests their
+# review automatically. Combined with the "Protect release branches" ruleset
+# (require_code_owner_review on release/*), this is the tighter gate: a PR into
+# a release branch needs an approval from @Osiris-DevWorks specifically, not
+# just any approving review.
+#
+# GitHub reads CODEOWNERS from the PR's base branch, so this file lives on main
+# (the default branch) and every release/X.Y.Z branched off main inherits it.
+* @Osiris-DevWorks


### PR DESCRIPTION
Adds `.github/CODEOWNERS` naming `@Osiris-DevWorks` owner of the whole tree.

Paired with the "Protect release branches" ruleset's `require_code_owner_review` rule, this tightens the release-branch gate from "a PR with any approval" to "a PR approved by the owner specifically."

Lives on `main` (the default branch) so every `release/X.Y.Z` cut from main inherits it. The current `release/2.1.0` gets it added directly in a sibling PR since it was branched before this file existed.

No code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)