### PR TITLE
Feature: language selection page as the installer's first screen

### DIFF
--- a/installer.iss
+++ b/installer.iss
@@ -75,6 +75,14 @@ var
     HKCU\...\ui_mode in WriteInstallerChoicesToRegistry and the app reads it on
     first launch. Defaults to Simple, pre-selected from a prior install. }
   ModeChoicePage: TInputOptionWizardPage;
+  { App UI/string language. Radio page anchored to wpWelcome so it's the very
+    first page the user sees, before any of the built-in wizard pages. The
+    choice is written to HKCU\...\selected_language (matching AppSettings.
+    SELECTED_LANGUAGE) so the app opens in that language on first launch
+    instead of defaulting to English until the user finds the Config tab's
+    language selector. Options must stay in sync with the non-stub folders
+    under languages/ (AppSettings.get_available_languages()). }
+  LanguageChoicePage: TInputOptionWizardPage;
 
 function IsAutoUpdate(): Boolean;
 begin
@@ -703,6 +711,23 @@ begin
     RegWriteStringValue(HKCU,
       'Software\Osiris DevWorks\Smart Citizen', 'ui_mode', 'simple');
   Log('Saved ui_mode to registry.');
+
+  { App UI/string language, matching AppSettings.SELECTED_LANGUAGE. Always
+    written (not just on a non-English choice) so a fresh install opens in
+    the chosen language rather than relying on the app's English fallback.
+    Values here must stay in sync with the folder names under languages/. }
+  case LanguageChoicePage.SelectedValueIndex of
+    1: RegWriteStringValue(HKCU,
+         'Software\Osiris DevWorks\Smart Citizen', 'selected_language', 'french');
+    2: RegWriteStringValue(HKCU,
+         'Software\Osiris DevWorks\Smart Citizen', 'selected_language', 'portuguese_br');
+    3: RegWriteStringValue(HKCU,
+         'Software\Osiris DevWorks\Smart Citizen', 'selected_language', 'spanish');
+  else
+    RegWriteStringValue(HKCU,
+      'Software\Osiris DevWorks\Smart Citizen', 'selected_language', 'english');
+  end;
+  Log('Saved selected_language to registry.');
 end;
 
 procedure CurStepChanged(CurStep: TSetupStep);
@@ -865,7 +890,49 @@ var
   SCRoot: String;
   ActiveChannel: String;
   SavedDataDir: String;
+  SavedLanguage: String;
+  LanguageIndex: Integer;
 begin
+  { App UI/string language — first page, anchored to wpWelcome. Kept ahead
+    of every other custom page (and the built-in Select Destination /
+    Program Group / Tasks pages) so it's the first choice a user makes. }
+  LanguageChoicePage := CreateInputOptionPage(
+    wpWelcome,
+    'Select Language',
+    'Choose the language Smart Citizen starts in.',
+    'This sets both the app''s interface language and, where available, '
+    + 'the in-game localization strings it loads.'
+    + #13#10 + #13#10 +
+    'You can change this anytime from the app''s Config tab.',
+    True,
+    False
+  );
+  { Plain ASCII labels, matching the app's own Config-tab language combo
+    (ConfigTab._populate_language_combo does lang.replace('_', ' ').title(),
+    not native-script names) — installer.iss has no UTF-8 BOM, so accented
+    characters risk mangling under ISCC's ANSI-codepage fallback. }
+  LanguageChoicePage.Add('English');
+  LanguageChoicePage.Add('French');
+  LanguageChoicePage.Add('Portuguese (Brazil)');
+  LanguageChoicePage.Add('Spanish');
+
+  { Pre-select the prior choice on a reinstall so an upgrade doesn't
+    silently reset a non-English user back to English. Defaults to
+    English (index 0) when nothing is saved yet or the saved value
+    doesn't match a known option. }
+  LanguageIndex := 0;
+  if RegQueryStringValue(HKCU, 'Software\Osiris DevWorks\Smart Citizen',
+       'selected_language', SavedLanguage) then
+  begin
+    if CompareText(SavedLanguage, 'french') = 0 then
+      LanguageIndex := 1
+    else if CompareText(SavedLanguage, 'portuguese_br') = 0 then
+      LanguageIndex := 2
+    else if CompareText(SavedLanguage, 'spanish') = 0 then
+      LanguageIndex := 3;
+  end;
+  LanguageChoicePage.SelectedValueIndex := LanguageIndex;
+
   { Registry path resolution order:
       1. NEW "Smart Citizen" node (post-0.9.2 rebrand) — every app launch
          writes here, and the one-shot migrate_registry_appname() in the


### PR DESCRIPTION
## Summary
- Adds a language selection page (English / Français / Português-BR / Español) as the first screen of the Inno Setup installer, writing the chosen language to the app's settings so first launch comes up already localized.
- Installer-only change (`installer.iss`); no app code touched.

## Testing
- Installer script change — verify by compiling `installer.iss` with Inno Setup and stepping through the wizard (page order, each language choice persisting into the app's `SELECTED_LANGUAGE` setting).

🤖 Generated with [Claude Code](https://claude.com/claude-code)