### PR TITLE
feat: Owned blueprint column + [Owned] tag (#157)

### DIFF
--- a/languages/english/ui.json
+++ b/languages/english/ui.json
@@ -220,6 +220,10 @@
       "ht": "Status",
       "at": ""
     },
+    "col_owned": {
+      "ht": "Owned",
+      "at": ""
+    },
     "no_data": {
       "ht": "No data loaded",
       "at": ""

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -28,7 +28,7 @@ from src.gui.log_tab import LogTab
 from src.gui.simple_mode_widget import SimpleModeWidget
 from src.gui.markdown_renderer import markdown_to_html as _md_to_html
 from src.gui.string_table_model import (
-    StringTableModel, COL_STAR, COL_ORDER, COL_CUSTOM, COL_STATUS,
+    StringTableModel, COL_STAR, COL_ORDER, COL_CUSTOM, COL_STATUS, COL_OWNED,
     status_color,
 )
 from src.gui.theme import (
@@ -292,6 +292,10 @@ class MainWindow(QMainWindow):
         # enhancements-generation-finished slot should continue into
         # apply_to_game. Cleared on completion or any failure.
         self._simple_run_active = False
+
+        # #157: item names (normalized) that appear in any POTENTIAL BLUEPRINTS
+        # list — the rows eligible for the Owned star. Recomputed on each load.
+        self._bp_item_names: set[str] = set()
 
         # Track whether we've prompted for enhancements on startup (prevents duplicate dialogs)
         self._enhancements_prompted_on_startup = False
@@ -1063,6 +1067,7 @@ class MainWindow(QMainWindow):
         header.setSectionResizeMode(5, QHeaderView.ResizeMode.ResizeToContents)  # Order #
         header.setSectionResizeMode(6, QHeaderView.ResizeMode.Stretch)           # Custom Value
         header.setSectionResizeMode(7, QHeaderView.ResizeMode.ResizeToContents)  # Status
+        header.setSectionResizeMode(COL_OWNED, QHeaderView.ResizeMode.ResizeToContents)  # Owned (#157)
 
         # Set custom delegates: Custom Value text editor + Sort Order spin box.
         # Parent each to the table so Qt's object tree owns them: the view does
@@ -1425,6 +1430,17 @@ class MainWindow(QMainWindow):
 
             # Merge all sources in hierarchy order, with user edits on top
             merged_dict = merge_sources_by_hierarchy(sources_dict, hierarchy, user_overrides_dict)
+
+            # #157: weave [Owned] into blueprint lists so the tag reaches the
+            # applied game file (apply re-loads sources from disk, where the
+            # live owned overlay isn't baked in). Idempotent.
+            _owned = AppSettings.get_owned_items()
+            if _owned:
+                from src.utils.owned_items import apply_owned_to_value
+                for _k, _v in list(merged_dict.items()):
+                    _nv = apply_owned_to_value(_v, _owned)
+                    if _nv != _v:
+                        merged_dict[_k] = _nv
 
             # Stamp Journal entries Smart Citizen produced or modified —
             # both user-edited journals AND auto-generated journal
@@ -1883,6 +1899,7 @@ class MainWindow(QMainWindow):
                     AppSettings.get_favorite_prefix(),
                 )
                 self.apply_filters()
+                self._recompute_owned()  # #157
 
                 # Update status bar with entry counts and per-source status
                 self._update_status_bar()
@@ -2300,6 +2317,7 @@ class MainWindow(QMainWindow):
                 self.entries, self.default_values, AppSettings.get_favorite_prefix(),
             )
             self.apply_filters()
+            self._recompute_owned()  # #157
 
             # Update status bar with entry counts and per-source status
             self._update_status_bar()
@@ -3159,6 +3177,7 @@ class MainWindow(QMainWindow):
             tr("strings_tab.col_order"),
             tr("strings_tab.col_custom_value"),
             tr("strings_tab.col_status"),
+            tr("strings_tab.col_owned"),
         ]
         self.filter_header.update_column_names(new_column_names)
         self._model.retranslate()
@@ -3869,6 +3888,7 @@ class MainWindow(QMainWindow):
             sort_keys=sort_keys,
         )
         self.apply_filters()
