### PR TITLE
fix(simple-mode): smaller button + compact startup window

### DIFF
--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -252,7 +252,11 @@ class MainWindow(QMainWindow):
     def __init__(self):
         super().__init__()
         self.setWindowTitle(tr("window.title", version=get_version()))
-        self.setGeometry(100, 100, 1400, 800)
+        # Position only; the size is set after the UI is built — restored from
+        # saved geometry, or sized to the compact content hint on first run
+        # (#180 follow-up: open as small as the layout allows). See
+        # restore_window_state().
+        self.move(100, 100)
 
         # Set window icon (taskbar + window title bar + favicon)
         icon_path = get_resource_path(os.path.join("assets", "logo.ico"))
@@ -4421,12 +4425,20 @@ class MainWindow(QMainWindow):
         self._model.notify_entry_changed(entry_idx)
 
     def restore_window_state(self):
-        """Restore window geometry and state."""
+        """Restore window geometry and state.
+
+        With no saved geometry (fresh install), open at the compact content
+        hint instead of a fixed large default — Simple mode is the default
+        view and a near-empty screen shouldn't open oversized (#180 follow-up).
+        Returning users keep whatever size they last left the window.
+        """
         geometry = AppSettings.get_window_geometry()
         state = AppSettings.get_window_state()
 
         if geometry:
             self.restoreGeometry(geometry)
+        else:
+            self.resize(self.sizeHint())
         if state:
             self.restoreState(state)
 

--- a/src/gui/simple_mode_widget.py
+++ b/src/gui/simple_mode_widget.py
@@ -58,17 +58,21 @@ class SimpleModeWidget(QWidget):
         # The one big button.
         self.generate_apply_btn = QPushButton(tr("simple_mode.generate_apply_btn"))
         self.generate_apply_btn.setToolTip(tr("simple_mode.generate_apply_tip"))
-        self.generate_apply_btn.setMinimumHeight(96)
+        self.generate_apply_btn.setMinimumHeight(44)
+        # Sized to its content and centred rather than a full-width bar, so the
+        # Simple page stays compact (#180 follow-up).
         self.generate_apply_btn.setSizePolicy(
-            QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed
+            QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Fixed
         )
         self.generate_apply_btn.setStyleSheet(
             f"background-color: {get_button_color('apply')}; "
             f"color: {get_button_text_color()}; font-weight: bold; "
-            f"font-size: 20px; padding: 12px;"
+            f"font-size: 14px; padding: 10px 28px;"
         )
         self.generate_apply_btn.clicked.connect(self.generate_and_apply_requested)
-        layout.addWidget(self.generate_apply_btn)
+        layout.addWidget(
+            self.generate_apply_btn, alignment=Qt.AlignmentFlag.AlignHCenter
+        )
 
         self.hint_label = QLabel(tr("simple_mode.defaults_hint"))
         self.hint_label.setAlignment(Qt.AlignmentFlag.AlignCenter)


### PR DESCRIPTION
Follow-up polish on the Simple mode from #180.

- **Smaller action button** — the Simple page's **Generate & Apply to Game** button drops from a 96px full-width bar (20px font) to a normal 44px content-sized button (14px font), centred on the page.
- **Compact startup** — the window now opens at its content size hint instead of a fixed 1400×800. In Simple mode that's ~666×348 (the floor is set by the Advanced table's column width, so it's as small as the layout allows). Returning users still restore their last saved geometry; only first-run / no-saved-geometry opens compact.
- **Footer unchanged** — the Osiris logo, Discord, and donation elements keep their fixed 40px sizing, matching the Advanced view exactly.

Verified offscreen: button 44px + centred, window 666×348 on a fresh profile, footer logo still 40px. `test_ui_mode` and `test_window_state_portable` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)