### PR TITLE
fix(missions): component tag fallback, full show_fields gating, ace detail (#158 #160 #163)

### DIFF
--- a/scripts/generate_enhancements_ini.py
+++ b/scripts/generate_enhancements_ini.py
@@ -786,13 +786,10 @@ def _component_name_tag(desc_value: str, root: ET.Element | None = None,
     if not type_abbrev and class_name:
         type_abbrev = _ITEM_TYPE_ABBREV.get(class_name)
 
-    if not (type_abbrev or grade_letter):
+    if not type_abbrev:
         return None
 
-    parts: list[str] = []
-    if type_abbrev:
-        parts.append(type_abbrev)
-    parts.append(f"S{size}")
+    parts: list[str] = [type_abbrev, f"S{size}"]
     if grade_letter:
         parts.append(grade_letter)
     return f"[{'-'.join(parts)}]"
@@ -2592,7 +2589,7 @@ def _extract_mission_flags(root: ET.Element) -> list[str]:
 
 def enhancements_mission(root: ET.Element, reputation_lookup: dict[str, int] | None = None,
                          rep_xp_label: str = _DEFAULT_REP_XP_LABEL,
-                         show_spawns: bool = True,
+                         show_fields: "dict | None" = None,
                          spawn_ambiguous_keys: "set[str] | None" = None) -> str:
     """Extract mission/contract reward stats (aUEC + Reputation XP) and flags.
 
@@ -2605,25 +2602,29 @@ def enhancements_mission(root: ET.Element, reputation_lookup: dict[str, int] | N
     lines = []
     reputation_lookup = reputation_lookup or {}
 
+    def _show(f: str) -> bool:
+        return bool((show_fields or {}).get(f, True))
+
     try:
         loc_key = _mission_loc_key(root) or _loc_key(root)
         lines.append(f"<EM4>Engagement Type:</EM4> {_classify_mission_engagement(loc_key)}")
 
         flags = _extract_mission_flags(root)
-        lines.append(f"<EM4>Mission Type:</EM4> {', '.join(flags) if flags else 'Standard'}")
+        if _show("mission_type"):
+            lines.append(f"<EM4>Mission Type:</EM4> {', '.join(flags) if flags else 'Standard'}")
 
         difficulty = _extract_difficulty(root)
-        if difficulty:
+        if difficulty and _show("difficulty"):
             lines.append(f"<EM4>Difficulty (1-7):</EM4> {difficulty}")
 
         total_rep_xp = _extract_mission_xp(root, reputation_lookup)
-        if total_rep_xp > 0:
+        if total_rep_xp > 0 and _show("reputation"):
             lines.append(f"<EM4>{rep_xp_label}:</EM4> +{total_rep_xp:,}")
 
         # Extract spawn/wave counts — bucketed Hostiles / Friendlies /
         # Objectives / Unknown rather than the pre-1.4.1 single-tally
         # Enemies + Non-hostiles. Empty buckets are dropped by the formatter.
-        # #163: gated by the Hostiles mission-detail toggle. The contractgen
+        # #163: gated by per-field show_fields (Hostiles toggle). The contractgen
         # path gates this too (via _show("spawns")); pu_missions / entities
         # missions reach the table through here, so without the gate salvage
         # contracts kept showing hostiles after the user turned them off.
@@ -2633,7 +2634,7 @@ def enhancements_mission(root: ET.Element, reputation_lookup: dict[str, int] | N
         # — a single body can't honestly show one count for both. The
         # consistent buckets (e.g. Friendlies "Salvageable Ships") still show.
         _ambiguous = loc_key in spawn_ambiguous_keys if spawn_ambiguous_keys else False
-        if show_spawns:
+        if _show("spawns"):
             _bd = _extract_spawn_counts(root)
             if _ambiguous:
                 _bd[SPAWN_HOSTILE] = {}
@@ -5055,7 +5056,6 @@ def _run_gen_missions(ctx: dict) -> dict[str, str]:
 
     out: dict[str, str] = {}
     pu_missions_dir = records / "missionbroker" / "pu_missions"
-    _show_spawns = _show("spawns")  # #163: honor the Hostiles toggle here too
 
     # #165: pre-pass — a single mission description is often shared by many
     # pu_missions XMLs with DIFFERENT hostile spawns (every lawful AND unlawful
@@ -5094,7 +5094,7 @@ def _run_gen_missions(ctx: dict) -> dict[str, str]:
             pu_missions_dir,
             lambda root: enhancements_mission(root, reputation_lookup,
                                               rep_xp_label=rep_xp_label,
-                                              show_spawns=_show_spawns,
+                                              show_fields=_mdf,
                                               spawn_ambiguous_keys=spawn_ambiguous_descs),
             loc=loc, loc_key_fn=_mission_loc_key,
             separator=mission_sep, capture_all=True,
@@ -5111,7 +5111,7 @@ def _run_gen_missions(ctx: dict) -> dict[str, str]:
                 mission_dir,
                 lambda root: enhancements_mission(root, reputation_lookup,
                                                   rep_xp_label=rep_xp_label,
-                                                  show_spawns=_show_spawns,
+                                                  show_fields=_mdf,
                                                   spawn_ambiguous_keys=spawn_ambiguous_descs),
                 loc=loc, separator=mission_sep, capture_all=True,
                 xml_path_index=xml_path_index, records_dir=records,
@@ -5344,6 +5344,8 @@ def _run_gen_missions(ctx: dict) -> dict[str, str]:
                 details_lines.append(f"<EM4>Difficulty (1-7):</EM4> {all_difficulties[0]}")
             if _show("spawns"):
                 details_lines.extend(_format_spawn_lines(agg_spawns))
+            if _show("ace") and bool(agg_spawns.get(SPAWN_HOSTILE, {}).get("Ace Pilots", 0)):
+                details_lines.append("<EM4>Ace Pilot:</EM4> Yes")
             nonzero_tiers = [(s, f, rn) for s, f, rn in desc_seen_tiers if s > 0]
             if _show("reputation"):
                 if len(nonzero_tiers) == 1:

--- a/scripts/generate_enhancements_ini.py
+++ b/scripts/generate_enhancements_ini.py
@@ -4261,6 +4261,56 @@ def _armor_stats_block(armor_root: ET.Element) -> str:
     return "\\n".join(lines)
 
 
+# ── Earnable ship name overrides ─────────────────────────────────────────────
+# One-off vehicle_Name* renames for ships only earnable in-game (exec hangar
+# PYX ships and Wikelo WIK ships), where CIG's loc key doesn't distinguish the
+# variant from the pledge-store version. Applied at write time when the
+# "Standardize earnable ship names" option is enabled.
+# Empty-string values are placeholders and are skipped — they won't overwrite
+# the existing name.
+EARNABLE_SHIP_NAME_OVERRIDES: dict[str, str] = {
+    "vehicle_NameANVL_Hornet_F7A_Mk2_PYAM_Exec":             "Anvil F7A Hornet Mk II PYX",
+    "vehicle_NameDRAK_Cutlass_Black_PYAM_Exec":               "Drake Cutlass Black PYX",
+    "vehicle_NameRSI_Meteor_Collector_Military":               "RSI Meteor Collector Military PYX",
+    "vehicle_NameANVL_Lightning_F8C_PYAM_Exec":               "Anvil F8C Lightning PYX",
+    "vehicle_NameDRAK_Corsair_PYAM_Exec":                     "Drake Corsair PYX",
+    "vehicle_NameGAMA_Syulen_PYAM_Exec":                      "Gama Syulen PYX",
+    "TheCollector_ShipMod_MISC_Fortune_VehicleName":          "MISC Fortune WIK",
+    "TheCollector_ShipMod_MRAI_GuardianQI_VehicleName":       "Mirai Guardian QI WIK",
+    "TheCollector_ShipMod_MRAI_Pulse_VehicleName":            "Mirai Pulse WIK",
+    "TheCollector_ShipMod_URSA_Medivac_VehicleName":          "RSI Ursa Medivac WIK",
+    "TheCollector_ShipMod_XIAN_Nox_VehicleName":              "Aopoa Nox WIK",
+    "vehicle_NameCRUS_Spirit_C1_Collector_Civilian":           "Crusader C1 Spirit WIK",
+    "vehicle_NameRSI_Polaris_Collector_Military":              "RSI Polaris WIK",
+    "vehicle_NameAEGS_Firebird_Collector_Milt":                "Aegis Sabre Firebird WIK War",
+    "vehicle_NameAEGS_Idris_P_Collector_Military":             "Aegis Idris-P WIK War",
+    "vehicle_NameANVL_Asgard_Collector_Military":              "",  # placeholder — skipped
+    "vehicle_NameANVL_Lightning_F8C_Collector_Military":       "Anvil F8C Lightning WIK War",
+    "vehicle_NameCRUS_Starfighter_Inferno_Collector_Military": "Crusader Ares Star Fighter Inferno WIK War",
+    "vehicle_NameCRUS_Starlifter_A2_Collector_Military":       "Crusader A2 Hercules Starlifter WIK War",
+    "vehicle_NameKRIG_L21_Wolf_Collector_Military":            "Kruger L-21 Wolf WIK War",
+    "vehicle_NameKRIG_L22_Alpha_Wolf_Collector_Military":      "Kruger L-22 Alpha Wolf WIK War",
+    "vehicle_NameMISC_Starlancer_TAC_Collector_Military":      "MISC Starlancer TAC WIK War",
+    "vehicle_NameMRAI_Guardian_Collector_Military":            "Mirai Guardian WIK War",
+    "vehicle_NameMRAI_Guardian_MX_Collector_Military":         "Mirai Guardian MX WIK War",
+    "vehicle_NameRSI_Constellation_Taurus_Collector_Military": "RSI Constellation Taurus WIK War",
+    "vehicle_NameANVL_Lightning_F8C_Collector_Stealth":        "Anvil F8C Lightning WIK Stealth",
+    "vehicle_NameCRUS_Starfighter_Ion_Collector_Stealth":      "Crusader Ares Star Fighter Ion WIK Stealth",
+    "vehicle_NameKRIG_L21_Wolf_Collector_Stealth":             "Kruger L-21 Wolf WIK Stealth",
+    "vehicle_NameRSI_Apollo_Triage_Collector_Stealth":         "RSI Apollo Triage WIK Stealth",
+    "vehicle_NameRSI_Meteor_Collector_Stealth":                "RSI Meteor WIK Stealth",
+    "vehicle_NameRSI_Scorpius_Collector_Stealth":              "RSI Scorpius WIK Stealth",
+    "vehicle_NameARGO_RAFT_Collector_Indust":                  "Argo RAFT WIK Work",
+    "vehicle_NameCRUS_Intrepid_Collector_Indust":              "Crusader Intrepid WIK Work",
+    "vehicle_NameDRAK_Golem_Collector_Indust":                 "Drake Golem WIK Work",
+    "vehicle_NameESPR_Prowler_Utility_Collector_Indust":       "Prowler Utility WIK Work",
+    "vehicle_NameMISC_Prospector_Collector_Indust":            "MISC Prospector WIK Work",
+    "vehicle_NameMISC_Starlancer_MAX_Collector_Indust":        "MISC Starlancer MAX WIK Work",
+    "vehicle_NameRSI_Zeus_CL_Collector_Indust":                "RSI Zeus Mk II CL WIK Work",
+    "vehicle_NameRSI_Zeus_ES_Collector_Indust":                "RSI Zeus Mk II ES WIK Work",
+}
+
+
 def enhancements_ship_dataforge(
     root: ET.Element,
     controller_root: ET.Element | None,
@@ -5605,6 +5655,7 @@ def main(base_ini_path: Path, forge_dir: Path | None = None,
          mission_header_em_tag: str = _DEFAULT_MISSION_HEADER_EM_TAG,
          mission_detail_fields: dict | None = None,
          stats_prepend: bool = False,
+         standardize_earnable_ship_names: bool = False,
          english_base_ini_path: Path | None = None) -> None:
     import sys as sys_mod
     # Deferred import — the script is loaded by both the app worker (where
@@ -5951,6 +6002,10 @@ def main(base_ini_path: Path, forge_dir: Path | None = None,
     logger.info("Writing output files…")
     _flush()
     if _want("ship_descs"):
+        if standardize_earnable_ship_names:
+            applied = {k: v for k, v in EARNABLE_SHIP_NAME_OVERRIDES.items() if v}
+            out_ships.update(applied)
+            logger.info(f"Earnable ship name overrides: applied {len(applied)} entries")
         write_ini(output_dir / "ships_desc_enhancements.ini",       out_ships)
     if _want("component_descs"):
         write_ini(output_dir / "components_desc_enhancements.ini",  out_components)

--- a/src/gui/enhancements_tab.py
+++ b/src/gui/enhancements_tab.py
@@ -256,6 +256,21 @@ class EnhancementsTab(QWidget):
         )
         gl.addWidget(self._stats_prepend_check)
 
+        self._standardize_ship_names_check = QCheckBox("Standardize earnable ship names")
+        self._standardize_ship_names_check.setChecked(
+            AppSettings.get_standardize_earnable_ship_names()
+        )
+        self._standardize_ship_names_check.setStyleSheet("font-size: 11px;")
+        self._standardize_ship_names_check.setToolTip(
+            "Rename exec-hangar (PYX) and Wikelo (WIK) ship variants to include "
+            "a suffix that distinguishes them from the standard pledge-store version "
+            "(e.g. \"Anvil F8C Lightning PYX\"). Takes effect on the next Generate Enhancements."
+        )
+        self._standardize_ship_names_check.toggled.connect(
+            lambda checked: AppSettings.set_standardize_earnable_ship_names(checked)
+        )
+        gl.addWidget(self._standardize_ship_names_check)
+
         btn_row = QHBoxLayout()
 
         self._apply_categories_btn = QPushButton(tr("enhancements.apply_btn"))

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -4051,6 +4051,7 @@ class MainWindow(QMainWindow):
             mission_header_em_tag=AppSettings.get_mission_header_em_tag(),
             mission_detail_fields=AppSettings.get_mission_detail_fields(),
             stats_prepend=AppSettings.get_stats_prepend(),
+            standardize_earnable_ship_names=AppSettings.get_standardize_earnable_ship_names(),
             language=language,
         )
         self.enhancements_tab.set_operation_running("Generating enhancements…")

--- a/src/gui/workers.py
+++ b/src/gui/workers.py
@@ -245,6 +245,7 @@ class EnhancementsGeneratorWorker(QThread):
                  mission_header_em_tag: str = AppSettings.DEFAULT_MISSION_HEADER_EM_TAG,
                  mission_detail_fields: dict | None = None,
                  stats_prepend: bool = False,
+                 standardize_earnable_ship_names: bool = False,
                  language: str | None = None):
         super().__init__()
         self.categories = categories
@@ -255,6 +256,7 @@ class EnhancementsGeneratorWorker(QThread):
         self.mission_header_em_tag = mission_header_em_tag
         self.mission_detail_fields = mission_detail_fields
         self.stats_prepend = stats_prepend
+        self.standardize_earnable_ship_names = standardize_earnable_ship_names
         # Which language's base.ini to generate against. None resolves to the
         # selected language at run time. English uses the P4K base.ini in the
         # channel cache root; other languages use the downloaded per-language
@@ -350,6 +352,7 @@ class EnhancementsGeneratorWorker(QThread):
                      mission_header_em_tag=self.mission_header_em_tag,
                      mission_detail_fields=self.mission_detail_fields,
                      stats_prepend=self.stats_prepend,
+                     standardize_earnable_ship_names=self.standardize_earnable_ship_names,
                      english_base_ini_path=AppSettings.get_base_ini_path(
                          AppSettings.DEFAULT_LANGUAGE))
             logger.info("Enhancements generation worker: mod.main() completed successfully")

--- a/src/utils/settings.py
+++ b/src/utils/settings.py
@@ -273,6 +273,7 @@ class AppSettings:
     # the actual component names elsewhere. Issue #31 follow-up.
     TAG_ANNOTATE_MISSION_DESCS = "tag_builder/annotate_mission_descs"
     STATS_PREPEND = "stats_prepend"  # #153: stats block above the description
+    STANDARDIZE_EARNABLE_SHIP_NAMES = "standardize_earnable_ship_names"
     OWNED_ITEMS = "owned_items"      # #157: blueprint items the user owns (JSON list of names)
 
     # Settings keys - Data sources (new)
@@ -794,6 +795,21 @@ class AppSettings:
     def set_stats_prepend(enabled: bool) -> None:
         """Persist the stats-above-description toggle (#153)."""
         AppSettings.settings().setValue(AppSettings.STATS_PREPEND, bool(enabled))
+        AppSettings.settings().sync()
+
+    @staticmethod
+    def get_standardize_earnable_ship_names() -> bool:
+        """Whether to apply standardized display names for earnable ships
+        (PYX exec-hangar and WIK Wikelo variants). Off by default."""
+        return bool(AppSettings.settings().value(
+            AppSettings.STANDARDIZE_EARNABLE_SHIP_NAMES, False, type=bool
+        ))
+
+    @staticmethod
+    def set_standardize_earnable_ship_names(enabled: bool) -> None:
+        AppSettings.settings().setValue(
+            AppSettings.STANDARDIZE_EARNABLE_SHIP_NAMES, bool(enabled)
+        )
         AppSettings.settings().sync()
 
     @staticmethod

--- a/tests/test_blueprint_pools.py
+++ b/tests/test_blueprint_pools.py
@@ -448,12 +448,13 @@ class TestBlueprintNameTags:
         assert tag(arbor_desc) == "[MIN-S0]"
 
     def test_tagger_fallback_grade_only_no_known_item_type(self, gen_module):
-        """An item with Size + Grade but an Item Type we haven't added to
-        the abbreviation map still gets a usable tag — just without the
-        type prefix. Future-proofs against new ship-item categories."""
+        """#160: An item with Size + Grade but an Item Type not in the
+        abbreviation map returns None on the fallback path. A grade-only
+        [Sx-grade] tag conveys nothing useful without a type and was
+        incorrectly appearing on FPS gear / salvage heads in blueprint lists."""
         tag = gen_module._component_name_tag
         desc = "Item Type: Unrecognised Widget\\nSize: 2\\nGrade: A\\n"
-        assert tag(desc) == "[S2-A]"
+        assert tag(desc) is None
 
     def test_tagger_ship_weapons_tag_with_damage_type(self, gen_module):
         """1.4.1 regression: ship weapons in POTENTIAL BLUEPRINTS lists

--- a/tests/test_spawn_classifier.py
+++ b/tests/test_spawn_classifier.py
@@ -659,12 +659,12 @@ class TestSpawnGatingInEnhancementsMission:
         )
 
     def test_show_spawns_true_emits_hostiles(self, gen_module):
-        body = gen_module.enhancements_mission(self._mission(), show_spawns=True)
+        body = gen_module.enhancements_mission(self._mission(), show_fields={"spawns": True})
         assert "Hostiles:" in body and "Pirates" in body
 
     def test_show_spawns_false_drops_all_spawn_lines(self, gen_module):
         # #163: with the Hostiles toggle off, no spawn bucket is emitted.
-        body = gen_module.enhancements_mission(self._mission(), show_spawns=False)
+        body = gen_module.enhancements_mission(self._mission(), show_fields={"spawns": False})
         assert "Hostiles:" not in body
         assert "Salvageable Ships" not in body
 
@@ -674,7 +674,7 @@ class TestSpawnGatingInEnhancementsMission:
         root = self._mission()
         key = gen_module._mission_loc_key(root)
         body = gen_module.enhancements_mission(
-            root, show_spawns=True, spawn_ambiguous_keys={key}
+            root, spawn_ambiguous_keys={key}
         )
         assert "Hostiles:" not in body
         assert "Salvageable Ships" in body


### PR DESCRIPTION
## Summary

Four issues addressed across two commits.

---

### #160 -- `_component_name_tag` fallback no longer emits grade-only tags

The fallback path (used when the `Class:` lookup fails) previously emitted
a tag like `[S2-A]` whenever a grade was known, even when no Item Type
abbreviation could be resolved. The class prefix is the only part that
tells a player what kind of item they are looking at; a grade alone is
meaningless as a tag. Changed the guard from
`if not (type_abbrev or grade_letter)` to `if not type_abbrev` and
simplified the parts-list construction. Items with a recognised grade but
an unrecognised type now return `None` and fall through to the raw name.

**Covered by:** `test_tagger_fallback_grade_only_no_known_item_type` in
`test_blueprint_pools.py` -- expectation updated from `[S2-A]` to `None`.

---

### #163 -- `enhancements_mission` now respects all mission-detail field toggles

`enhancements_mission` is the code path for standalone `pu_missions` and
`entities/missions` XMLs (not the contractgenerator loop). It previously
only gated the spawns bucket via a bare `show_spawns: bool` parameter
added in an earlier partial fix, leaving `mission_type`, `difficulty`, and
`reputation` always emitted regardless of user preference.

Replaced `show_spawns: bool = True` with `show_fields: dict | None = None`
and added a local `_show()` helper that defaults missing keys to `True` (so
an unconfigured call gets the full body, exactly as before). All four
fields are now gated. Both call sites in `_run_gen_missions` updated from
`show_spawns=_show_spawns` to `show_fields=_mdf`, making the `pu_missions`
and contractgenerator paths use the same settings dict end-to-end.

**Covered by:** three `TestSpawnGatingInEnhancementsMission` tests in
`test_spawn_classifier.py` updated from `show_spawns=...` to
`show_fields={"spawns": ...}`; all `test_mission_detail_fields.py` tests.

---

### #158 -- "Ace Pilot: Yes" detail line in mission description bodies

The `[ACE]`/`[ACE?]` title-level tags were already in HEAD. This adds the
companion line in the MISSION DETAILS body: emits `Ace Pilot: Yes` when
the aggregated spawn breakdown for that description contains a non-zero
`Ace Pilots` hostile group, gated by `_show("ace")` so it respects the
user's per-field toggle independently of the title tag.

---

### New feature -- "Standardize earnable ship names" (PYX / WIK)

CIG's loc keys for exec-hangar (PYX) and Wikelo (WIK) ship variants share
the same `vehicle_Name*` prefix as their pledge-store equivalents, so
Smart Citizen has no way to distinguish them in the ship descriptions
table. A player who owns both the standard F8C Lightning and the
exec-hangar PYX version sees two entries with the same display name.

Adds an opt-in toggle ("Standardize earnable ship names") on the
Enhancements tab. When enabled, a static lookup table of ~35 entries is
applied at write time just before `ships_desc_enhancements.ini` is
written, appending a `PYX` or `WIK` suffix (plus a variant tag for WIK
ships: War / Work / Stealth) to every earnable-only variant. Entries with
an empty-string value are placeholder stubs and are skipped. Feature is
off by default -- existing users see no change until they opt in.

Ships covered:

**PYX exec-hangar (6):** F7A Hornet Mk II, Cutlass Black, Meteor
Collector, F8C Lightning, Corsair, Syulen

**WIK Wikelo (29):** Fortune, Guardian QI, Pulse, Ursa Medivac, Nox,
C1 Spirit, Polaris -- plus War/Work/Stealth variants including Sabre
Firebird, Idris-P, F8C Lightning, Ares Ion/Inferno, A2 Hercules,
L-21/L-22 Wolf, Starlancer TAC/MAX, Guardian/MX, Constellation Taurus,
Apollo Triage, Meteor, Scorpius, RAFT, Intrepid, Golem, Prowler Utility,
Prospector, Zeus CL/ES

**Files changed:**

- `scripts/generate_enhancements_ini.py`: `EARNABLE_SHIP_NAME_OVERRIDES`
  dict + `standardize_earnable_ship_names` param on `main()`
- `src/utils/settings.py`: `STANDARDIZE_EARNABLE_SHIP_NAMES` key +
  `get/set_standardize_earnable_ship_names()`
- `src/gui/enhancements_tab.py`: `_standardize_ship_names_check` checkbox
  with tooltip, wired to settings
- `src/gui/workers.py`: param plumbed through `EnhancementsGeneratorWorker`
- `src/gui/main_window.py`: setting read and passed to worker

## Test plan

- [x] `pytest tests/test_blueprint_pools.py` -- `test_tagger_fallback_grade_only_no_known_item_type` returns `None`
- [x] `pytest tests/test_spawn_classifier.py` -- three `TestSpawnGatingInEnhancementsMission` tests pass with new `show_fields` API
- [x] `pytest tests/test_mission_detail_fields.py` -- all field-gate tests pass
- [x] `pytest tests/` -- full suite (937 passed, 16 skipped)
- [ ] Manual: enable "Standardize earnable ship names", run Generate Enhancements, confirm PYX/WIK entries appear in the ships table with the correct suffixes
- [ ] Manual: disable the toggle, regenerate, confirm names revert to CIG originals

🤖 Generated with [Claude Code](https://claude.com/claude-code)