+        self._recompute_owned()  # #157: weave [Owned] tags + populate Owned stars
 
         # Update status bar with entry counts and per-source status
         self._update_status_bar()
@@ -4455,11 +4475,39 @@ class MainWindow(QMainWindow):
 
     @pyqtSlot(QModelIndex)
     def _on_cell_clicked(self, proxy_index: QModelIndex):
-        """Handle cell clicks — col 4 (★) toggles favorite for Ship rows."""
-        if proxy_index.column() == COL_STAR:
+        """Handle cell clicks — COL_STAR toggles favorite (Ships); COL_OWNED
+        toggles owned (#157) on blueprint-item rows."""
+        col = proxy_index.column()
+        if col == COL_STAR:
             entry_idx = self._entry_index_for_row(proxy_index.row())
             if entry_idx < len(self.entries) and self.entries[entry_idx].category == "Ships":
                 self.toggle_favorite(proxy_index.row())
+        elif col == COL_OWNED:
+            entry_idx = self._entry_index_for_row(proxy_index.row())
+            if 0 <= entry_idx < len(self.entries):
+                from src.utils.owned_items import normalize_item_name
+                e = self.entries[entry_idx]
+                name = normalize_item_name(e.custom_value or e.original_value)
+                if name and name in self._bp_item_names:
+                    AppSettings.toggle_owned_item(name)
+                    self._recompute_owned()
+
+    def _recompute_owned(self):
+        """#157: rebuild the blueprint-item set, weave/strip [Owned] tags on
+        blueprint-list bullets to match the owned set, and refresh the table.
+        Called after every load and on every Owned toggle; the transform is
+        idempotent so repeated runs never double the tag."""
+        from src.utils.owned_items import extract_bp_item_names, apply_owned_to_value
+        owned = AppSettings.get_owned_items()
+        bp: set[str] = set()
+        for e in self.entries:
+            bp |= extract_bp_item_names(e.original_value)
+        self._bp_item_names = bp
+        for e in self.entries:
+            new_val = apply_owned_to_value(e.original_value, owned)
+            if new_val != e.original_value:
+                e.original_value = new_val
+        self._model.set_owned_state(bp, owned)
 
     def toggle_favorite(self, proxy_row: int):
         """Add or remove the sort prefix from a ship's custom value."""

--- a/src/gui/string_table_model.py
+++ b/src/gui/string_table_model.py
@@ -16,7 +16,11 @@ from PyQt6.QtWidgets import QApplication
 
 from src.models.string_model import StringEntry
 from src.utils.i18n import tr
+from src.utils.owned_items import normalize_item_name
 from src.utils.ship_sort_prefix import get_order, set_order
+
+_OWNED_GOLD = QColor("#FFD700")
+_OWNED_GREY = QColor("#666666")
 
 # ---------------------------------------------------------------------------
 # Column constants
@@ -29,7 +33,8 @@ COL_STAR = 4
 COL_ORDER = 5
 COL_CUSTOM = 6
 COL_STATUS = 7
