### PR TITLE
Add CODEOWNERS to release/2.1.0 (owner gate)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,11 @@
+# Code owners for Smart Citizen.
+#
+# @Osiris-DevWorks owns the entire tree, so every pull request requests their
+# review automatically. Combined with the "Protect release branches" ruleset
+# (require_code_owner_review on release/*), this is the tighter gate: a PR into
+# a release branch needs an approval from @Osiris-DevWorks specifically, not
+# just any approving review.
+#
+# GitHub reads CODEOWNERS from the PR's base branch, so this file lives on main
+# (the default branch) and every release/X.Y.Z branched off main inherits it.
+* @Osiris-DevWorks


### PR DESCRIPTION
Adds `.github/CODEOWNERS` to the active `release/2.1.0` branch so the "Protect release branches" ruleset's `require_code_owner_review` rule applies to PRs targeting it.

`main` got this file in #177; future release branches inherit it from main, but `release/2.1.0` was cut before it existed, so it's added directly here.

No code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)