-NUM_COLUMNS = 8
+COL_OWNED = 8   # #157: "owned blueprint" star, shown on craftable-blueprint item rows
+NUM_COLUMNS = 9
 
 _HEADER_KEYS = [
     "strings_tab.col_category",
@@ -40,6 +45,7 @@ _HEADER_KEYS = [
     "strings_tab.col_order",
     "strings_tab.col_custom_value",
     "strings_tab.col_status",
+    "strings_tab.col_owned",
 ]
 
 # ---------------------------------------------------------------------------
@@ -137,6 +143,9 @@ def _make_sort_key(entries, default_values, sort_keys, col, grouped, favorite_pr
         return lambda idx: entries[idx].custom_value.lower()
     if col == COL_STATUS:
         return lambda idx: entries[idx].status.lower()
+    if col == COL_OWNED:
+        # The owned set lives on the model, not here, so sort stably by key.
+        return lambda idx: entries[idx].key.lower()
     if col == COL_STAR:
         # Favorite = Ship with the configured prefix on its custom_value.
         # Primary key 0 for favorites, 1 for non-favorites → ascending puts
@@ -185,6 +194,10 @@ class StringTableModel(QAbstractTableModel):
         self._grouped_sort: bool = False
         self._sort_column: int = COL_KEY
         self._sort_order: Qt.SortOrder = Qt.SortOrder.AscendingOrder
+        # #157: item names appearing in any POTENTIAL BLUEPRINTS list (the rows
+        # that get an Owned star), and the user's owned set. Both normalized.
+        self._bp_item_names: set[str] = set()
+        self._owned_items: set[str] = set()
         # Cached values recomputed only on theme/language change, not per-paint.
         self._header_labels: list[str] = [tr(k) for k in _HEADER_KEYS]
         self._fav_bg: QColor = _compute_fav_bg()
@@ -233,6 +246,23 @@ class StringTableModel(QAbstractTableModel):
 
     def set_grouped_sort(self, enabled: bool) -> None:
         self._grouped_sort = enabled
+
+    def set_owned_state(self, bp_item_names: set, owned_items: set) -> None:
+        """#157: set which item names are blueprint items (eligible for the
+        Owned star) and which are currently owned. Triggers a full refresh."""
+        self.beginResetModel()
+        self._bp_item_names = bp_item_names or set()
+        self._owned_items = owned_items or set()
+        self.endResetModel()
+
+    def _owned_name(self, entry: StringEntry) -> str:
+        """Normalized display name used to match an entry against blueprint
+        bullet names (the row's effective value, tag-stripped)."""
+        return normalize_item_name(entry.custom_value or entry.original_value)
+
+    def _is_bp_item(self, entry: StringEntry) -> bool:
+        """True if this row names an item that appears in a blueprint list."""
+        return bool(self._bp_item_names) and self._owned_name(entry) in self._bp_item_names
 
     # -- entry access helpers -----------------------------------------------
 
@@ -295,6 +325,10 @@ class StringTableModel(QAbstractTableModel):
             if entry is not None and entry.category == "Ships":
                 return base | Qt.ItemFlag.ItemIsEditable
             return Qt.ItemFlag.ItemIsEnabled  # non-ships: shown, not editable
+        if col == COL_OWNED:
+            entry = self.entry_for_row(index.row())
+            if entry is not None and not self._is_bp_item(entry):
+                return Qt.ItemFlag.ItemIsEnabled  # non-blueprint rows: blank, not selectable
         return base
 
     def data(self, index: QModelIndex, role=Qt.ItemDataRole.DisplayRole):
@@ -330,6 +364,10 @@ class StringTableModel(QAbstractTableModel):
                 return entry.custom_value
             if col == COL_STATUS:
                 return entry.status
+            if col == COL_OWNED:
+                if not self._is_bp_item(entry):
+                    return ""
+                return "★" if self._owned_name(entry) in self._owned_items else "☆"
             return None
 
         # -- edit text (populates the inline editor on double-click) --------
@@ -356,12 +394,20 @@ class StringTableModel(QAbstractTableModel):
                 if entry.category == "Ships":
                     return "Sort order: click to pick a number for ASOP ordering"
                 return None
+            if col == COL_OWNED:
+                if self._is_bp_item(entry):
+                    if self._owned_name(entry) in self._owned_items:
+                        return "Owned — click to unmark; [Owned] is removed from blueprint lists"
+                    return "Click to mark owned — appends [Owned] to this item in blueprint lists"
+                return None
             return self.data(index, Qt.ItemDataRole.DisplayRole)
 
         # -- foreground colour ----------------------------------------------
         if role == Qt.ItemDataRole.ForegroundRole:
             if col == COL_STAR and entry.category == "Ships":
                 return _FAV_GOLD if entry.custom_value.startswith(prefix) else _FAV_GREY
+            if col == COL_OWNED and self._is_bp_item(entry):
+                return _OWNED_GOLD if self._owned_name(entry) in self._owned_items else _OWNED_GREY
             if col == COL_STATUS:
                 return status_color(entry.status)
             return None
@@ -374,7 +420,7 @@ class StringTableModel(QAbstractTableModel):
 
         # -- alignment ------------------------------------------------------
         if role == Qt.ItemDataRole.TextAlignmentRole:
-            if col in (COL_STAR, COL_ORDER):
+            if col in (COL_STAR, COL_ORDER, COL_OWNED):
                 return int(Qt.AlignmentFlag.AlignCenter)
             return None
 

--- a/src/utils/entry_filter.py
+++ b/src/utils/entry_filter.py
@@ -80,6 +80,11 @@ def filter_entry_indices(
         lambda e: get_order(e.custom_value, favorite_prefix) if e.category == "Ships" else "",
         lambda e: e.custom_value.lower(),
         lambda e: e.status.lower(),
+        # COL_OWNED (#157): the owned star isn't text-filterable from here (the
+        # owned set lives on the model), so this getter just keeps the tuple
+        # aligned with NUM_COLUMNS for the drift guard. Blueprint filtering is
+        # covered by the dedicated BP filters (#156).
+        lambda e: "",
     )
     active_filter_fns = [(_col_getters[i], t) for i, t in valid_col_filters]
 

--- a/src/utils/owned_items.py
+++ b/src/utils/owned_items.py
@@ -1,0 +1,87 @@
+"""Owned-blueprint tagging (#157).
+
+Users mark blueprint items they already own; an ``[Owned]`` tag is then woven
+onto that item wherever it appears in a mission reward POTENTIAL BLUEPRINTS
+list. Keyed by item *display name* (issue #157 option a) because the GUI table
+never sees item UUIDs — it works purely from localization keys and values.
+
+Qt-free and settings-free so it can be unit-tested with plain strings. The
+transform is idempotent: it strips any existing ``[Owned]`` tags before
+re-applying, so it can run on every load and on every toggle without doubling.
+
+Values use a literal ``\\n`` (backslash-n) line separator — the in-INI encoding
+the parser and game both read — so all matching here is on the two-character
+sequence, not a real newline.
+"""
+from __future__ import annotations
+
+import re
+
+# The bullet line separator inside a stored INI value (literal backslash-n).
+_NL = "\\n"
+# A POTENTIAL BLUEPRINTS bullet: "\n- <name>". Names can carry a leading
+# component tag ("[Mil-S1-A] Norfield") and we keep everything up to the next
+# separator.
+_BULLET_RE = re.compile(re.escape(_NL) + r"- ([^\\]+)")
+# The owned tag we weave in. EM4 renders blue in-game — the visibility the
+# request asked for ("so it's in blue").
+_OWNED_TAG = " <EM4>[Owned]</EM4>"
+# Strip a previously-applied owned tag (with or without the leading space).
+_OWNED_STRIP_RE = re.compile(r"\s*<EM4>\[Owned\]</EM4>")
+# A leading bracketed component tag on a bullet name, e.g. "[Mil-S1-A] ".
+_LEADING_TAG_RE = re.compile(r"^\[[^\]]*\]\s*")
+
+# Marks the start of a POTENTIAL BLUEPRINTS section. The header text is
+# user-configurable but the default is "POTENTIAL BLUEPRINTS"; we match the
+# default case-insensitively. A value with no such header has no bullets to
+# tag, so it passes through untouched.
+_BP_HEADER_RE = re.compile(r"POTENTIAL BLUEPRINTS", re.IGNORECASE)
+
+
+def normalize_item_name(name: str) -> str:
+    """Reduce a bullet/name to a stable identity for matching.
+
+    Strips a leading component tag (``[Mil-S1-A] Norfield`` -> ``Norfield``),
+    any ``[Owned]`` tag, and surrounding whitespace. Used for both the owned
+    set and bullet matching so a tagged bullet matches its bare item row.
+    """
+    if not name:
+        return ""
+    s = _OWNED_STRIP_RE.sub("", name)
+    s = _LEADING_TAG_RE.sub("", s)
+    return s.strip()
+
+
+def extract_bp_item_names(value: str) -> set[str]:
+    """Return the normalized item names in *value*'s POTENTIAL BLUEPRINTS list.
+
+    Empty when the value has no such section.
+    """
+    if not value or not _BP_HEADER_RE.search(value):
+        return set()
+    return {normalize_item_name(m.group(1)) for m in _BULLET_RE.finditer(value)
+            if normalize_item_name(m.group(1))}
+
+
+def apply_owned_to_value(value: str, owned: set[str]) -> str:
+    """Return *value* with ``[Owned]`` on bullets whose item is in *owned*.
+
+    Idempotent: any existing ``[Owned]`` tag is removed first, so the result is
+    a pure function of (value, owned) and re-running never doubles the tag.
+    Values without a POTENTIAL BLUEPRINTS section are returned unchanged (after
+    stripping stale owned tags, in case an item was just un-owned).
+    """
+    if not value:
+        return value
+    # Strip any prior owned tags first (handles un-owning + idempotency).
+    value = _OWNED_STRIP_RE.sub("", value)
+    if not owned or not _BP_HEADER_RE.search(value):
+        return value
+
+    def _retag(m: re.Match) -> str:
+        raw = m.group(1)
+        if normalize_item_name(raw) in owned:
+            return f"{_NL}- {raw}{_OWNED_TAG}"
+        return m.group(0)
+
+    return _BULLET_RE.sub(_retag, value)

--- a/src/utils/settings.py
+++ b/src/utils/settings.py
@@ -273,6 +273,7 @@ class AppSettings:
     # the actual component names elsewhere. Issue #31 follow-up.
     TAG_ANNOTATE_MISSION_DESCS = "tag_builder/annotate_mission_descs"
     STATS_PREPEND = "stats_prepend"  # #153: stats block above the description
+    OWNED_ITEMS = "owned_items"      # #157: blueprint items the user owns (JSON list of names)
 
     # Settings keys - Data sources (new)
     # Prefix: data_sources/{source_name}/
@@ -794,6 +795,45 @@ class AppSettings:
         """Persist the stats-above-description toggle (#153)."""
         AppSettings.settings().setValue(AppSettings.STATS_PREPEND, bool(enabled))
         AppSettings.settings().sync()
+
+    @staticmethod
+    def get_owned_items() -> set:
+        """Return the set of owned blueprint item names (#157).
+
+        Stored as a JSON list string so it round-trips identically through the
+        registry (QSettings) and the portable JSON backend — a raw Python list
+        in QSettings comes back as a QStringList and mangles single-item sets.
+        """
+        import json
+        raw = AppSettings.settings().value(AppSettings.OWNED_ITEMS, "", type=str)
+        if not raw:
+            return set()
+        try:
+            return set(json.loads(raw))
+        except (ValueError, TypeError):
+            return set()
+
+    @staticmethod
+    def set_owned_items(names) -> None:
+        """Persist the owned blueprint item-name set (#157)."""
+        import json
+        AppSettings.settings().setValue(
+            AppSettings.OWNED_ITEMS, json.dumps(sorted(names))
+        )
+        AppSettings.settings().sync()
+
+    @staticmethod
+    def toggle_owned_item(name: str) -> bool:
+        """Add/remove *name* from the owned set; return the new owned state."""
+        owned = AppSettings.get_owned_items()
+        if name in owned:
+            owned.discard(name)
+            new_state = False
+        else:
+            owned.add(name)
+            new_state = True
+        AppSettings.set_owned_items(owned)
+        return new_state
 
     @staticmethod
     def get_tutorial_completed_version() -> str:

--- a/src/utils/test_plan.py
+++ b/src/utils/test_plan.py
@@ -124,6 +124,16 @@ TEST_SECTIONS: list[dict] = [
             "Turn the Ace Pilot Tag toggle off, regenerate, and confirm the [ACE] tags disappear.",
         ],
     },
+    {
+        "title": "Owned blueprints (#157)",
+        "items": [
+            "Find an item that appears in mission POTENTIAL BLUEPRINTS lists (e.g. an Antium armour piece); its row shows an Owned star in the new Owned column.",
+            "Click the Owned star: it fills, and that item gains a blue [Owned] tag in every mission's POTENTIAL BLUEPRINTS list where it appears.",
+            "Click again to unmark: the [Owned] tag disappears everywhere.",
+            "Restart the app and confirm your owned marks persisted (the [Owned] tags reappear).",
+            "Apply to Game with an item owned, then confirm [Owned] shows in that blueprint list in-game.",
+        ],
+    },
 ]
 
 

--- a/tests/test_owned_items.py
+++ b/tests/test_owned_items.py
@@ -1,0 +1,151 @@
+"""Owned-blueprint tagging core (#157)."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+from utils.owned_items import (  # noqa: E402
+    apply_owned_to_value,
+    extract_bp_item_names,
+    normalize_item_name,
+)
+
+pytestmark = [pytest.mark.unit, pytest.mark.regression]
+
+# A realistic BP-bearing mission description value (literal \n separators).
+_DESC = (
+    "POSTING: salvage run.\\n\\n<EM3>POTENTIAL BLUEPRINTS</EM3>"
+    "\\n- Antium Core\\n- [Mil-S1-A] Norfield\\n- Abrade Scraper Module"
+    "\\n\\n<EM3>MISSION DETAILS</EM3>\\n<EM4>Difficulty:</EM4> 3"
+)
+
+
+class TestNormalize:
+    def test_strips_leading_component_tag(self):
+        assert normalize_item_name("[Mil-S1-A] Norfield") == "Norfield"
+
+    def test_strips_owned_tag(self):
+        assert normalize_item_name("Antium Core <EM4>[Owned]</EM4>") == "Antium Core"
+
+    def test_bare_name_unchanged(self):
+        assert normalize_item_name("Antium Core") == "Antium Core"
+
+    def test_tagged_bullet_matches_bare_row(self):
+        # The whole point: a tagged bullet and the bare item row normalize equal.
+        assert normalize_item_name("[Mil-S1-A] Norfield") == normalize_item_name("Norfield")
+
+
+class TestExtract:
+    def test_finds_normalized_bullet_names(self):
+        names = extract_bp_item_names(_DESC)
+        assert names == {"Antium Core", "Norfield", "Abrade Scraper Module"}
+
+    def test_no_section_returns_empty(self):
+        assert extract_bp_item_names("Just a plain description, no rewards.") == set()
+
+    def test_empty_value(self):
+        assert extract_bp_item_names("") == set()
+
+
+class TestApply:
+    def test_tags_only_owned_bullets(self):
+        out = apply_owned_to_value(_DESC, {"Antium Core"})
+        assert "- Antium Core <EM4>[Owned]</EM4>" in out
+        assert "- [Mil-S1-A] Norfield\\n" in out  # not owned -> untagged
+
+    def test_tags_owned_via_normalized_match_through_component_tag(self):
+        out = apply_owned_to_value(_DESC, {"Norfield"})
+        assert "- [Mil-S1-A] Norfield <EM4>[Owned]</EM4>" in out
+
+    def test_idempotent(self):
+        once = apply_owned_to_value(_DESC, {"Antium Core"})
+        twice = apply_owned_to_value(once, {"Antium Core"})
+        assert once == twice
+        assert once.count("[Owned]") == 1
+
+    def test_unowning_removes_tag(self):
+        tagged = apply_owned_to_value(_DESC, {"Antium Core"})
+        cleared = apply_owned_to_value(tagged, set())
+        assert "[Owned]" not in cleared
+        assert cleared == _DESC
+
+    def test_no_bp_section_only_strips_stale_owned(self):
+        v = "A plain line\\n- not a blueprint bullet <EM4>[Owned]</EM4>"
+        out = apply_owned_to_value(v, {"whatever"})
+        assert "[Owned]" not in out
+
+    def test_empty_owned_set_strips_and_returns(self):
+        tagged = apply_owned_to_value(_DESC, {"Antium Core"})
+        assert "[Owned]" not in apply_owned_to_value(tagged, set())
+
+
+# ── AppSettings owned-set persistence + model rendering ──────────────────────
+
+import os as _os  # noqa: E402
+_os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+from PyQt6.QtCore import QSettings, Qt  # noqa: E402
+from PyQt6.QtWidgets import QApplication  # noqa: E402
+from src.utils.settings import AppSettings  # noqa: E402
+
+
+@pytest.fixture
+def isolated_settings(tmp_path, monkeypatch):
+    shared = QSettings(str(tmp_path / "reg.ini"), QSettings.Format.IniFormat)
+    monkeypatch.setattr(AppSettings, "settings", staticmethod(lambda: shared))
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    return QApplication.instance() or QApplication([])
+
+
+class TestOwnedSettings:
+    def test_default_empty(self, isolated_settings):
+        assert AppSettings.get_owned_items() == set()
+
+    def test_roundtrip_single_item(self, isolated_settings):
+        # The JSON-string backing must survive a single-item set (a raw list in
+        # QSettings would come back mangled).
+        AppSettings.set_owned_items({"Antium Core"})
+        assert AppSettings.get_owned_items() == {"Antium Core"}
+
+    def test_toggle(self, isolated_settings):
+        assert AppSettings.toggle_owned_item("Norfield") is True
+        assert "Norfield" in AppSettings.get_owned_items()
+        assert AppSettings.toggle_owned_item("Norfield") is False
+        assert "Norfield" not in AppSettings.get_owned_items()
+
+
+class TestModelOwnedColumn:
+    def _model(self, qapp):
+        from src.gui.string_table_model import StringTableModel
+        from src.models.string_model import StringEntry
+        m = StringTableModel()
+        item = StringEntry(key="item_NameNorfield", source_file="global",
+                           category="Components", original_value="Norfield",
+                           custom_value="", status="Unmodified")
+        other = StringEntry(key="misc", source_file="global", category="Misc",
+                            original_value="not an item", custom_value="", status="Unmodified")
+        m.set_data_source([item, other], {}, "*")
+        return m, item, other
+
+    def test_star_only_on_bp_item_rows(self, qapp):
+        from src.gui.string_table_model import COL_OWNED
+        m, item, other = self._model(qapp)
+        m.set_owned_state({"Norfield"}, set())
+        item_row = m.source_row_for_entry_index(0)
+        other_row = m.source_row_for_entry_index(1)
+        assert m.data(m.index(item_row, COL_OWNED), Qt.ItemDataRole.DisplayRole) == "☆"   # empty star
+        assert m.data(m.index(other_row, COL_OWNED), Qt.ItemDataRole.DisplayRole) == ""        # non-item: blank
+
+    def test_filled_star_when_owned(self, qapp):
+        from src.gui.string_table_model import COL_OWNED
+        m, item, other = self._model(qapp)
+        m.set_owned_state({"Norfield"}, {"Norfield"})
+        item_row = m.source_row_for_entry_index(0)
+        assert m.data(m.index(item_row, COL_OWNED), Qt.ItemDataRole.DisplayRole) == "★"   # filled star


### PR DESCRIPTION
Implements #157 with display-name keying (option a, as you chose).

## What it does
- New **Owned** star column on craftable-blueprint item rows (items that appear in at least one mission POTENTIAL BLUEPRINTS list).
- Click the star to mark an item owned. A blue `<EM4>[Owned]</EM4>` tag is woven onto that item **wherever** it appears in a mission's POTENTIAL BLUEPRINTS list (descriptions only, not titles).
- Reapplied on every load (survives restart) and woven into the merged output at **Apply to Game**, so `[Owned]` shows in-game.
- Blue per the request on the issue (EM4 = blue; EM3 is underline per #164).

## How it's built
- Core logic is Qt-free in `src/utils/owned_items.py`: `normalize_item_name` (strips a leading component tag and the owned tag), `extract_bp_item_names`, and an **idempotent** `apply_owned_to_value` (strips existing `[Owned]` then re-adds, so it's a pure function of `(value, owned)` and never doubles).
- Matching is **tag-normalized**, so a tagged bullet (`[Mil-S1-A] Norfield`) matches its bare item row.
- Persistence: `AppSettings.OWNED_ITEMS` as a JSON-list string (round-trips identically through the registry and the portable JSON backend; a raw list in QSettings mangles single-item sets).
- `COL_OWNED` added at the **end** of the column model (NUM_COLUMNS 8→9), with the `entry_filter` getter tuple kept aligned for the drift guard. `_recompute_owned()` runs after every load and on every toggle.

## Why a PR (not a direct push like the other 2.1.0 fixes)
This is the largest change of the set — a new table column plus a live cross-row transform — so it gets a reviewable diff rather than landing straight on the release branch.

## Known limitation
Name keying means two **distinct** items that share an identical display name would share owned state. That's the tradeoff of option (a); option (b) (a generator-emitted loc-key→UUID map) would remove it. Flagged so it's a conscious choice.

## Tests
18 new tests (core transform, settings round-trip, model star rendering) + integration-verified offscreen (star toggles, `[Owned]` woven/removed). Full suite: **914 passed, 16 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)