### PR TITLE
Feature: translate every hardcoded UI tooltip (EN/FR/PT-BR/ES)

### DIFF
--- a/languages/english/ui.json
+++ b/languages/english/ui.json
@@ -824,6 +824,34 @@
       "ht": "Remove selected blueprints from owned",
       "at": ""
     },
+    "bp_scan_title": {
+      "ht": "BP Scan",
+      "at": ""
+    },
+    "bp_scan_starting": {
+      "ht": "Scanning Star Citizen logs for received blueprints…",
+      "at": ""
+    },
+    "bp_scan_progress": {
+      "ht": "Scanning {file}…",
+      "at": ""
+    },
+    "bp_scan_finishing": {
+      "ht": "Finishing up…",
+      "at": ""
+    },
+    "bp_scan_no_path": {
+      "ht": "No Star Citizen install path is configured, so there are no logs to scan. Set your game folder on the Config tab first.",
+      "at": ""
+    },
+    "bp_scan_none": {
+      "ht": "No new blueprints found since the last scan.",
+      "at": ""
+    },
+    "bp_scan_summary": {
+      "ht": "Added {count} blueprint(s) to your owned list.\n\n{visible} are visible in your current blueprint lists now; the rest will show [Owned] automatically whenever their item next appears in a mission's blueprint rewards.",
+      "at": ""
+    },
     "mission_field_ace_tooltip": {
       "ht": "Show an \"Ace Pilot: Yes\" line in the mission details body when the mission spawns an ace pilot. The [ACE] title tag is a separate toggle under General Tags. Takes effect on the next Generate Enhancements.",
       "at": ""

--- a/languages/english/ui.json
+++ b/languages/english/ui.json
@@ -335,6 +335,10 @@
     "column_filter_tooltip": {
       "ht": "Filter the {column} column. Filters across columns combine with AND.",
       "at": ""
+    },
+    "column_filter_placeholder": {
+      "ht": "Filter {column}…",
+      "at": ""
     }
   },
   "config": {

--- a/languages/english/ui.json
+++ b/languages/english/ui.json
@@ -76,14 +76,6 @@
       "ht": "Apply Enhancements",
       "at": ""
     },
-    "apply_btn_enabled_tooltip": {
-      "ht": "Write the merged table contents to the game's global.ini. A timestamped backup of the current global.ini is created first.",
-      "at": ""
-    },
-    "apply_btn_disabled_tooltip": {
-      "ht": "Already applied: nothing has changed since the last Apply to Game.",
-      "at": ""
-    },
     "restore_backup_btn": {
       "ht": "Restore Backup",
       "at": ""
@@ -138,6 +130,50 @@
     },
     "menu_switch_to_simple": {
       "ht": "Switch to Simple Mode",
+      "at": ""
+    },
+    "editor_tooltip": {
+      "ht": "Toggle the side-docked String Editor, a larger canvas for editing the selected row's custom value",
+      "at": ""
+    },
+    "help_tooltip": {
+      "ht": "Toggle the Help side-panel",
+      "at": ""
+    },
+    "tutorial_tooltip": {
+      "ht": "Start the guided tour of Smart Citizen's workflow. Runs automatically on first launch; click here anytime to replay.",
+      "at": ""
+    },
+    "restore_backup_tooltip": {
+      "ht": "Restore a previous global.ini from the backups folder. Up to 5 timestamped backups are kept; the oldest is pruned when a new one is created.",
+      "at": ""
+    },
+    "test_plan_tooltip": {
+      "ht": "Open the tester Test Plan: a checklist of what changed in this release, with progress tracking and a report you can submit.",
+      "at": ""
+    },
+    "switch_to_simple_tooltip": {
+      "ht": "Switch to the simplified one-button view.",
+      "at": ""
+    },
+    "more_tooltip": {
+      "ht": "More actions: restore a backup, clear localization or cache, import or export, open the localization folder",
+      "at": ""
+    },
+    "osiris_github_tooltip": {
+      "ht": "Open the Osiris DevWorks GitHub organization",
+      "at": ""
+    },
+    "feedback_tooltip": {
+      "ht": "Open the Smart Citizen Discord channel for feedback, bug reports, and voting on upcoming features (requires joining the Osiris DevWorks Discord).",
+      "at": ""
+    },
+    "apply_enabled_tooltip": {
+      "ht": "Write the merged table contents to the game's global.ini. A timestamped backup of the current global.ini is created first.",
+      "at": ""
+    },
+    "apply_disabled_tooltip": {
+      "ht": "Already applied: nothing has changed since the last Apply to Game.",
       "at": ""
     }
   },
@@ -197,6 +233,42 @@
     "copy_filtered_btn": {
       "ht": "Copy Filtered",
       "at": ""
+    },
+    "category_tooltip": {
+      "ht": "Filter rows by domain (Ships, Ship Items, Missions, Gear, Commodities, Journal, Other). Categories are derived from the loc-key prefix.",
+      "at": ""
+    },
+    "status_tooltip": {
+      "ht": "Filter by status. Modified = you've set a Custom Value; Enhanced = produced by Smart Citizen's enhancements pipeline (ship stats, mission rewards, etc.); Unmodified = default text only; New = key exists only in enhancements/user.ini, not in the base file.",
+      "at": ""
+    },
+    "hide_unmodified_tooltip": {
+      "ht": "Show only rows where you've set a Custom Value. Same as the Status filter's Modified option but togglable on its own.",
+      "at": ""
+    },
+    "favorites_only_tooltip": {
+      "ht": "Show only rows you've starred as favorites. Favorites get a configurable prefix prepended to their name so they sort to the top of the in-game list.",
+      "at": ""
+    },
+    "bp_titles_only_tooltip": {
+      "ht": "Show only mission titles carrying the [BP] / [BP?] blueprint tag.",
+      "at": ""
+    },
+    "bp_descs_only_tooltip": {
+      "ht": "Show only mission descriptions containing a POTENTIAL BLUEPRINTS section.",
+      "at": ""
+    },
+    "group_sort_tooltip": {
+      "ht": "Sort titles and descriptions together for the same entity",
+      "at": ""
+    },
+    "clear_filters_tooltip": {
+      "ht": "Reset every filter (category, status, search, per-column boxes, checkboxes) so the full table is shown.",
+      "at": ""
+    },
+    "copy_filtered_tooltip": {
+      "ht": "Copy all visible filtered rows to clipboard (tab-separated)",
+      "at": ""
     }
   },
   "strings_tab": {
@@ -250,6 +322,18 @@
     },
     "context_highlight": {
       "ht": "Highlight",
+      "at": ""
+    },
+    "editor_underline_tooltip": {
+      "ht": "Underline the selected text (wraps it in <EM3>...</EM3>)",
+      "at": ""
+    },
+    "editor_highlight_tooltip": {
+      "ht": "Highlight the selected text with color emphasis (wraps it in <EM4>...</EM4>)",
+      "at": ""
+    },
+    "column_filter_tooltip": {
+      "ht": "Filter the {column} column. Filters across columns combine with AND.",
       "at": ""
     }
   },
@@ -489,6 +573,90 @@
     "no_sources_warning": {
       "ht": "No sources available to merge.",
       "at": ""
+    },
+    "include_new_tooltip": {
+      "ht": "When checked, items discovered from DataForge XML (status 'New') that have non-empty text will be included in the applied global.ini.",
+      "at": ""
+    },
+    "import_ini_tooltip": {
+      "ht": "Fold an external .ini into your overrides. A conflict-resolution dialog lets you decide per key: keep current, use imported, append, prepend, or provide a custom value.",
+      "at": ""
+    },
+    "reset_user_ini_tooltip": {
+      "ht": "Delete every custom string override for the active channel. A timestamped backup is saved next to the original so you can restore it.",
+      "at": ""
+    },
+    "restore_user_ini_tooltip": {
+      "ht": "Restore your custom string overrides from an automatic snapshot. Smart Citizen keeps the last few states of user.ini, so you can roll back a bad edit or recover after the file was emptied.",
+      "at": ""
+    },
+    "preview_apply_tooltip": {
+      "ht": "Dry-run summary of what Apply Enhancements would write — per-source key counts (with Enhancements broken down by category) and a Modified / Enhanced / Unmodified / New status tally. Nothing is written to the game until you click Apply Enhancements.",
+      "at": ""
+    },
+    "check_updates_tooltip": {
+      "ht": "Check GitHub for a newer Smart Citizen release.",
+      "at": ""
+    },
+    "theme_tooltip": {
+      "ht": "Switch the app theme. Takes effect immediately across the main window, toolbar, tabs, and Help panel.",
+      "at": ""
+    },
+    "disable_tutorial_tooltip": {
+      "ht": "When checked, the guided tour will not auto-launch on a new version. The Tutorial button in the toolbar still works.",
+      "at": ""
+    },
+    "game_path_tooltip": {
+      "ht": "Star Citizen install root — the directory that contains LIVE/, PTU/, EPTU/, HOTFIX/, and/or TECH-PREVIEW/. Auto-detected at install time; edit if your game lives elsewhere. The 'Channel' dropdown below picks which one the app reads and writes.",
+      "at": ""
+    },
+    "browse_game_tooltip": {
+      "ht": "Pick the Star Citizen install root in a folder browser.",
+      "at": ""
+    },
+    "channel_tooltip": {
+      "ht": "Star Citizen channel to read Data.p4k from and write global.ini to. Channels with no Data.p4k under the install root are disabled. Switching channels immediately reloads strings against the new channel's data.",
+      "at": ""
+    },
+    "channel_not_installed_tooltip": {
+      "ht": "{channel} isn't installed — no Data.p4k at {path}",
+      "at": ""
+    },
+    "language_tooltip": {
+      "ht": "Language to apply to the game. Keys missing from the translation fall back to English automatically.",
+      "at": ""
+    },
+    "map_language_tooltip": {
+      "ht": "Set a URL to each language's global.ini. When you switch to that language, Smart Citizen downloads it and uses it as the base strings instead of the English Data.p4k extraction.",
+      "at": ""
+    },
+    "data_dir_tooltip": {
+      "ht": "Smart Citizen's app data root. Each channel gets its own subfolder inside this directory. Leave blank or click Reset to use Documents\\Smart Citizen.",
+      "at": ""
+    },
+    "browse_data_tooltip": {
+      "ht": "Pick the Smart Citizen data folder in a folder browser.",
+      "at": ""
+    },
+    "reset_data_tooltip": {
+      "ht": "Clear the custom data folder and use Documents\\Smart Citizen.",
+      "at": ""
+    },
+    "cache_dir_tooltip": {
+      "ht": "Base folder for the extracted DataForge XML tree (~1.4 GB). Each channel nests under this as {base}\\{channel}\\cache\\dataforge\\. Defaults to %LOCALAPPDATA%\\Smart Citizen so it stays out of OneDrive. Changing the path triggers a re-extraction.",
+      "at": ""
+    },
+    "browse_cache_tooltip": {
+      "ht": "Pick the DataForge cache base folder in a folder browser.",
+      "at": ""
+    },
+    "reset_cache_tooltip": {
+      "ht": "Clear the custom cache folder and use the platform default.",
+      "at": ""
+    },
+    "extract_tooltip": {
+      "ht": "Unpack stock localization (base.ini) plus the DataForge entity XMLs from your installed Data.p4k. Run after every Star Citizen patch — the strings reload into the table automatically when extraction finishes.",
+      "at": ""
     }
   },
   "enhancements": {
@@ -652,40 +820,76 @@
       "ht": "Remove selected blueprints from owned",
       "at": ""
     },
-    "bp_scan_button": {
-      "ht": "BP Scan",
+    "mission_field_ace_tooltip": {
+      "ht": "Show an \"Ace Pilot: Yes\" line in the mission details body when the mission spawns an ace pilot. The [ACE] title tag is a separate toggle under General Tags. Takes effect on the next Generate Enhancements.",
       "at": ""
     },
-    "bp_scan_tooltip": {
-      "ht": "Scan your Star Citizen log files for blueprints you've received in-game and add them to your owned list. Only blueprints received since your last scan are imported.",
+    "mission_field_default_tooltip": {
+      "ht": "Show the {label} line in generated mission bodies. Takes effect on the next Generate Enhancements.",
       "at": ""
     },
-    "bp_scan_title": {
-      "ht": "BP Scan",
+    "stats_prepend_tooltip": {
+      "ht": "Put the generated stats block above the manufacturer/PR description instead of below it (ships, components, weapons). Takes effect on the next Generate Enhancements.",
       "at": ""
     },
-    "bp_scan_starting": {
-      "ht": "Scanning Star Citizen logs for received blueprints…",
+    "standardize_ship_names_tooltip": {
+      "ht": "Rename exec-hangar (PYX) and Wikelo (WIK) ship variants to include a suffix that distinguishes them from the standard pledge-store version (e.g. \"Anvil F8C Lightning PYX\"). Takes effect on the next Generate Enhancements.",
       "at": ""
     },
-    "bp_scan_progress": {
-      "ht": "Scanning {file}…",
+    "apply_categories_tooltip": {
+      "ht": "Save category selection. Unchecked categories will be disabled.",
       "at": ""
     },
-    "bp_scan_finishing": {
-      "ht": "Finishing up…",
+    "generate_enabled_tooltip": {
+      "ht": "Generate enhanced localization files from your game's Data.p4k.\nDataForge data will be extracted automatically if not already cached\n(first run takes a few minutes; subsequent runs are fast).",
       "at": ""
     },
-    "bp_scan_no_path": {
-      "ht": "No Star Citizen install path is configured, so there are no logs to scan. Set your game folder on the Config tab first.",
+    "generate_disabled_tooltip": {
+      "ht": "Already up to date — nothing that affects the generated output (categories, mission fields, stats/name options, Tag Builder) has changed since the last run.",
       "at": ""
     },
-    "bp_scan_none": {
-      "ht": "No new blueprints found since the last scan.",
+    "favorite_prefix_tooltip": {
+      "ht": "Character prepended to favorited ship names so they sort to the top of the in-game ship list. Click Apply Prefix after changing to update all existing favorites.",
       "at": ""
     },
-    "bp_scan_summary": {
-      "ht": "Added {count} blueprint(s) to your owned list.\n\n{visible} are visible in your current blueprint lists now; the rest will show [Owned] automatically whenever their item next appears in a mission's blueprint rewards.",
+    "rep_xp_label_tooltip": {
+      "ht": "Label for missions without a rank name (e.g. 'Rep: +100 XP')",
+      "at": ""
+    },
+    "header_em_tooltip": {
+      "ht": "Style for section headers: Underline (EM3) or Blue text (EM4)",
+      "at": ""
+    },
+    "prefix_enabled_tooltip": {
+      "ht": "Save the selected prefix and update all existing favorites to use it",
+      "at": ""
+    },
+    "prefix_disabled_tooltip": {
+      "ht": "Already applied — the selected prefix matches your current favorites.",
+      "at": ""
+    },
+    "annotate_mission_descs_tooltip": {
+      "ht": "When checked, the configured [CLASS-Sx-grade] tag is added to component names inside the POTENTIAL BLUEPRINTS list of mission descriptions. Uncheck for a cleaner mission body while keeping the tag on the actual component names elsewhere.",
+      "at": ""
+    },
+    "reset_tag_tooltip": {
+      "ht": "Restore the default pattern, mapping, and ordering for every category (Components / Missiles / Ship Weapons). Does not save or regenerate until you click Save Tag Changes or Generate Enhancements.",
+      "at": ""
+    },
+    "tag_enabled_tooltip": {
+      "ht": "Save the Components / Missiles / Ship Weapons tag configs and re-run the enhancement generator. New tags appear in-game after the next Apply Enhancements.",
+      "at": ""
+    },
+    "tag_disabled_tooltip": {
+      "ht": "Already saved — no Tag Builder changes since the last save.",
+      "at": ""
+    },
+    "generating_enhancements_tooltip": {
+      "ht": "Generating enhancements…",
+      "at": ""
+    },
+    "extracting_dataforge_tooltip": {
+      "ht": "Extracting DataForge from Data.p4k…",
       "at": ""
     }
   },
@@ -742,6 +946,22 @@
     },
     "lines_label": {
       "ht": "{count} lines",
+      "at": ""
+    },
+    "min_level_tooltip": {
+      "ht": "Minimum severity to display. Entries below the selected level are hidden (DEBUG < INFO < WARNING < ERROR).",
+      "at": ""
+    },
+    "auto_scroll_tooltip": {
+      "ht": "Automatically scroll to the newest log entry as it arrives. Turn off to pin the view while inspecting older lines.",
+      "at": ""
+    },
+    "clear_tooltip": {
+      "ht": "Clear the on-screen log buffer. The session log file on disk is unaffected.",
+      "at": ""
+    },
+    "export_tooltip": {
+      "ht": "Save the current log buffer to a .log file — useful when filing a bug report.",
       "at": ""
     }
   },
@@ -813,6 +1033,14 @@
     "excluded_summary": {
       "ht": "{count} keys excluded (not in base.ini).",
       "at": ""
+    },
+    "keep_all_tooltip": {
+      "ht": "Resolve every conflict by keeping your existing value and discarding the imported one.",
+      "at": ""
+    },
+    "import_all_tooltip": {
+      "ht": "Resolve every conflict by accepting the imported value and overwriting your existing one.",
+      "at": ""
     }
   },
   "coach": {
@@ -860,6 +1088,10 @@
     },
     "col_long": {
       "ht": "Long",
+      "at": ""
+    },
+    "reset_tooltip": {
+      "ht": "Restore every cell in this mapping table to the built-in Smart Citizen defaults.",
       "at": ""
     }
   },
@@ -1155,6 +1387,18 @@
     "unapplied_changes_exit": {
       "ht": "Exit Without Applying",
       "at": ""
+    },
+    "browse_ini_tooltip": {
+      "ht": "Pick a local .ini file to import.",
+      "at": ""
+    },
+    "generate_now_tooltip": {
+      "ht": "Run the DataForge extraction + enhancements pipeline now. Takes a few minutes the first time.",
+      "at": ""
+    },
+    "skip_generate_tooltip": {
+      "ht": "Continue without generating enhancements. You can run it later from the Enhancements tab.",
+      "at": ""
     }
   },
   "progress": {
@@ -1254,6 +1498,10 @@
     },
     "update_indicator_failed": {
       "ht": "v{current} · check failed",
+      "at": ""
+    },
+    "open_release_page_tooltip": {
+      "ht": "Open release page for v{version}",
       "at": ""
     }
   }

--- a/languages/french/ui.json
+++ b/languages/french/ui.json
@@ -315,6 +315,10 @@
     "column_filter_tooltip": {
       "ht": "",
       "at": "Filtrer la colonne {column}. Les filtres de plusieurs colonnes se combinent avec un ET."
+    },
+    "column_filter_placeholder": {
+      "ht": "",
+      "at": "Filtrer {column}…"
     }
   },
   "config": {

--- a/languages/french/ui.json
+++ b/languages/french/ui.json
@@ -123,6 +123,50 @@
     "menu_switch_to_simple": {
       "ht": "",
       "at": "Passer en mode simple"
+    },
+    "editor_tooltip": {
+      "ht": "",
+      "at": "Afficher/masquer l'éditeur de chaînes ancré sur le côté, une plus grande zone pour modifier la valeur personnalisée de la ligne sélectionnée"
+    },
+    "help_tooltip": {
+      "ht": "",
+      "at": "Afficher/masquer le panneau d'aide"
+    },
+    "tutorial_tooltip": {
+      "ht": "",
+      "at": "Démarrer la visite guidée du fonctionnement de Smart Citizen. Elle se lance automatiquement au premier démarrage ; cliquez ici à tout moment pour la revoir."
+    },
+    "restore_backup_tooltip": {
+      "ht": "",
+      "at": "Restaurer un global.ini précédent depuis le dossier des sauvegardes. Jusqu'à 5 sauvegardes horodatées sont conservées ; la plus ancienne est supprimée à la création d'une nouvelle."
+    },
+    "test_plan_tooltip": {
+      "ht": "",
+      "at": "Ouvrir le plan de test du testeur : une liste de contrôle des changements de cette version, avec suivi de la progression et un rapport à soumettre."
+    },
+    "switch_to_simple_tooltip": {
+      "ht": "",
+      "at": "Passer à la vue simplifiée à un seul bouton."
+    },
+    "more_tooltip": {
+      "ht": "",
+      "at": "Autres actions : restaurer une sauvegarde, effacer la localisation ou le cache, importer ou exporter, ouvrir le dossier de localisation"
+    },
+    "osiris_github_tooltip": {
+      "ht": "",
+      "at": "Ouvrir l'organisation GitHub d'Osiris DevWorks"
+    },
+    "feedback_tooltip": {
+      "ht": "",
+      "at": "Ouvrir le salon Discord de Smart Citizen pour les retours, rapports de bugs et votes sur les futures fonctionnalités (nécessite de rejoindre le Discord d'Osiris DevWorks)."
+    },
+    "apply_enabled_tooltip": {
+      "ht": "",
+      "at": "Écrire le contenu fusionné de la table dans le global.ini du jeu. Une sauvegarde horodatée du global.ini actuel est créée au préalable."
+    },
+    "apply_disabled_tooltip": {
+      "ht": "",
+      "at": "Déjà appliqué — rien n'a changé depuis la dernière application au jeu."
     }
   },
   "filters": {
@@ -173,6 +217,42 @@
     "copy_filtered_btn": {
       "ht": "Copier les résultats filtrés",
       "at": "Copier les résultats filtrés"
+    },
+    "category_tooltip": {
+      "ht": "",
+      "at": "Filtrer les lignes par domaine (Vaisseaux, Objets de vaisseau, Missions, Équipement, Marchandises, Journal, Autre). Les catégories sont dérivées du préfixe de la clé de localisation."
+    },
+    "status_tooltip": {
+      "ht": "",
+      "at": "Filtrer par statut. Modifié = vous avez défini une valeur personnalisée ; Amélioré = généré par le pipeline d'enrichissements de Smart Citizen (statistiques de vaisseau, récompenses de mission, etc.) ; Inchangé = texte par défaut uniquement ; Nouveau = la clé n'existe que dans enhancements/user.ini, pas dans le fichier de base."
+    },
+    "hide_unmodified_tooltip": {
+      "ht": "",
+      "at": "Afficher uniquement les lignes où vous avez défini une valeur personnalisée. Identique à l'option « Modifié » du filtre de statut, mais activable indépendamment."
+    },
+    "favorites_only_tooltip": {
+      "ht": "",
+      "at": "Afficher uniquement les lignes marquées comme favorites. Les favoris reçoivent un préfixe configurable ajouté devant leur nom afin qu'ils apparaissent en tête de la liste en jeu."
+    },
+    "bp_titles_only_tooltip": {
+      "ht": "",
+      "at": "Afficher uniquement les titres de mission portant l'étiquette de plan [BP] / [BP?]."
+    },
+    "bp_descs_only_tooltip": {
+      "ht": "",
+      "at": "Afficher uniquement les descriptions de mission contenant une section POTENTIAL BLUEPRINTS."
+    },
+    "group_sort_tooltip": {
+      "ht": "",
+      "at": "Trier les titres et descriptions ensemble pour une même entité"
+    },
+    "clear_filters_tooltip": {
+      "ht": "",
+      "at": "Réinitialiser tous les filtres (catégorie, statut, recherche, champs par colonne, cases à cocher) afin d'afficher la table complète."
+    },
+    "copy_filtered_tooltip": {
+      "ht": "",
+      "at": "Copier toutes les lignes filtrées visibles dans le presse-papiers (séparées par des tabulations)"
     }
   },
   "strings_tab": {
@@ -223,6 +303,18 @@
     "context_highlight": {
       "ht": "",
       "at": "Surligner"
+    },
+    "editor_underline_tooltip": {
+      "ht": "",
+      "at": "Souligner le texte sélectionné (l'entoure de <EM3>...</EM3>)"
+    },
+    "editor_highlight_tooltip": {
+      "ht": "",
+      "at": "Mettre en évidence le texte sélectionné avec une couleur d'emphase (l'entoure de <EM4>...</EM4>)"
+    },
+    "column_filter_tooltip": {
+      "ht": "",
+      "at": "Filtrer la colonne {column}. Les filtres de plusieurs colonnes se combinent avec un ET."
     }
   },
   "config": {
@@ -461,6 +553,90 @@
     "no_sources_warning": {
       "ht": "Aucune source disponible pour la fusion.",
       "at": "Aucune source disponible pour la fusion."
+    },
+    "include_new_tooltip": {
+      "ht": "",
+      "at": "Si coché, les éléments découverts dans le XML DataForge (statut « Nouveau ») dont le texte n'est pas vide seront inclus dans le global.ini appliqué."
+    },
+    "import_ini_tooltip": {
+      "ht": "",
+      "at": "Intégrer un fichier .ini externe dans vos remplacements. Une boîte de dialogue de résolution des conflits vous permet de décider clé par clé : conserver l'actuelle, utiliser l'importée, ajouter à la suite, ajouter au début, ou fournir une valeur personnalisée."
+    },
+    "reset_user_ini_tooltip": {
+      "ht": "",
+      "at": "Supprimer tous les remplacements de chaînes personnalisés du canal actif. Une sauvegarde horodatée est enregistrée à côté de l'original afin de pouvoir la restaurer."
+    },
+    "restore_user_ini_tooltip": {
+      "ht": "",
+      "at": "Restaurer vos remplacements de chaînes personnalisés à partir d'un instantané automatique. Smart Citizen conserve les derniers états de user.ini, ce qui permet d'annuler une mauvaise modification ou de récupérer le fichier après qu'il a été vidé."
+    },
+    "preview_apply_tooltip": {
+      "ht": "",
+      "at": "Résumé à blanc de ce que « Appliquer les enrichissements » écrirait — nombre de clés par source (avec le détail des enrichissements par catégorie) et un décompte des statuts Modifié / Amélioré / Inchangé / Nouveau. Rien n'est écrit dans le jeu tant que vous n'avez pas cliqué sur « Appliquer les enrichissements »."
+    },
+    "check_updates_tooltip": {
+      "ht": "",
+      "at": "Vérifier sur GitHub si une nouvelle version de Smart Citizen est disponible."
+    },
+    "theme_tooltip": {
+      "ht": "",
+      "at": "Changer le thème de l'application. Le changement s'applique immédiatement à la fenêtre principale, la barre d'outils, les onglets et le panneau d'aide."
+    },
+    "disable_tutorial_tooltip": {
+      "ht": "",
+      "at": "Si coché, la visite guidée ne se lancera pas automatiquement lors d'une nouvelle version. Le bouton Tutoriel de la barre d'outils reste fonctionnel."
+    },
+    "game_path_tooltip": {
+      "ht": "",
+      "at": "Racine d'installation de Star Citizen — le dossier contenant LIVE/, PTU/, EPTU/, HOTFIX/ et/ou TECH-PREVIEW/. Détectée automatiquement à l'installation ; modifiez-la si votre jeu se trouve ailleurs. Le menu déroulant « Canal » ci-dessous détermine celui que l'application lit et écrit."
+    },
+    "browse_game_tooltip": {
+      "ht": "",
+      "at": "Choisir la racine d'installation de Star Citizen dans un navigateur de dossiers."
+    },
+    "channel_tooltip": {
+      "ht": "",
+      "at": "Canal Star Citizen depuis lequel lire Data.p4k et dans lequel écrire global.ini. Les canaux sans Data.p4k sous la racine d'installation sont désactivés. Changer de canal recharge immédiatement les chaînes avec les données du nouveau canal."
+    },
+    "channel_not_installed_tooltip": {
+      "ht": "",
+      "at": "{channel} n'est pas installé — aucun Data.p4k à {path}"
+    },
+    "language_tooltip": {
+      "ht": "",
+      "at": "Langue à appliquer au jeu. Les clés absentes de la traduction reviennent automatiquement à l'anglais."
+    },
+    "map_language_tooltip": {
+      "ht": "",
+      "at": "Définir une URL pour le global.ini de chaque langue. Lorsque vous basculez vers cette langue, Smart Citizen le télécharge et l'utilise comme chaînes de base au lieu de l'extraction anglaise de Data.p4k."
+    },
+    "data_dir_tooltip": {
+      "ht": "",
+      "at": "Racine des données de l'application Smart Citizen. Chaque canal reçoit son propre sous-dossier dans ce répertoire. Laissez vide ou cliquez sur Réinitialiser pour utiliser Documents\\Smart Citizen."
+    },
+    "browse_data_tooltip": {
+      "ht": "",
+      "at": "Choisir le dossier de données de Smart Citizen dans un navigateur de dossiers."
+    },
+    "reset_data_tooltip": {
+      "ht": "",
+      "at": "Effacer le dossier de données personnalisé et utiliser Documents\\Smart Citizen."
+    },
+    "cache_dir_tooltip": {
+      "ht": "",
+      "at": "Dossier de base pour l'arborescence XML DataForge extraite (~1,4 Go). Chaque canal se place sous celui-ci en tant que {base}\\{channel}\\cache\\dataforge\\. Par défaut %LOCALAPPDATA%\\Smart Citizen afin de rester hors de OneDrive. Modifier ce chemin déclenche une nouvelle extraction."
+    },
+    "browse_cache_tooltip": {
+      "ht": "",
+      "at": "Choisir le dossier de base du cache DataForge dans un navigateur de dossiers."
+    },
+    "reset_cache_tooltip": {
+      "ht": "",
+      "at": "Effacer le dossier de cache personnalisé et utiliser celui par défaut de la plateforme."
+    },
+    "extract_tooltip": {
+      "ht": "",
+      "at": "Extraire la localisation d'origine (base.ini) ainsi que les XML d'entités DataForge depuis votre Data.p4k installé. À exécuter après chaque mise à jour de Star Citizen — les chaînes se rechargent automatiquement dans la table une fois l'extraction terminée."
     }
   },
   "enhancements": {
@@ -551,6 +727,78 @@
     "edit_mapping_btn": {
       "ht": "Modifier le mapping...",
       "at": "Modifier le mapping..."
+    },
+    "mission_field_ace_tooltip": {
+      "ht": "",
+      "at": "Afficher une ligne « Ace Pilot: Yes » dans le corps des détails de mission lorsque la mission fait apparaître un pilote as. L'étiquette de titre [ACE] est une option distincte sous Étiquettes générales. Prend effet à la prochaine génération des enrichissements."
+    },
+    "mission_field_default_tooltip": {
+      "ht": "",
+      "at": "Afficher la ligne {label} dans les corps de mission générés. Prend effet à la prochaine génération des enrichissements."
+    },
+    "stats_prepend_tooltip": {
+      "ht": "",
+      "at": "Placer le bloc de statistiques généré au-dessus de la description du fabricant/RP plutôt qu'en dessous (vaisseaux, composants, armes). Prend effet à la prochaine génération des enrichissements."
+    },
+    "standardize_ship_names_tooltip": {
+      "ht": "",
+      "at": "Renommer les variantes de vaisseau exec-hangar (PYX) et Wikelo (WIK) pour inclure un suffixe les distinguant de la version standard du magasin de pledge (ex. « Anvil F8C Lightning PYX »). Prend effet à la prochaine génération des enrichissements."
+    },
+    "apply_categories_tooltip": {
+      "ht": "",
+      "at": "Enregistrer la sélection des catégories. Les catégories décochées seront désactivées."
+    },
+    "generate_enabled_tooltip": {
+      "ht": "",
+      "at": "Générer les fichiers de localisation enrichis à partir du Data.p4k de votre jeu.\nLes données DataForge seront extraites automatiquement si elles ne sont pas déjà en cache\n(la première exécution prend quelques minutes ; les suivantes sont rapides)."
+    },
+    "generate_disabled_tooltip": {
+      "ht": "",
+      "at": "Déjà à jour — rien de ce qui affecte le résultat généré (catégories, champs de mission, options de statistiques/noms, Générateur d'étiquettes) n'a changé depuis la dernière exécution."
+    },
+    "favorite_prefix_tooltip": {
+      "ht": "",
+      "at": "Caractère ajouté devant les noms des vaisseaux favoris afin qu'ils apparaissent en tête de la liste des vaisseaux en jeu. Cliquez sur « Appliquer le préfixe » après modification pour mettre à jour tous les favoris existants."
+    },
+    "rep_xp_label_tooltip": {
+      "ht": "",
+      "at": "Libellé pour les missions sans nom de rang (ex. « Rep : +100 XP »)"
+    },
+    "header_em_tooltip": {
+      "ht": "",
+      "at": "Style des en-têtes de section : Souligné (EM3) ou Texte bleu (EM4)"
+    },
+    "prefix_enabled_tooltip": {
+      "ht": "",
+      "at": "Enregistrer le préfixe sélectionné et mettre à jour tous les favoris existants pour l'utiliser"
+    },
+    "prefix_disabled_tooltip": {
+      "ht": "",
+      "at": "Déjà appliqué — le préfixe sélectionné correspond à vos favoris actuels."
+    },
+    "annotate_mission_descs_tooltip": {
+      "ht": "",
+      "at": "Si coché, l'étiquette [CLASS-Sx-grade] configurée est ajoutée aux noms de composants dans la liste POTENTIAL BLUEPRINTS des descriptions de mission. Décochez pour un corps de mission plus épuré, tout en conservant l'étiquette sur les noms de composants ailleurs."
+    },
+    "reset_tag_tooltip": {
+      "ht": "",
+      "at": "Restaurer le modèle, le mappage et l'ordre par défaut pour chaque catégorie (Composants / Missiles / Armes de vaisseau). N'enregistre ni ne régénère tant que vous n'avez pas cliqué sur « Enregistrer les modifications d'étiquettes » ou « Générer les enrichissements »."
+    },
+    "tag_enabled_tooltip": {
+      "ht": "",
+      "at": "Enregistrer les configurations d'étiquettes Composants / Missiles / Armes de vaisseau et relancer le générateur d'enrichissements. Les nouvelles étiquettes apparaissent en jeu après la prochaine application des enrichissements."
+    },
+    "tag_disabled_tooltip": {
+      "ht": "",
+      "at": "Déjà enregistré — aucune modification du Générateur d'étiquettes depuis le dernier enregistrement."
+    },
+    "generating_enhancements_tooltip": {
+      "ht": "",
+      "at": "Génération des enrichissements en cours…"
+    },
+    "extracting_dataforge_tooltip": {
+      "ht": "",
+      "at": "Extraction de DataForge depuis Data.p4k…"
     }
   },
   "log": {
@@ -581,6 +829,22 @@
     "lines_label": {
       "ht": "{count} lignes",
       "at": "{count} lignes"
+    },
+    "min_level_tooltip": {
+      "ht": "",
+      "at": "Niveau de gravité minimum à afficher. Les entrées inférieures au niveau sélectionné sont masquées (DEBUG < INFO < WARNING < ERROR)."
+    },
+    "auto_scroll_tooltip": {
+      "ht": "",
+      "at": "Défiler automatiquement vers la dernière entrée du journal à son arrivée. Désactivez pour figer la vue lors de l'inspection des lignes plus anciennes."
+    },
+    "clear_tooltip": {
+      "ht": "",
+      "at": "Effacer le tampon du journal affiché à l'écran. Le fichier journal de la session sur le disque n'est pas affecté."
+    },
+    "export_tooltip": {
+      "ht": "",
+      "at": "Enregistrer le tampon de journal actuel dans un fichier .log — utile pour signaler un bug."
     }
   },
   "import_dialog": {
@@ -651,6 +915,14 @@
     "excluded_summary": {
       "ht": "{count} clés exclues (absentes du fichier base.ini).",
       "at": "{count} clés exclues (absentes du fichier base.ini)."
+    },
+    "keep_all_tooltip": {
+      "ht": "",
+      "at": "Résoudre tous les conflits en conservant votre valeur existante et en ignorant celle importée."
+    },
+    "import_all_tooltip": {
+      "ht": "",
+      "at": "Résoudre tous les conflits en acceptant la valeur importée et en écrasant celle existante."
     }
   },
   "coach": {
@@ -699,6 +971,10 @@
     "col_long": {
       "ht": "Longue",
       "at": "Longue"
+    },
+    "reset_tooltip": {
+      "ht": "",
+      "at": "Restaurer toutes les cellules de cette table de correspondance aux valeurs par défaut intégrées de Smart Citizen."
     }
   },
   "dialogs": {
@@ -977,6 +1253,18 @@
     "copy_error_body": {
       "ht": "",
       "at": "Échec de la copie vers le presse-papiers : {error}"
+    },
+    "browse_ini_tooltip": {
+      "ht": "",
+      "at": "Choisir un fichier .ini local à importer."
+    },
+    "generate_now_tooltip": {
+      "ht": "",
+      "at": "Lancer maintenant l'extraction DataForge et le pipeline d'enrichissements. Prend quelques minutes la première fois."
+    },
+    "skip_generate_tooltip": {
+      "ht": "",
+      "at": "Continuer sans générer les enrichissements. Vous pourrez le faire plus tard depuis l'onglet Enrichissements."
     }
   },
   "progress": {
@@ -1073,6 +1361,10 @@
     "update_indicator_failed": {
       "ht": "v{current} · vérification échouée",
       "at": "v{current} · vérification échouée"
+    },
+    "open_release_page_tooltip": {
+      "ht": "",
+      "at": "Ouvrir la page de version pour la v{version}"
     }
   },
   "tutorial": {

--- a/languages/portuguese_br/ui.json
+++ b/languages/portuguese_br/ui.json
@@ -123,6 +123,50 @@
     "menu_switch_to_simple": {
       "ht": "",
       "at": "Mudar para o Modo Simples"
+    },
+    "editor_tooltip": {
+      "ht": "",
+      "at": "Alternar o Editor de Strings lateral, uma área maior para editar o valor personalizado da linha selecionada"
+    },
+    "help_tooltip": {
+      "ht": "",
+      "at": "Alternar o painel lateral de Ajuda"
+    },
+    "tutorial_tooltip": {
+      "ht": "",
+      "at": "Iniciar o tour guiado do fluxo de trabalho do Smart Citizen. Executa automaticamente na primeira inicialização; clique aqui a qualquer momento para repetir."
+    },
+    "restore_backup_tooltip": {
+      "ht": "",
+      "at": "Restaurar um global.ini anterior a partir da pasta de backups. Até 5 backups com carimbo de data/hora são mantidos; o mais antigo é removido quando um novo é criado."
+    },
+    "test_plan_tooltip": {
+      "ht": "",
+      "at": "Abrir o Plano de Teste do testador: uma lista de verificação do que mudou nesta versão, com acompanhamento de progresso e um relatório que você pode enviar."
+    },
+    "switch_to_simple_tooltip": {
+      "ht": "",
+      "at": "Mudar para a visualização simplificada de um botão."
+    },
+    "more_tooltip": {
+      "ht": "",
+      "at": "Mais ações: restaurar um backup, limpar localização ou cache, importar ou exportar, abrir a pasta de localização"
+    },
+    "osiris_github_tooltip": {
+      "ht": "",
+      "at": "Abrir a organização do Osiris DevWorks no GitHub"
+    },
+    "feedback_tooltip": {
+      "ht": "",
+      "at": "Abrir o canal do Discord do Smart Citizen para feedback, relatos de bugs e votação em recursos futuros (requer entrar no Discord da Osiris DevWorks)."
+    },
+    "apply_enabled_tooltip": {
+      "ht": "",
+      "at": "Gravar o conteúdo mesclado da tabela no global.ini do jogo. Um backup com carimbo de data/hora do global.ini atual é criado primeiro."
+    },
+    "apply_disabled_tooltip": {
+      "ht": "",
+      "at": "Já aplicado — nada mudou desde a última aplicação ao jogo."
     }
   },
   "filters": {
@@ -173,6 +217,42 @@
     "copy_filtered_btn": {
       "ht": "Copiar Filtrados",
       "at": "Copiar Filtrados"
+    },
+    "category_tooltip": {
+      "ht": "",
+      "at": "Filtrar linhas por domínio (Naves, Itens de Nave, Missões, Equipamentos, Mercadorias, Diário, Outros). As categorias são derivadas do prefixo da chave de localização."
+    },
+    "status_tooltip": {
+      "ht": "",
+      "at": "Filtrar por status. Modificado = você definiu um Valor Personalizado; Aprimorado = produzido pelo pipeline de aprimoramentos do Smart Citizen (estatísticas de naves, recompensas de missões, etc.); Inalterado = apenas texto padrão; Novo = a chave existe somente em enhancements/user.ini, não no arquivo base."
+    },
+    "hide_unmodified_tooltip": {
+      "ht": "",
+      "at": "Mostrar apenas linhas onde você definiu um Valor Personalizado. O mesmo que a opção Modificado do filtro de Status, mas ativável de forma independente."
+    },
+    "favorites_only_tooltip": {
+      "ht": "",
+      "at": "Mostrar apenas as linhas marcadas como favoritas. Os favoritos recebem um prefixo configurável adicionado ao nome para que apareçam no topo da lista dentro do jogo."
+    },
+    "bp_titles_only_tooltip": {
+      "ht": "",
+      "at": "Mostrar apenas títulos de missão com a tag de blueprint [BP] / [BP?]."
+    },
+    "bp_descs_only_tooltip": {
+      "ht": "",
+      "at": "Mostrar apenas descrições de missão que contenham uma seção POTENTIAL BLUEPRINTS."
+    },
+    "group_sort_tooltip": {
+      "ht": "",
+      "at": "Ordenar títulos e descrições juntos para a mesma entidade"
+    },
+    "clear_filters_tooltip": {
+      "ht": "",
+      "at": "Redefinir todos os filtros (categoria, status, busca, campos por coluna, caixas de seleção) para exibir a tabela completa."
+    },
+    "copy_filtered_tooltip": {
+      "ht": "",
+      "at": "Copiar todas as linhas filtradas visíveis para a área de transferência (separadas por tabulação)"
     }
   },
   "strings_tab": {
@@ -223,6 +303,18 @@
     "context_highlight": {
       "ht": "",
       "at": "Destacar"
+    },
+    "editor_underline_tooltip": {
+      "ht": "",
+      "at": "Sublinhar o texto selecionado (envolve-o em <EM3>...</EM3>)"
+    },
+    "editor_highlight_tooltip": {
+      "ht": "",
+      "at": "Destacar o texto selecionado com ênfase de cor (envolve-o em <EM4>...</EM4>)"
+    },
+    "column_filter_tooltip": {
+      "ht": "",
+      "at": "Filtrar a coluna {column}. Os filtros entre colunas se combinam com E."
     }
   },
   "config": {
@@ -461,6 +553,90 @@
     "no_sources_warning": {
       "ht": "Não há fontes disponíveis para mesclar.",
       "at": "Não há fontes disponíveis para mesclar."
+    },
+    "include_new_tooltip": {
+      "ht": "",
+      "at": "Quando marcado, itens descobertos no XML do DataForge (status 'Novo') que tenham texto não vazio serão incluídos no global.ini aplicado."
+    },
+    "import_ini_tooltip": {
+      "ht": "",
+      "at": "Incorporar um .ini externo às suas substituições. Uma caixa de diálogo de resolução de conflitos permite decidir por chave: manter a atual, usar a importada, anexar, prefixar ou fornecer um valor personalizado."
+    },
+    "reset_user_ini_tooltip": {
+      "ht": "",
+      "at": "Excluir todas as substituições de string personalizadas do canal ativo. Um backup com carimbo de data/hora é salvo ao lado do original para que você possa restaurá-lo."
+    },
+    "restore_user_ini_tooltip": {
+      "ht": "",
+      "at": "Restaurar suas substituições de string personalizadas a partir de um snapshot automático. O Smart Citizen mantém os últimos estados do user.ini, permitindo reverter uma edição ruim ou recuperar o arquivo após ele ter sido esvaziado."
+    },
+    "preview_apply_tooltip": {
+      "ht": "",
+      "at": "Resumo de simulação do que Aplicar Aprimoramentos escreveria — contagem de chaves por fonte (com os Aprimoramentos detalhados por categoria) e uma contagem de status Modificado / Aprimorado / Inalterado / Novo. Nada é gravado no jogo até você clicar em Aplicar Aprimoramentos."
+    },
+    "check_updates_tooltip": {
+      "ht": "",
+      "at": "Verificar no GitHub se há uma versão mais recente do Smart Citizen."
+    },
+    "theme_tooltip": {
+      "ht": "",
+      "at": "Alterar o tema do aplicativo. Tem efeito imediato na janela principal, barra de ferramentas, abas e painel de Ajuda."
+    },
+    "disable_tutorial_tooltip": {
+      "ht": "",
+      "at": "Quando marcado, o tour guiado não será iniciado automaticamente em uma nova versão. O botão Tutorial na barra de ferramentas continua funcionando."
+    },
+    "game_path_tooltip": {
+      "ht": "",
+      "at": "Raiz de instalação do Star Citizen — o diretório que contém LIVE/, PTU/, EPTU/, HOTFIX/ e/ou TECH-PREVIEW/. Detectado automaticamente na instalação; edite se o seu jogo estiver em outro local. O menu suspenso 'Canal' abaixo escolhe qual deles o aplicativo lê e grava."
+    },
+    "browse_game_tooltip": {
+      "ht": "",
+      "at": "Escolher a raiz de instalação do Star Citizen em um navegador de pastas."
+    },
+    "channel_tooltip": {
+      "ht": "",
+      "at": "Canal do Star Citizen de onde ler o Data.p4k e onde gravar o global.ini. Canais sem Data.p4k sob a raiz de instalação ficam desabilitados. Trocar de canal recarrega imediatamente as strings com os dados do novo canal."
+    },
+    "channel_not_installed_tooltip": {
+      "ht": "",
+      "at": "{channel} não está instalado — nenhum Data.p4k em {path}"
+    },
+    "language_tooltip": {
+      "ht": "",
+      "at": "Idioma a aplicar ao jogo. As chaves ausentes da tradução retornam automaticamente ao inglês."
+    },
+    "map_language_tooltip": {
+      "ht": "",
+      "at": "Definir uma URL para o global.ini de cada idioma. Ao mudar para esse idioma, o Smart Citizen o baixa e o usa como strings base em vez da extração em inglês do Data.p4k."
+    },
+    "data_dir_tooltip": {
+      "ht": "",
+      "at": "Raiz de dados do aplicativo Smart Citizen. Cada canal recebe sua própria subpasta dentro deste diretório. Deixe em branco ou clique em Resetar para usar Documents\\Smart Citizen."
+    },
+    "browse_data_tooltip": {
+      "ht": "",
+      "at": "Escolher a pasta de dados do Smart Citizen em um navegador de pastas."
+    },
+    "reset_data_tooltip": {
+      "ht": "",
+      "at": "Limpar a pasta de dados personalizada e usar Documents\\Smart Citizen."
+    },
+    "cache_dir_tooltip": {
+      "ht": "",
+      "at": "Pasta base para a árvore XML extraída do DataForge (~1,4 GB). Cada canal se aninha sob esta como {base}\\{channel}\\cache\\dataforge\\. O padrão é %LOCALAPPDATA%\\Smart Citizen para ficar fora do OneDrive. Alterar o caminho aciona uma nova extração."
+    },
+    "browse_cache_tooltip": {
+      "ht": "",
+      "at": "Escolher a pasta base do cache do DataForge em um navegador de pastas."
+    },
+    "reset_cache_tooltip": {
+      "ht": "",
+      "at": "Limpar a pasta de cache personalizada e usar o padrão da plataforma."
+    },
+    "extract_tooltip": {
+      "ht": "",
+      "at": "Extrair a localização original (base.ini) e os XMLs de entidades do DataForge do seu Data.p4k instalado. Execute após cada patch do Star Citizen — as strings recarregam automaticamente na tabela quando a extração terminar."
     }
   },
   "enhancements": {
@@ -551,6 +727,78 @@
     "edit_mapping_btn": {
       "ht": "Editar mapeamento...",
       "at": "Editar mapeamento..."
+    },
+    "mission_field_ace_tooltip": {
+      "ht": "",
+      "at": "Mostrar uma linha \"Ace Pilot: Yes\" no corpo dos detalhes da missão quando a missão gerar um piloto ás. A tag de título [ACE] é uma opção separada em Tags Gerais. Entra em vigor na próxima Geração de Aprimoramentos."
+    },
+    "mission_field_default_tooltip": {
+      "ht": "",
+      "at": "Mostrar a linha {label} nos corpos de missão gerados. Entra em vigor na próxima Geração de Aprimoramentos."
+    },
+    "stats_prepend_tooltip": {
+      "ht": "",
+      "at": "Colocar o bloco de estatísticas gerado acima da descrição do fabricante/RP em vez de abaixo (naves, componentes, armas). Entra em vigor na próxima Geração de Aprimoramentos."
+    },
+    "standardize_ship_names_tooltip": {
+      "ht": "",
+      "at": "Renomear variantes de nave exec-hangar (PYX) e Wikelo (WIK) para incluir um sufixo que as diferencie da versão padrão da loja de pledge (ex.: \"Anvil F8C Lightning PYX\"). Entra em vigor na próxima Geração de Aprimoramentos."
+    },
+    "apply_categories_tooltip": {
+      "ht": "",
+      "at": "Salvar a seleção de categorias. Categorias desmarcadas serão desativadas."
+    },
+    "generate_enabled_tooltip": {
+      "ht": "",
+      "at": "Gerar arquivos de localização aprimorados a partir do Data.p4k do seu jogo.\nOs dados do DataForge serão extraídos automaticamente se ainda não estiverem em cache\n(a primeira execução leva alguns minutos; as seguintes são rápidas)."
+    },
+    "generate_disabled_tooltip": {
+      "ht": "",
+      "at": "Já atualizado — nada que afete a saída gerada (categorias, campos de missão, opções de estatísticas/nomes, Criador de tags) mudou desde a última execução."
+    },
+    "favorite_prefix_tooltip": {
+      "ht": "",
+      "at": "Caractere adicionado antes dos nomes de naves favoritas para que apareçam no topo da lista de naves no jogo. Clique em Aplicar Prefixo após alterar para atualizar todos os favoritos existentes."
+    },
+    "rep_xp_label_tooltip": {
+      "ht": "",
+      "at": "Rótulo para missões sem nome de patente (ex.: 'Rep: +100 XP')"
+    },
+    "header_em_tooltip": {
+      "ht": "",
+      "at": "Estilo dos cabeçalhos de seção: Sublinhado (EM3) ou Texto azul (EM4)"
+    },
+    "prefix_enabled_tooltip": {
+      "ht": "",
+      "at": "Salvar o prefixo selecionado e atualizar todos os favoritos existentes para usá-lo"
+    },
+    "prefix_disabled_tooltip": {
+      "ht": "",
+      "at": "Já aplicado — o prefixo selecionado corresponde aos seus favoritos atuais."
+    },
+    "annotate_mission_descs_tooltip": {
+      "ht": "",
+      "at": "Quando marcado, a tag [CLASS-Sx-grade] configurada é adicionada aos nomes de componentes dentro da lista POTENTIAL BLUEPRINTS das descrições de missão. Desmarque para um corpo de missão mais limpo, mantendo a tag nos nomes reais dos componentes em outros lugares."
+    },
+    "reset_tag_tooltip": {
+      "ht": "",
+      "at": "Restaurar o padrão, mapeamento e ordenação padrão para cada categoria (Componentes / Mísseis / Armas de Nave). Não salva nem regenera até você clicar em Aplicar Alterações nas Tags ou Gerar Aprimoramentos."
+    },
+    "tag_enabled_tooltip": {
+      "ht": "",
+      "at": "Salvar as configurações de tags de Componentes / Mísseis / Armas de Nave e executar novamente o gerador de aprimoramentos. Novas tags aparecem no jogo após a próxima Aplicação de Aprimoramentos."
+    },
+    "tag_disabled_tooltip": {
+      "ht": "",
+      "at": "Já salvo — nenhuma alteração no Criador de tags desde o último salvamento."
+    },
+    "generating_enhancements_tooltip": {
+      "ht": "",
+      "at": "Gerando aprimoramentos…"
+    },
+    "extracting_dataforge_tooltip": {
+      "ht": "",
+      "at": "Extraindo o DataForge do Data.p4k…"
     }
   },
   "log": {
@@ -581,6 +829,22 @@
     "lines_label": {
       "ht": "{count} linhas",
       "at": "{count} linhas"
+    },
+    "min_level_tooltip": {
+      "ht": "",
+      "at": "Severidade mínima a exibir. Entradas abaixo do nível selecionado ficam ocultas (DEBUG < INFO < WARNING < ERROR)."
+    },
+    "auto_scroll_tooltip": {
+      "ht": "",
+      "at": "Rolar automaticamente até a entrada mais recente do log conforme ela chega. Desative para fixar a visualização ao inspecionar linhas mais antigas."
+    },
+    "clear_tooltip": {
+      "ht": "",
+      "at": "Limpar o buffer de log exibido na tela. O arquivo de log da sessão em disco não é afetado."
+    },
+    "export_tooltip": {
+      "ht": "",
+      "at": "Salvar o buffer de log atual em um arquivo .log — útil ao registrar um relatório de bug."
     }
   },
   "import_dialog": {
@@ -651,6 +915,14 @@
     "excluded_summary": {
       "ht": "{count} chaves excluídas (não estão no arquivo base.ini).",
       "at": "{count} chaves excluídas (não estão no arquivo base.ini)."
+    },
+    "keep_all_tooltip": {
+      "ht": "",
+      "at": "Resolver todos os conflitos mantendo seu valor existente e descartando o importado."
+    },
+    "import_all_tooltip": {
+      "ht": "",
+      "at": "Resolver todos os conflitos aceitando o valor importado e substituindo o existente."
     }
   },
   "coach": {
@@ -699,6 +971,10 @@
     "col_long": {
       "ht": "Longo",
       "at": "Longo"
+    },
+    "reset_tooltip": {
+      "ht": "",
+      "at": "Restaurar todas as células desta tabela de mapeamento para os padrões internos do Smart Citizen."
     }
   },
   "dialogs": {
@@ -977,6 +1253,18 @@
     "copy_error_body": {
       "ht": "",
       "at": "Falha ao copiar para a área de transferência: {error}"
+    },
+    "browse_ini_tooltip": {
+      "ht": "",
+      "at": "Escolher um arquivo .ini local para importar."
+    },
+    "generate_now_tooltip": {
+      "ht": "",
+      "at": "Executar agora a extração do DataForge + o pipeline de aprimoramentos. Leva alguns minutos na primeira vez."
+    },
+    "skip_generate_tooltip": {
+      "ht": "",
+      "at": "Continuar sem gerar aprimoramentos. Você pode executá-lo depois na aba Aprimoramentos."
     }
   },
   "progress": {
@@ -1073,6 +1361,10 @@
     "update_indicator_failed": {
       "ht": "v{current} · falha na verificação",
       "at": "v{current} · falha na verificação"
+    },
+    "open_release_page_tooltip": {
+      "ht": "",
+      "at": "Abrir a página de lançamento da v{version}"
     }
   },
   "tutorial": {

--- a/languages/portuguese_br/ui.json
+++ b/languages/portuguese_br/ui.json
@@ -315,6 +315,10 @@
     "column_filter_tooltip": {
       "ht": "",
       "at": "Filtrar a coluna {column}. Os filtros entre colunas se combinam com E."
+    },
+    "column_filter_placeholder": {
+      "ht": "",
+      "at": "Filtrar {column}…"
     }
   },
   "config": {

--- a/languages/spanish/ui.json
+++ b/languages/spanish/ui.json
@@ -127,6 +127,50 @@
     "menu_switch_to_simple": {
       "ht": "",
       "at": "Cambiar a modo simple"
+    },
+    "editor_tooltip": {
+      "ht": "",
+      "at": "Mostrar/ocultar el Editor de cadenas acoplado lateralmente, un lienzo más grande para editar el valor personalizado de la fila seleccionada"
+    },
+    "help_tooltip": {
+      "ht": "",
+      "at": "Mostrar/ocultar el panel lateral de Ayuda"
+    },
+    "tutorial_tooltip": {
+      "ht": "",
+      "at": "Iniciar la visita guiada del flujo de trabajo de Smart Citizen. Se ejecuta automáticamente en el primer inicio; haz clic aquí en cualquier momento para repetirla."
+    },
+    "restore_backup_tooltip": {
+      "ht": "",
+      "at": "Restaurar un global.ini anterior desde la carpeta de copias de seguridad. Se conservan hasta 5 copias con marca de tiempo; la más antigua se elimina al crear una nueva."
+    },
+    "test_plan_tooltip": {
+      "ht": "",
+      "at": "Abrir el Plan de pruebas del tester: una lista de verificación de los cambios en esta versión, con seguimiento del progreso y un informe que puedes enviar."
+    },
+    "switch_to_simple_tooltip": {
+      "ht": "",
+      "at": "Cambiar a la vista simplificada de un solo botón."
+    },
+    "more_tooltip": {
+      "ht": "",
+      "at": "Más acciones: restaurar una copia de seguridad, borrar la localización o la caché, importar o exportar, abrir la carpeta de localización"
+    },
+    "osiris_github_tooltip": {
+      "ht": "",
+      "at": "Abrir la organización de GitHub de Osiris DevWorks"
+    },
+    "feedback_tooltip": {
+      "ht": "",
+      "at": "Abrir el canal de Discord de Smart Citizen para comentarios, informes de errores y votación de próximas funciones (requiere unirse al Discord de Osiris DevWorks)."
+    },
+    "apply_enabled_tooltip": {
+      "ht": "",
+      "at": "Escribir el contenido combinado de la tabla en el global.ini del juego. Primero se crea una copia de seguridad con marca de tiempo del global.ini actual."
+    },
+    "apply_disabled_tooltip": {
+      "ht": "",
+      "at": "Ya aplicado — no ha cambiado nada desde la última aplicación al juego."
     }
   },
   "filters": {
@@ -185,6 +229,42 @@
     "copy_filtered_btn": {
       "ht": "Copiar filtrados",
       "at": ""
+    },
+    "category_tooltip": {
+      "ht": "",
+      "at": "Filtrar filas por dominio (Naves, Objetos de nave, Misiones, Equipo, Mercancías, Diario, Otros). Las categorías se derivan del prefijo de la clave de localización."
+    },
+    "status_tooltip": {
+      "ht": "",
+      "at": "Filtrar por estado. Modificado = has establecido un Valor personalizado; Mejorado = producido por el proceso de mejoras de Smart Citizen (estadísticas de naves, recompensas de misiones, etc.); Sin modificar = solo texto predeterminado; Nuevo = la clave existe solo en enhancements/user.ini, no en el archivo base."
+    },
+    "hide_unmodified_tooltip": {
+      "ht": "",
+      "at": "Mostrar solo las filas donde has establecido un Valor personalizado. Igual que la opción Modificado del filtro de Estado, pero activable de forma independiente."
+    },
+    "favorites_only_tooltip": {
+      "ht": "",
+      "at": "Mostrar solo las filas marcadas como favoritas. Los favoritos reciben un prefijo configurable delante de su nombre para que aparezcan en la parte superior de la lista dentro del juego."
+    },
+    "bp_titles_only_tooltip": {
+      "ht": "",
+      "at": "Mostrar solo los títulos de misión con la etiqueta de plano [BP] / [BP?]."
+    },
+    "bp_descs_only_tooltip": {
+      "ht": "",
+      "at": "Mostrar solo las descripciones de misión que contengan una sección POTENTIAL BLUEPRINTS."
+    },
+    "group_sort_tooltip": {
+      "ht": "",
+      "at": "Ordenar títulos y descripciones juntos para la misma entidad"
+    },
+    "clear_filters_tooltip": {
+      "ht": "",
+      "at": "Restablecer todos los filtros (categoría, estado, búsqueda, campos por columna, casillas de verificación) para mostrar la tabla completa."
+    },
+    "copy_filtered_tooltip": {
+      "ht": "",
+      "at": "Copiar todas las filas filtradas visibles al portapapeles (separadas por tabulaciones)"
     }
   },
   "strings_tab": {
@@ -239,6 +319,18 @@
     "context_highlight": {
       "ht": "Resaltar",
       "at": ""
+    },
+    "editor_underline_tooltip": {
+      "ht": "",
+      "at": "Subrayar el texto seleccionado (lo envuelve en <EM3>...</EM3>)"
+    },
+    "editor_highlight_tooltip": {
+      "ht": "",
+      "at": "Resaltar el texto seleccionado con énfasis de color (lo envuelve en <EM4>...</EM4>)"
+    },
+    "column_filter_tooltip": {
+      "ht": "",
+      "at": "Filtrar la columna {column}. Los filtros de varias columnas se combinan con Y."
     }
   },
   "config": {
@@ -477,6 +569,90 @@
     "no_sources_warning": {
       "ht": "No hay fuentes disponibles para fusionar.",
       "at": ""
+    },
+    "include_new_tooltip": {
+      "ht": "",
+      "at": "Si está marcado, los elementos descubiertos en el XML de DataForge (estado 'Nuevo') que tengan texto no vacío se incluirán en el global.ini aplicado."
+    },
+    "import_ini_tooltip": {
+      "ht": "",
+      "at": "Incorporar un .ini externo a tus anulaciones. Un diálogo de resolución de conflictos te permite decidir por clave: mantener la actual, usar la importada, añadir al final, añadir al principio o proporcionar un valor personalizado."
+    },
+    "reset_user_ini_tooltip": {
+      "ht": "",
+      "at": "Eliminar todas las anulaciones de cadenas personalizadas del canal activo. Se guarda una copia de seguridad con marca de tiempo junto al original para que puedas restaurarla."
+    },
+    "restore_user_ini_tooltip": {
+      "ht": "",
+      "at": "Restaurar tus anulaciones de cadenas personalizadas desde una instantánea automática. Smart Citizen guarda los últimos estados de user.ini, para poder deshacer una edición errónea o recuperar el archivo después de que se vaciara."
+    },
+    "preview_apply_tooltip": {
+      "ht": "",
+      "at": "Resumen de simulación de lo que Aplicar mejoras escribiría — recuento de claves por fuente (con las mejoras desglosadas por categoría) y un recuento de estados Modificado / Mejorado / Sin modificar / Nuevo. No se escribe nada en el juego hasta que hagas clic en Aplicar mejoras."
+    },
+    "check_updates_tooltip": {
+      "ht": "",
+      "at": "Comprobar en GitHub si hay una versión más reciente de Smart Citizen."
+    },
+    "theme_tooltip": {
+      "ht": "",
+      "at": "Cambiar el tema de la aplicación. Se aplica de inmediato a la ventana principal, la barra de herramientas, las pestañas y el panel de Ayuda."
+    },
+    "disable_tutorial_tooltip": {
+      "ht": "",
+      "at": "Si está marcado, la visita guiada no se iniciará automáticamente en una nueva versión. El botón Tutorial de la barra de herramientas sigue funcionando."
+    },
+    "game_path_tooltip": {
+      "ht": "",
+      "at": "Raíz de instalación de Star Citizen — el directorio que contiene LIVE/, PTU/, EPTU/, HOTFIX/ y/o TECH-PREVIEW/. Se detecta automáticamente al instalar; edítalo si tu juego está en otro lugar. El menú desplegable 'Canal' de abajo elige cuál lee y escribe la aplicación."
+    },
+    "browse_game_tooltip": {
+      "ht": "",
+      "at": "Elegir la raíz de instalación de Star Citizen en un explorador de carpetas."
+    },
+    "channel_tooltip": {
+      "ht": "",
+      "at": "Canal de Star Citizen desde el que leer Data.p4k y en el que escribir global.ini. Los canales sin Data.p4k bajo la raíz de instalación están deshabilitados. Cambiar de canal recarga inmediatamente las cadenas con los datos del nuevo canal."
+    },
+    "channel_not_installed_tooltip": {
+      "ht": "",
+      "at": "{channel} no está instalado — no hay Data.p4k en {path}"
+    },
+    "language_tooltip": {
+      "ht": "",
+      "at": "Idioma que se aplicará al juego. Las claves que falten en la traducción vuelven automáticamente al inglés."
+    },
+    "map_language_tooltip": {
+      "ht": "",
+      "at": "Establecer una URL para el global.ini de cada idioma. Al cambiar a ese idioma, Smart Citizen lo descarga y lo usa como cadenas base en lugar de la extracción en inglés de Data.p4k."
+    },
+    "data_dir_tooltip": {
+      "ht": "",
+      "at": "Raíz de datos de la aplicación Smart Citizen. Cada canal recibe su propia subcarpeta dentro de este directorio. Déjalo en blanco o haz clic en Restablecer para usar Documents\\Smart Citizen."
+    },
+    "browse_data_tooltip": {
+      "ht": "",
+      "at": "Elegir la carpeta de datos de Smart Citizen en un explorador de carpetas."
+    },
+    "reset_data_tooltip": {
+      "ht": "",
+      "at": "Borrar la carpeta de datos personalizada y usar Documents\\Smart Citizen."
+    },
+    "cache_dir_tooltip": {
+      "ht": "",
+      "at": "Carpeta base para el árbol XML de DataForge extraído (~1,4 GB). Cada canal se anida bajo esta como {base}\\{channel}\\cache\\dataforge\\. Por defecto %LOCALAPPDATA%\\Smart Citizen para mantenerse fuera de OneDrive. Cambiar la ruta activa una nueva extracción."
+    },
+    "browse_cache_tooltip": {
+      "ht": "",
+      "at": "Elegir la carpeta base de la caché de DataForge en un explorador de carpetas."
+    },
+    "reset_cache_tooltip": {
+      "ht": "",
+      "at": "Borrar la carpeta de caché personalizada y usar la predeterminada de la plataforma."
+    },
+    "extract_tooltip": {
+      "ht": "",
+      "at": "Extraer la localización original (base.ini) y los XML de entidades de DataForge de tu Data.p4k instalado. Ejecuta esto después de cada parche de Star Citizen — las cadenas se recargan automáticamente en la tabla cuando finaliza la extracción."
     }
   },
   "enhancements": {
@@ -567,6 +743,78 @@
     "edit_mapping_btn": {
       "ht": "Editar mapeo...",
       "at": ""
+    },
+    "mission_field_ace_tooltip": {
+      "ht": "",
+      "at": "Mostrar una línea \"Ace Pilot: Yes\" en el cuerpo de detalles de la misión cuando la misión genere un piloto as. La etiqueta de título [ACE] es una opción independiente en Etiquetas generales. Surte efecto en la próxima generación de mejoras."
+    },
+    "mission_field_default_tooltip": {
+      "ht": "",
+      "at": "Mostrar la línea {label} en los cuerpos de misión generados. Surte efecto en la próxima generación de mejoras."
+    },
+    "stats_prepend_tooltip": {
+      "ht": "",
+      "at": "Colocar el bloque de estadísticas generado encima de la descripción del fabricante/RP en lugar de debajo (naves, componentes, armas). Surte efecto en la próxima generación de mejoras."
+    },
+    "standardize_ship_names_tooltip": {
+      "ht": "",
+      "at": "Renombrar las variantes de nave exec-hangar (PYX) y Wikelo (WIK) para incluir un sufijo que las distinga de la versión estándar de la tienda de pledge (p. ej. \"Anvil F8C Lightning PYX\"). Surte efecto en la próxima generación de mejoras."
+    },
+    "apply_categories_tooltip": {
+      "ht": "",
+      "at": "Guardar la selección de categorías. Las categorías sin marcar se desactivarán."
+    },
+    "generate_enabled_tooltip": {
+      "ht": "",
+      "at": "Generar archivos de localización mejorados a partir del Data.p4k de tu juego.\nLos datos de DataForge se extraerán automáticamente si aún no están en caché\n(la primera ejecución tarda unos minutos; las siguientes son rápidas)."
+    },
+    "generate_disabled_tooltip": {
+      "ht": "",
+      "at": "Ya actualizado — nada que afecte a la salida generada (categorías, campos de misión, opciones de estadísticas/nombres, Generador de etiquetas) ha cambiado desde la última ejecución."
+    },
+    "favorite_prefix_tooltip": {
+      "ht": "",
+      "at": "Carácter que se antepone a los nombres de las naves favoritas para que aparezcan en la parte superior de la lista de naves en el juego. Haz clic en Aplicar prefijo después de cambiarlo para actualizar todos los favoritos existentes."
+    },
+    "rep_xp_label_tooltip": {
+      "ht": "",
+      "at": "Etiqueta para misiones sin nombre de rango (p. ej. 'Rep: +100 XP')"
+    },
+    "header_em_tooltip": {
+      "ht": "",
+      "at": "Estilo de los encabezados de sección: Subrayado (EM3) o Texto azul (EM4)"
+    },
+    "prefix_enabled_tooltip": {
+      "ht": "",
+      "at": "Guardar el prefijo seleccionado y actualizar todos los favoritos existentes para usarlo"
+    },
+    "prefix_disabled_tooltip": {
+      "ht": "",
+      "at": "Ya aplicado — el prefijo seleccionado coincide con tus favoritos actuales."
+    },
+    "annotate_mission_descs_tooltip": {
+      "ht": "",
+      "at": "Si está marcado, la etiqueta [CLASS-Sx-grade] configurada se añade a los nombres de componentes dentro de la lista POTENTIAL BLUEPRINTS de las descripciones de misión. Desmárcalo para un cuerpo de misión más limpio, manteniendo la etiqueta en los nombres reales de los componentes en otros lugares."
+    },
+    "reset_tag_tooltip": {
+      "ht": "",
+      "at": "Restaurar el patrón, la asignación y el orden predeterminados de cada categoría (Componentes / Misiles / Armas de nave). No guarda ni regenera hasta que hagas clic en Aplicar cambios de etiquetas o Generar mejoras."
+    },
+    "tag_enabled_tooltip": {
+      "ht": "",
+      "at": "Guardar las configuraciones de etiquetas de Componentes / Misiles / Armas de nave y volver a ejecutar el generador de mejoras. Las nuevas etiquetas aparecen en el juego tras la siguiente aplicación de mejoras."
+    },
+    "tag_disabled_tooltip": {
+      "ht": "",
+      "at": "Ya guardado — no hay cambios en el Generador de etiquetas desde el último guardado."
+    },
+    "generating_enhancements_tooltip": {
+      "ht": "",
+      "at": "Generando mejoras…"
+    },
+    "extracting_dataforge_tooltip": {
+      "ht": "",
+      "at": "Extrayendo DataForge desde Data.p4k…"
     }
   },
   "log": {
@@ -597,6 +845,22 @@
     "lines_label": {
       "ht": "{count} líneas",
       "at": ""
+    },
+    "min_level_tooltip": {
+      "ht": "",
+      "at": "Gravedad mínima a mostrar. Las entradas por debajo del nivel seleccionado se ocultan (DEBUG < INFO < WARNING < ERROR)."
+    },
+    "auto_scroll_tooltip": {
+      "ht": "",
+      "at": "Desplazarse automáticamente hasta la entrada más reciente del registro a medida que llega. Desactívalo para fijar la vista al inspeccionar líneas anteriores."
+    },
+    "clear_tooltip": {
+      "ht": "",
+      "at": "Borrar el búfer del registro en pantalla. El archivo de registro de la sesión en el disco no se ve afectado."
+    },
+    "export_tooltip": {
+      "ht": "",
+      "at": "Guardar el búfer de registro actual en un archivo .log — útil al reportar un error."
     }
   },
   "import_dialog": {
@@ -667,6 +931,14 @@
     "excluded_summary": {
       "ht": "{count} claves excluidas (no están en base.ini).",
       "at": ""
+    },
+    "keep_all_tooltip": {
+      "ht": "",
+      "at": "Resolver todos los conflictos manteniendo tu valor existente y descartando el importado."
+    },
+    "import_all_tooltip": {
+      "ht": "",
+      "at": "Resolver todos los conflictos aceptando el valor importado y sobrescribiendo el existente."
     }
   },
   "coach": {
@@ -715,6 +987,10 @@
     "col_long": {
       "ht": "Largo",
       "at": ""
+    },
+    "reset_tooltip": {
+      "ht": "",
+      "at": "Restaurar todas las celdas de esta tabla de asignación a los valores predeterminados integrados de Smart Citizen."
     }
   },
   "dialogs": {
@@ -993,6 +1269,18 @@
     "copy_error_body": {
       "ht": "No se pudo copiar al portapapeles: {error}",
       "at": ""
+    },
+    "browse_ini_tooltip": {
+      "ht": "",
+      "at": "Elegir un archivo .ini local para importar."
+    },
+    "generate_now_tooltip": {
+      "ht": "",
+      "at": "Ejecutar ahora la extracción de DataForge y el proceso de mejoras. Tarda unos minutos la primera vez."
+    },
+    "skip_generate_tooltip": {
+      "ht": "",
+      "at": "Continuar sin generar mejoras. Puedes ejecutarlo más tarde desde la pestaña Mejoras."
     }
   },
   "progress": {
@@ -1089,6 +1377,10 @@
     "update_indicator_failed": {
       "ht": "v{current} - comprobación fallida",
       "at": ""
+    },
+    "open_release_page_tooltip": {
+      "ht": "",
+      "at": "Abrir la página de la versión v{version}"
     }
   }
 }

--- a/languages/spanish/ui.json
+++ b/languages/spanish/ui.json
@@ -331,6 +331,10 @@
     "column_filter_tooltip": {
       "ht": "",
       "at": "Filtrar la columna {column}. Los filtros de varias columnas se combinan con Y."
+    },
+    "column_filter_placeholder": {
+      "ht": "",
+      "at": "Filtrar {column}…"
     }
   },
   "config": {

--- a/src/gui/config_tab.py
+++ b/src/gui/config_tab.py
@@ -90,10 +90,7 @@ class ConfigTab(QWidget):
         tools_layout.addWidget(self._tools_desc_label)
 
         self.include_new_cb = QCheckBox("Include discovered items")
-        self.include_new_cb.setToolTip(
-            "When checked, items discovered from DataForge XML (status 'New') "
-            "that have non-empty text will be included in the applied global.ini."
-        )
+        self.include_new_cb.setToolTip(tr("config.include_new_tooltip"))
         self.include_new_cb.setChecked(AppSettings.get_include_new_lines())
         self.include_new_cb.toggled.connect(self._on_include_new_toggled)
         tools_layout.addWidget(self.include_new_cb)
@@ -102,49 +99,31 @@ class ConfigTab(QWidget):
 
         self._import_btn = QPushButton(tr("config.import_ini_btn"))
         self._import_btn.setMaximumWidth(150)
-        self._import_btn.setToolTip(
-            "Fold an external .ini into your overrides. A conflict-resolution "
-            "dialog lets you decide per key: keep current, use imported, append, "
-            "prepend, or provide a custom value."
-        )
+        self._import_btn.setToolTip(tr("config.import_ini_tooltip"))
         self._import_btn.clicked.connect(self.import_ini_requested.emit)
         button_layout.addWidget(self._import_btn)
 
         self._reset_user_ini_btn = QPushButton(tr("config.reset_user_ini_btn"))
         self._reset_user_ini_btn.setMaximumWidth(150)
-        self._reset_user_ini_btn.setToolTip(
-            "Delete every custom string override for the active channel. "
-            "A timestamped backup is saved next to the original so you can restore it."
-        )
+        self._reset_user_ini_btn.setToolTip(tr("config.reset_user_ini_tooltip"))
         self._reset_user_ini_btn.clicked.connect(self.reset_user_ini_requested.emit)
         button_layout.addWidget(self._reset_user_ini_btn)
 
         self._restore_user_ini_btn = QPushButton(tr("config.restore_user_ini_btn"))
         self._restore_user_ini_btn.setMaximumWidth(150)
-        self._restore_user_ini_btn.setToolTip(
-            "Restore your custom string overrides from an automatic snapshot. "
-            "Smart Citizen keeps the last few states of user.ini, so you can roll "
-            "back a bad edit or recover after the file was emptied."
-        )
+        self._restore_user_ini_btn.setToolTip(tr("config.restore_user_ini_tooltip"))
         self._restore_user_ini_btn.clicked.connect(self.restore_user_ini_requested.emit)
         button_layout.addWidget(self._restore_user_ini_btn)
 
         self._preview_btn = QPushButton(tr("config.preview_apply_btn"))
         self._preview_btn.setMaximumWidth(150)
-        self._preview_btn.setToolTip(
-            "Dry-run summary of what Apply Enhancements would write — per-source key "
-            "counts (with Enhancements broken down by category) and a "
-            "Modified / Enhanced / Unmodified / New status tally. Nothing is "
-            "written to the game until you click Apply Enhancements."
-        )
+        self._preview_btn.setToolTip(tr("config.preview_apply_tooltip"))
         self._preview_btn.clicked.connect(self.preview_merge)
         button_layout.addWidget(self._preview_btn)
 
         self._check_updates_btn = QPushButton(tr("config.check_updates_btn"))
         self._check_updates_btn.setMaximumWidth(170)
-        self._check_updates_btn.setToolTip(
-            "Check GitHub for a newer Smart Citizen release."
-        )
+        self._check_updates_btn.setToolTip(tr("config.check_updates_tooltip"))
         self._check_updates_btn.clicked.connect(self.check_updates_requested.emit)
         button_layout.addWidget(self._check_updates_btn)
 
@@ -167,7 +146,7 @@ class ConfigTab(QWidget):
         appearance_layout.addWidget(self._theme_label)
 
         self.theme_combo = QComboBox()
-        self.theme_combo.setToolTip("Switch the app theme. Takes effect immediately across the main window, toolbar, tabs, and Help panel.")
+        self.theme_combo.setToolTip(tr("config.theme_tooltip"))
         self.theme_combo.addItem(tr("config.theme_default"), THEME_SCLE)
         self.theme_combo.addItem(tr("config.theme_light"), THEME_LIGHT)
         self.theme_combo.addItem(tr("config.theme_dark"), THEME_DARK)
@@ -182,10 +161,7 @@ class ConfigTab(QWidget):
 
         appearance_layout.addSpacing(20)
         self.disable_tutorial_cb = QCheckBox("Disable Tutorial")
-        self.disable_tutorial_cb.setToolTip(
-            "When checked, the guided tour will not auto-launch on a new "
-            "version. The Tutorial button in the toolbar still works."
-        )
+        self.disable_tutorial_cb.setToolTip(tr("config.disable_tutorial_tooltip"))
         self.disable_tutorial_cb.setChecked(AppSettings.get_tutorial_disabled())
         self.disable_tutorial_cb.toggled.connect(AppSettings.set_tutorial_disabled)
         appearance_layout.addWidget(self.disable_tutorial_cb)
@@ -217,18 +193,13 @@ class ConfigTab(QWidget):
         self.game_path_input.setPlaceholderText(
             r"C:\Program Files\Roberts Space Industries\StarCitizen"
         )
-        self.game_path_input.setToolTip(
-            "Star Citizen install root — the directory that contains LIVE/, "
-            "PTU/, EPTU/, HOTFIX/, and/or TECH-PREVIEW/. Auto-detected at "
-            "install time; edit if your game lives elsewhere. The 'Channel' "
-            "dropdown below picks which one the app reads and writes."
-        )
+        self.game_path_input.setToolTip(tr("config.game_path_tooltip"))
         self.game_path_input.editingFinished.connect(self._save_game_path)
         game_input_layout.addWidget(self.game_path_input)
 
         self._game_browse_btn = QPushButton(tr("config.browse_btn"))
         self._game_browse_btn.setMaximumWidth(100)
-        self._game_browse_btn.setToolTip("Pick the Star Citizen install root in a folder browser.")
+        self._game_browse_btn.setToolTip(tr("config.browse_game_tooltip"))
         self._game_browse_btn.clicked.connect(self._browse_game_path)
         game_input_layout.addWidget(self._game_browse_btn)
         game_layout.addLayout(game_input_layout)
@@ -241,11 +212,7 @@ class ConfigTab(QWidget):
 
         self.channel_combo = QComboBox()
         self.channel_combo.setMaximumWidth(180)
-        self.channel_combo.setToolTip(
-            "Star Citizen channel to read Data.p4k from and write global.ini to. "
-            "Channels with no Data.p4k under the install root are disabled. "
-            "Switching channels immediately reloads strings against the new channel's data."
-        )
+        self.channel_combo.setToolTip(tr("config.channel_tooltip"))
         channel_row.addWidget(self.channel_combo)
 
         self._channel_hint_label = QLabel()
@@ -268,19 +235,12 @@ class ConfigTab(QWidget):
 
         self.language_combo = QComboBox()
         self.language_combo.setMaximumWidth(180)
-        self.language_combo.setToolTip(
-            "Language to apply to the game. Keys missing from the translation "
-            "fall back to English automatically."
-        )
+        self.language_combo.setToolTip(tr("config.language_tooltip"))
         language_row.addWidget(self.language_combo)
 
         self._map_lang_btn = QPushButton(tr("config.map_language_btn"))
         self._map_lang_btn.setMaximumWidth(160)
-        self._map_lang_btn.setToolTip(
-            "Set a URL to each language's global.ini. When you switch to that "
-            "language, Smart Citizen downloads it and uses it as the base "
-            "strings instead of the English Data.p4k extraction."
-        )
+        self._map_lang_btn.setToolTip(tr("config.map_language_tooltip"))
         self._map_lang_btn.clicked.connect(self._open_language_source_dialog)
         language_row.addWidget(self._map_lang_btn)
 
@@ -316,22 +276,19 @@ class ConfigTab(QWidget):
         data_input_layout = QHBoxLayout()
         self.data_dir_input = QLineEdit()
         self.data_dir_input.setText(os.path.normpath(str(AppSettings.get_user_data_dir())))
-        self.data_dir_input.setToolTip(
-            "Smart Citizen's app data root. Each channel gets its own subfolder "
-            "inside this directory. Leave blank or click Reset to use Documents\\Smart Citizen."
-        )
+        self.data_dir_input.setToolTip(tr("config.data_dir_tooltip"))
         self.data_dir_input.editingFinished.connect(self._save_data_dir)
         data_input_layout.addWidget(self.data_dir_input)
 
         self._data_browse_btn = QPushButton(tr("config.browse_btn"))
         self._data_browse_btn.setMaximumWidth(100)
-        self._data_browse_btn.setToolTip("Pick the Smart Citizen data folder in a folder browser.")
+        self._data_browse_btn.setToolTip(tr("config.browse_data_tooltip"))
         self._data_browse_btn.clicked.connect(self._browse_data_dir)
         data_input_layout.addWidget(self._data_browse_btn)
 
         self._data_reset_btn = QPushButton(tr("config.reset_btn"))
         self._data_reset_btn.setMaximumWidth(80)
-        self._data_reset_btn.setToolTip("Clear the custom data folder and use Documents\\Smart Citizen.")
+        self._data_reset_btn.setToolTip(tr("config.reset_data_tooltip"))
         self._data_reset_btn.clicked.connect(self._reset_data_dir)
         data_input_layout.addWidget(self._data_reset_btn)
 
@@ -352,24 +309,19 @@ class ConfigTab(QWidget):
         self.cache_dir_input.setText(
             os.path.normpath(str(AppSettings.get_dataforge_cache_base()))
         )
-        self.cache_dir_input.setToolTip(
-            "Base folder for the extracted DataForge XML tree (~1.4 GB). Each "
-            "channel nests under this as {base}\\{channel}\\cache\\dataforge\\. "
-            "Defaults to %LOCALAPPDATA%\\Smart Citizen so it stays out of "
-            "OneDrive. Changing the path triggers a re-extraction."
-        )
+        self.cache_dir_input.setToolTip(tr("config.cache_dir_tooltip"))
         self.cache_dir_input.editingFinished.connect(self._save_cache_dir)
         cache_input_layout.addWidget(self.cache_dir_input)
 
         self._cache_browse_btn = QPushButton(tr("config.browse_btn"))
         self._cache_browse_btn.setMaximumWidth(100)
-        self._cache_browse_btn.setToolTip("Pick the DataForge cache base folder in a folder browser.")
+        self._cache_browse_btn.setToolTip(tr("config.browse_cache_tooltip"))
         self._cache_browse_btn.clicked.connect(self._browse_cache_dir)
         cache_input_layout.addWidget(self._cache_browse_btn)
 
         self._cache_reset_btn = QPushButton(tr("config.reset_btn"))
         self._cache_reset_btn.setMaximumWidth(80)
-        self._cache_reset_btn.setToolTip("Clear the custom cache folder and use the platform default.")
+        self._cache_reset_btn.setToolTip(tr("config.reset_cache_tooltip"))
         self._cache_reset_btn.clicked.connect(self._reset_cache_dir)
         cache_input_layout.addWidget(self._cache_reset_btn)
 
@@ -399,11 +351,7 @@ class ConfigTab(QWidget):
 
         self._extract_btn = QPushButton(tr("config.extract_btn"))
         self._extract_btn.setMaximumWidth(180)
-        self._extract_btn.setToolTip(
-            "Unpack stock localization (base.ini) plus the DataForge entity XMLs "
-            "from your installed Data.p4k. Run after every Star Citizen patch — "
-            "the strings reload into the table automatically when extraction finishes."
-        )
+        self._extract_btn.setToolTip(tr("config.extract_tooltip"))
         self._extract_btn.clicked.connect(self.p4k_extract_requested.emit)
         p4k_status_row.addWidget(self._extract_btn)
 
@@ -442,13 +390,20 @@ class ConfigTab(QWidget):
         self._instructions_label.setText(tr("config.instructions"))
         self._tools_group.setTitle(tr("config.tools_group"))
         self._tools_desc_label.setText(tr("config.tools_desc"))
+        self.include_new_cb.setToolTip(tr("config.include_new_tooltip"))
         self._import_btn.setText(tr("config.import_ini_btn"))
+        self._import_btn.setToolTip(tr("config.import_ini_tooltip"))
         self._reset_user_ini_btn.setText(tr("config.reset_user_ini_btn"))
+        self._reset_user_ini_btn.setToolTip(tr("config.reset_user_ini_tooltip"))
         self._restore_user_ini_btn.setText(tr("config.restore_user_ini_btn"))
+        self._restore_user_ini_btn.setToolTip(tr("config.restore_user_ini_tooltip"))
         self._preview_btn.setText(tr("config.preview_apply_btn"))
+        self._preview_btn.setToolTip(tr("config.preview_apply_tooltip"))
         self._check_updates_btn.setText(tr("config.check_updates_btn"))
+        self._check_updates_btn.setToolTip(tr("config.check_updates_tooltip"))
         self._appearance_group.setTitle(tr("config.appearance_group"))
         self._theme_label.setText(tr("config.theme_label"))
+        self.theme_combo.setToolTip(tr("config.theme_tooltip"))
         self.theme_combo.blockSignals(True)
         try:
             self.theme_combo.setItemText(0, tr("config.theme_default"))
@@ -457,22 +412,35 @@ class ConfigTab(QWidget):
             self.theme_combo.setItemText(3, tr("config.theme_odw"))
         finally:
             self.theme_combo.blockSignals(False)
+        self.disable_tutorial_cb.setToolTip(tr("config.disable_tutorial_tooltip"))
         self._loc_group.setTitle(tr("config.star_citizen_group"))
         self._install_label.setText(tr("config.installation_label"))
         self._game_desc_label.setText(tr("config.installation_desc"))
+        self.game_path_input.setToolTip(tr("config.game_path_tooltip"))
         self._game_browse_btn.setText(tr("config.browse_btn"))
+        self._game_browse_btn.setToolTip(tr("config.browse_game_tooltip"))
         self._channel_label.setText(tr("config.channel_label"))
+        self.channel_combo.setToolTip(tr("config.channel_tooltip"))
         self._language_label.setText(tr("config.language_label"))
+        self.language_combo.setToolTip(tr("config.language_tooltip"))
         self._map_lang_btn.setText(tr("config.map_language_btn"))
+        self._map_lang_btn.setToolTip(tr("config.map_language_tooltip"))
         self._extract_btn.setText(tr("config.extract_btn"))
+        self._extract_btn.setToolTip(tr("config.extract_tooltip"))
         self._data_group.setTitle(tr("config.data_group"))
         self._data_desc_label.setText(tr("config.data_desc"))
         self._app_data_label.setText(tr("config.app_data_label"))
+        self.data_dir_input.setToolTip(tr("config.data_dir_tooltip"))
         self._data_browse_btn.setText(tr("config.browse_btn"))
+        self._data_browse_btn.setToolTip(tr("config.browse_data_tooltip"))
         self._data_reset_btn.setText(tr("config.reset_btn"))
+        self._data_reset_btn.setToolTip(tr("config.reset_data_tooltip"))
         self._cache_label.setText(tr("config.dataforge_cache_label"))
+        self.cache_dir_input.setToolTip(tr("config.cache_dir_tooltip"))
         self._cache_browse_btn.setText(tr("config.browse_btn"))
+        self._cache_browse_btn.setToolTip(tr("config.browse_cache_tooltip"))
         self._cache_reset_btn.setText(tr("config.reset_btn"))
+        self._cache_reset_btn.setToolTip(tr("config.reset_cache_tooltip"))
         self._p4k_group.setTitle(tr("config.p4k_group"))
         self._p4k_desc_label.setText(tr("config.p4k_desc"))
 
@@ -827,10 +795,10 @@ class ConfigTab(QWidget):
                 if item is not None and not is_available and root:
                     from PyQt6.QtCore import Qt
                     item.setFlags(item.flags() & ~Qt.ItemFlag.ItemIsEnabled)
-                    item.setToolTip(
-                        f"{channel} isn't installed — no Data.p4k at "
-                        f"{Path(root) / channel / 'Data.p4k'}"
-                    )
+                    item.setToolTip(tr(
+                        "config.channel_not_installed_tooltip",
+                        channel=channel, path=str(Path(root) / channel / "Data.p4k"),
+                    ))
                 if channel == active:
                     active_index = i
             self.channel_combo.setCurrentIndex(active_index)

--- a/src/gui/enhancements_tab.py
+++ b/src/gui/enhancements_tab.py
@@ -259,7 +259,10 @@ class EnhancementsTab(QWidget):
         mf_heading.setStyleSheet("font-size: 11px; font-weight: bold;")
         gl.addWidget(mf_heading)
 
-        _MISSION_FIELD_LABELS = [
+        # Stored on self (not a local) so retranslate_ui can rebuild each
+        # checkbox's tooltip after a language switch without duplicating
+        # this list.
+        self._mission_field_labels = [
             ("mission_type",  "Mission Type"),
             ("difficulty",    "Difficulty"),
             ("spawns",        "Hostiles"),
@@ -271,29 +274,15 @@ class EnhancementsTab(QWidget):
         # "General Tags" section (independent of this body-fields group) —
         # see AppSettings.get_mission_title_tags(). "ace" here now controls
         # ONLY the "Ace Pilot: Yes" body line.
-        _MISSION_FIELD_TOOLTIPS = {
-            "ace": (
-                "Show an \"Ace Pilot: Yes\" line in the mission details body "
-                "when the mission spawns an ace pilot. The [ACE] title tag is "
-                "a separate toggle under General Tags. "
-                "Takes effect on the next Generate Enhancements."
-            ),
-        }
         self._mission_field_checkboxes: dict = {}
         _mf_saved = AppSettings.get_mission_detail_fields()
         mf_row = QHBoxLayout()
         mf_row.setContentsMargins(0, 0, 0, 0)
-        for _field, _label in _MISSION_FIELD_LABELS:
+        for _field, _label in self._mission_field_labels:
             cb = QCheckBox(_label)
             cb.setChecked(_mf_saved.get(_field, True))
             cb.setStyleSheet("font-size: 11px;")
-            cb.setToolTip(
-                _MISSION_FIELD_TOOLTIPS.get(
-                    _field,
-                    f"Show the {_label} line in generated mission bodies. "
-                    "Takes effect on the next Generate Enhancements.",
-                )
-            )
+            cb.setToolTip(self._mission_field_tooltip(_field, _label))
             cb.toggled.connect(
                 lambda checked, f=_field: self._on_mission_field_toggled(f, checked)
             )
@@ -318,11 +307,7 @@ class EnhancementsTab(QWidget):
         self._stats_prepend_check = QCheckBox("Show stats above description")
         self._stats_prepend_check.setChecked(AppSettings.get_stats_prepend())
         self._stats_prepend_check.setStyleSheet("font-size: 11px;")
-        self._stats_prepend_check.setToolTip(
-            "Put the generated stats block above the manufacturer/PR description "
-            "instead of below it (ships, components, weapons). Takes effect on "
-            "the next Generate Enhancements."
-        )
+        self._stats_prepend_check.setToolTip(tr("enhancements.stats_prepend_tooltip"))
         self._stats_prepend_check.toggled.connect(
             lambda checked: AppSettings.set_stats_prepend(checked)
         )
@@ -334,11 +319,7 @@ class EnhancementsTab(QWidget):
             AppSettings.get_standardize_earnable_ship_names()
         )
         self._standardize_ship_names_check.setStyleSheet("font-size: 11px;")
-        self._standardize_ship_names_check.setToolTip(
-            "Rename exec-hangar (PYX) and Wikelo (WIK) ship variants to include "
-            "a suffix that distinguishes them from the standard pledge-store version "
-            "(e.g. \"Anvil F8C Lightning PYX\"). Takes effect on the next Generate Enhancements."
-        )
+        self._standardize_ship_names_check.setToolTip(tr("enhancements.standardize_ship_names_tooltip"))
         self._standardize_ship_names_check.toggled.connect(
             lambda checked: AppSettings.set_standardize_earnable_ship_names(checked)
         )
@@ -350,9 +331,7 @@ class EnhancementsTab(QWidget):
         self._apply_categories_btn = QPushButton(tr("enhancements.apply_btn"))
         self._apply_categories_btn.setMaximumWidth(100)
         self._apply_categories_btn.setEnabled(False)
-        self._apply_categories_btn.setToolTip(
-            "Save category selection. Unchecked categories will be disabled."
-        )
+        self._apply_categories_btn.setToolTip(tr("enhancements.apply_categories_tooltip"))
         self._apply_categories_btn.clicked.connect(self._apply_category_changes)
         btn_row.addWidget(self._apply_categories_btn)
 
@@ -376,29 +355,30 @@ class EnhancementsTab(QWidget):
         self._set_generate_btn_dirty(self._compute_initial_enhancements_dirty())
         return group
 
-    # Tooltip shown when the button is clickable vs. greyed out — the
-    # disabled-state text is what a user hovering a gone-grey button most
-    # wants to know: "why can't I click this?"
-    _GENERATE_ENABLED_TOOLTIP = (
-        "Generate enhanced localization files from your game's Data.p4k.\n"
-        "DataForge data will be extracted automatically if not already cached\n"
-        "(first run takes a few minutes; subsequent runs are fast)."
-    )
-    _GENERATE_DISABLED_TOOLTIP = (
-        "Already up to date — nothing that affects the generated output "
-        "(categories, mission fields, stats/name options, Tag Builder) has "
-        "changed since the last run."
-    )
+    @staticmethod
+    def _mission_field_tooltip(field: str, label: str) -> str:
+        """Tooltip for one mission-detail-field checkbox. "ace" gets a
+        dedicated string (it shares its settings key with the unrelated
+        [ACE] title tag under General Tags, so the distinction needs
+        spelling out); every other field gets the generic template. Shared
+        by setup_ui() and retranslate_ui() so the two can't drift apart."""
+        if field == "ace":
+            return tr("enhancements.mission_field_ace_tooltip")
+        return tr("enhancements.mission_field_default_tooltip", label=label)
 
     def _set_generate_btn_dirty(self, dirty: bool) -> None:
         """Single chokepoint for the button's enabled state, tooltip, and
         text color so none of the three can drift apart. Red text signals
         "click me — something changed"; clean/disabled reverts to Qt's
-        default look."""
+        default look. The two tooltip variants are resolved via tr() here
+        (not cached class constants) so they always reflect the active
+        language — the disabled-state text is what a user hovering a
+        gone-grey button most wants to know: "why can't I click this?" """
         self._enhancements_dirty = dirty
         self._generate_enhancements_btn.setEnabled(dirty)
         self._generate_enhancements_btn.setToolTip(
-            self._GENERATE_ENABLED_TOOLTIP if dirty else self._GENERATE_DISABLED_TOOLTIP
+            tr("enhancements.generate_enabled_tooltip") if dirty
+            else tr("enhancements.generate_disabled_tooltip")
         )
         self._generate_enhancements_btn.setStyleSheet(
             f"color: {get_button_color('needs_apply')};" if dirty else ""
@@ -514,7 +494,7 @@ class EnhancementsTab(QWidget):
         prefix_row.addWidget(self._sort_prefix_label)
 
         self.favorite_prefix_combo = _NoScrollComboBox()
-        self.favorite_prefix_combo.setToolTip("Character prepended to favorited ship names so they sort to the top of the in-game ship list. Click Apply Prefix after changing to update all existing favorites.")
+        self.favorite_prefix_combo.setToolTip(tr("enhancements.favorite_prefix_tooltip"))
         self.favorite_prefix_combo.setSizeAdjustPolicy(
             QComboBox.SizeAdjustPolicy.AdjustToContents
         )
@@ -581,7 +561,7 @@ class EnhancementsTab(QWidget):
         self._rep_xp_label_input = QLineEdit()
         self._rep_xp_label_input.setText(AppSettings.get_rep_xp_label())
         self._rep_xp_label_input.setMaximumWidth(100)
-        self._rep_xp_label_input.setToolTip("Label for missions without a rank name (e.g. 'Rep: +100 XP')")
+        self._rep_xp_label_input.setToolTip(tr("enhancements.rep_xp_label_tooltip"))
         self._rep_xp_label_input.editingFinished.connect(self._save_rep_xp_label)
         grid.addWidget(self._rep_xp_label_input, 0, 5)
 
@@ -598,7 +578,7 @@ class EnhancementsTab(QWidget):
             if self._header_em_combo.itemData(i) == current_em:
                 self._header_em_combo.setCurrentIndex(i)
                 break
-        self._header_em_combo.setToolTip("Style for section headers: Underline (EM3) or Blue text (EM4)")
+        self._header_em_combo.setToolTip(tr("enhancements.header_em_tooltip"))
         self._header_em_combo.currentIndexChanged.connect(self._save_header_em_tag)
         grid.addWidget(self._header_em_combo, 1, 5)
 
@@ -627,22 +607,17 @@ class EnhancementsTab(QWidget):
             AppSettings.set_mission_header_em_tag(tag)
             self._mark_enhancements_dirty()
 
-    # Same enabled/disabled tooltip + red-text pattern as the other
-    # dirty-tracked buttons on this tab.
-    _PREFIX_ENABLED_TOOLTIP = (
-        "Save the selected prefix and update all existing favorites to use it"
-    )
-    _PREFIX_DISABLED_TOOLTIP = (
-        "Already applied — the selected prefix matches your current favorites."
-    )
-
     def _set_prefix_btn_dirty(self, dirty: bool) -> None:
         """Single chokepoint for the button's enabled state, tooltip, and
-        text color so none of the three can drift apart."""
+        text color so none of the three can drift apart. Same enabled/
+        disabled tooltip + red-text pattern as the other dirty-tracked
+        buttons on this tab; resolved via tr() here (not cached class
+        constants) so they always reflect the active language."""
         self._prefix_dirty = dirty
         self._apply_prefix_btn.setEnabled(dirty)
         self._apply_prefix_btn.setToolTip(
-            self._PREFIX_ENABLED_TOOLTIP if dirty else self._PREFIX_DISABLED_TOOLTIP
+            tr("enhancements.prefix_enabled_tooltip") if dirty
+            else tr("enhancements.prefix_disabled_tooltip")
         )
         self._apply_prefix_btn.setStyleSheet(
             f"color: {get_button_color('needs_apply')};" if dirty else ""
@@ -786,12 +761,7 @@ class EnhancementsTab(QWidget):
             AppSettings.get_tag_annotate_mission_descs()
         )
         self._annotate_mission_descs_cb.toggled.connect(self._mark_tag_dirty)
-        self._annotate_mission_descs_cb.setToolTip(
-            "When checked, the configured [CLASS-Sx-grade] tag is added "
-            "to component names inside the POTENTIAL BLUEPRINTS list of "
-            "mission descriptions. Uncheck for a cleaner mission body "
-            "while keeping the tag on the actual component names elsewhere."
-        )
+        self._annotate_mission_descs_cb.setToolTip(tr("enhancements.annotate_mission_descs_tooltip"))
         gl.addWidget(self._annotate_mission_descs_cb)
 
         btn_row = QHBoxLayout()
@@ -801,12 +771,7 @@ class EnhancementsTab(QWidget):
         self._set_tag_btn_dirty(False)
 
         self._reset_tag_btn = QPushButton(tr("enhancements.reset_defaults_btn"))
-        self._reset_tag_btn.setToolTip(
-            "Restore the default pattern, mapping, and ordering for every "
-            "category (Components / Missiles / Ship Weapons). Does not save "
-            "or regenerate until you click Save Tag Changes or Generate "
-            "Enhancements."
-        )
+        self._reset_tag_btn.setToolTip(tr("enhancements.reset_tag_tooltip"))
         self._reset_tag_btn.clicked.connect(self._reset_all_tag_builder_pages)
         btn_row.addWidget(self._reset_tag_btn)
 
@@ -823,7 +788,9 @@ class EnhancementsTab(QWidget):
         self._enhancements_group_box.setTitle(tr("enhancements.enhancements_group"))
         self._enhancements_desc_label.setText(tr("enhancements.enhancements_desc"))
         self._apply_categories_btn.setText(tr("enhancements.apply_btn"))
+        self._apply_categories_btn.setToolTip(tr("enhancements.apply_categories_tooltip"))
         self._generate_enhancements_btn.setText(tr("enhancements.generate_btn"))
+        self._set_generate_btn_dirty(self._enhancements_dirty)
         _CAT_KEYS = {
             "ships":       "enhancements.cat_desc_ships",
             "ship_items":  "enhancements.cat_desc_ship_items",
@@ -836,15 +803,27 @@ class EnhancementsTab(QWidget):
         for key, lbl in self._cat_desc_labels.items():
             if key in _CAT_KEYS:
                 lbl.setText(tr(_CAT_KEYS[key]))
+        for field, cb in self._mission_field_checkboxes.items():
+            label = dict(self._mission_field_labels).get(field, field)
+            cb.setToolTip(self._mission_field_tooltip(field, label))
+        self._stats_prepend_check.setToolTip(tr("enhancements.stats_prepend_tooltip"))
+        self._standardize_ship_names_check.setToolTip(tr("enhancements.standardize_ship_names_tooltip"))
         self._favorites_group_box.setTitle(tr("enhancements.favorites_group"))
         self._favorites_desc_label.setText(tr("enhancements.favorites_desc"))
         self._sort_prefix_label.setText(tr("enhancements.sort_prefix_label"))
+        self.favorite_prefix_combo.setToolTip(tr("enhancements.favorite_prefix_tooltip"))
         self._apply_prefix_btn.setText(tr("enhancements.apply_btn"))
+        self._set_prefix_btn_dirty(self._prefix_dirty)
+        self._rep_xp_label_input.setToolTip(tr("enhancements.rep_xp_label_tooltip"))
+        self._header_em_combo.setToolTip(tr("enhancements.header_em_tooltip"))
         self._tag_builder_group_box.setTitle(tr("enhancements.tag_builder_group"))
         self._tag_builder_desc_label.setText(tr("enhancements.tag_builder_desc"))
         self._annotate_mission_descs_cb.setText(tr("enhancements.annotate_mission_descs_cb"))
+        self._annotate_mission_descs_cb.setToolTip(tr("enhancements.annotate_mission_descs_tooltip"))
         self._apply_tag_btn.setText(tr("enhancements.apply_tag_changes_btn"))
+        self._set_tag_btn_dirty(self._tag_dirty)
         self._reset_tag_btn.setText(tr("enhancements.reset_defaults_btn"))
+        self._reset_tag_btn.setToolTip(tr("enhancements.reset_tag_tooltip"))
 
     def _persist_tag_builder_state(self) -> None:
         """Save every Tag Builder page's TagConfig plus the annotate-descs
@@ -866,23 +845,17 @@ class EnhancementsTab(QWidget):
             AppSettings.set_tag_annotate_mission_descs(annotate_cb.isChecked())
         logger.info("Tag Builder: saved configs for %s", ", ".join(pages))
 
-    # Same enabled/disabled tooltip pattern as Generate Enhancements above.
-    _TAG_ENABLED_TOOLTIP = (
-        "Save the Components / Missiles / Ship Weapons tag configs and "
-        "re-run the enhancement generator. New tags appear in-game after "
-        "the next Apply Enhancements."
-    )
-    _TAG_DISABLED_TOOLTIP = (
-        "Already saved — no Tag Builder changes since the last save."
-    )
-
     def _set_tag_btn_dirty(self, dirty: bool) -> None:
         """Single chokepoint for the button's enabled state, tooltip, and
-        text color so none of the three can drift apart."""
+        text color so none of the three can drift apart. Same enabled/
+        disabled tooltip pattern as Generate Enhancements; resolved via
+        tr() here (not cached class constants) so they always reflect
+        the active language."""
         self._tag_dirty = dirty
         self._apply_tag_btn.setEnabled(dirty)
         self._apply_tag_btn.setToolTip(
-            self._TAG_ENABLED_TOOLTIP if dirty else self._TAG_DISABLED_TOOLTIP
+            tr("enhancements.tag_enabled_tooltip") if dirty
+            else tr("enhancements.tag_disabled_tooltip")
         )
         self._apply_tag_btn.setStyleSheet(
             f"color: {get_button_color('needs_apply')};" if dirty else ""

--- a/src/gui/filter_header.py
+++ b/src/gui/filter_header.py
@@ -86,7 +86,7 @@ class FilterHeaderView(QHeaderView):
                 continue
             editor = QLineEdit(self)
             editor.setObjectName("columnFilter")
-            editor.setPlaceholderText(f"Filter {name.lower()}…")
+            editor.setPlaceholderText(tr("strings_tab.column_filter_placeholder", column=name.lower()))
             editor.setToolTip(tr("strings_tab.column_filter_tooltip", column=name))
             editor.setClearButtonEnabled(True)
             editor.addAction(self._search_icon, QLineEdit.ActionPosition.LeadingPosition)
@@ -110,7 +110,7 @@ class FilterHeaderView(QHeaderView):
             if editor is None:
                 continue
             name = names[i] if i < len(names) else ""
-            editor.setPlaceholderText(f"Filter {name.lower()}…")
+            editor.setPlaceholderText(tr("strings_tab.column_filter_placeholder", column=name.lower()))
             editor.setToolTip(tr("strings_tab.column_filter_tooltip", column=name))
 
     def clear_all(self):

--- a/src/gui/filter_header.py
+++ b/src/gui/filter_header.py
@@ -4,6 +4,8 @@ from PyQt6.QtCore import Qt, QTimer, QEvent, pyqtSignal, QSize, QRect, QPoint
 from PyQt6.QtGui import QColor, QIcon, QPainter, QPalette, QPen, QPixmap
 from PyQt6.QtWidgets import QHeaderView, QLineEdit, QStyleOptionHeader, QStyle
 
+from src.utils.i18n import tr
+
 
 # Resting-border alpha used to approximate a 1.5px-feeling stroke without
 # leaving the 2px integer grid that QSS borders require. ~60% opacity reads
@@ -85,9 +87,7 @@ class FilterHeaderView(QHeaderView):
             editor = QLineEdit(self)
             editor.setObjectName("columnFilter")
             editor.setPlaceholderText(f"Filter {name.lower()}…")
-            editor.setToolTip(
-                f"Filter the {name} column. Filters across columns combine with AND."
-            )
+            editor.setToolTip(tr("strings_tab.column_filter_tooltip", column=name))
             editor.setClearButtonEnabled(True)
             editor.addAction(self._search_icon, QLineEdit.ActionPosition.LeadingPosition)
             editor.textChanged.connect(self._on_text_changed)
@@ -111,6 +111,7 @@ class FilterHeaderView(QHeaderView):
                 continue
             name = names[i] if i < len(names) else ""
             editor.setPlaceholderText(f"Filter {name.lower()}…")
+            editor.setToolTip(tr("strings_tab.column_filter_tooltip", column=name))
 
     def clear_all(self):
         """Clear every filter input without triggering per-keystroke signals."""

--- a/src/gui/import_dialog.py
+++ b/src/gui/import_dialog.py
@@ -59,12 +59,12 @@ class ImportConflictDialog(QDialog):
         # Bulk action buttons
         button_row = QHBoxLayout()
         keep_all_btn = QPushButton(tr("import_dialog.keep_all_btn"))
-        keep_all_btn.setToolTip("Resolve every conflict by keeping your existing value and discarding the imported one.")
+        keep_all_btn.setToolTip(tr("import_dialog.keep_all_tooltip"))
         keep_all_btn.clicked.connect(self._keep_all)
         button_row.addWidget(keep_all_btn)
 
         import_all_btn = QPushButton(tr("import_dialog.import_all_btn"))
-        import_all_btn.setToolTip("Resolve every conflict by accepting the imported value and overwriting your existing one.")
+        import_all_btn.setToolTip(tr("import_dialog.import_all_tooltip"))
         import_all_btn.clicked.connect(self._import_all)
         button_row.addWidget(import_all_btn)
 

--- a/src/gui/log_tab.py
+++ b/src/gui/log_tab.py
@@ -86,7 +86,7 @@ class LogTab(QWidget):
         self._min_level_label = QLabel(tr("log.min_level_label"))
         toolbar.addWidget(self._min_level_label)
         self._level_combo = QComboBox()
-        self._level_combo.setToolTip("Minimum severity to display. Entries below the selected level are hidden (DEBUG < INFO < WARNING < ERROR).")
+        self._level_combo.setToolTip(tr("log.min_level_tooltip"))
         for level, name in [
             (logging.DEBUG,   "DEBUG"),
             (logging.INFO,    "INFO"),
@@ -101,7 +101,7 @@ class LogTab(QWidget):
         toolbar.addSpacing(16)
 
         self._autoscroll_cb = QCheckBox(tr("log.auto_scroll_check"))
-        self._autoscroll_cb.setToolTip("Automatically scroll to the newest log entry as it arrives. Turn off to pin the view while inspecting older lines.")
+        self._autoscroll_cb.setToolTip(tr("log.auto_scroll_tooltip"))
         self._autoscroll_cb.setChecked(True)
         toolbar.addWidget(self._autoscroll_cb)
 
@@ -109,13 +109,13 @@ class LogTab(QWidget):
 
         self._clear_btn = QPushButton(tr("log.clear_btn"))
         self._clear_btn.setMaximumWidth(70)
-        self._clear_btn.setToolTip("Clear the on-screen log buffer. The session log file on disk is unaffected.")
+        self._clear_btn.setToolTip(tr("log.clear_tooltip"))
         self._clear_btn.clicked.connect(self._clear)
         toolbar.addWidget(self._clear_btn)
 
         self._export_btn = QPushButton(tr("log.export_btn"))
         self._export_btn.setMaximumWidth(130)
-        self._export_btn.setToolTip("Save the current log buffer to a .log file — useful when filing a bug report.")
+        self._export_btn.setToolTip(tr("log.export_tooltip"))
         self._export_btn.clicked.connect(self._export)
         toolbar.addWidget(self._export_btn)
 
@@ -144,9 +144,13 @@ class LogTab(QWidget):
     def retranslate_ui(self) -> None:
         """Re-apply tr() to every text-bearing widget after a language switch."""
         self._min_level_label.setText(tr("log.min_level_label"))
+        self._level_combo.setToolTip(tr("log.min_level_tooltip"))
         self._autoscroll_cb.setText(tr("log.auto_scroll_check"))
+        self._autoscroll_cb.setToolTip(tr("log.auto_scroll_tooltip"))
         self._clear_btn.setText(tr("log.clear_btn"))
+        self._clear_btn.setToolTip(tr("log.clear_tooltip"))
         self._export_btn.setText(tr("log.export_btn"))
+        self._export_btn.setToolTip(tr("log.export_tooltip"))
 
     # ── Handler lifecycle ─────────────────────────────────────────────────────
 

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -587,20 +587,20 @@ class MainWindow(QMainWindow):
         self.editor_btn = QPushButton(tr("toolbar.editor_btn"))
         self.editor_btn.setStyleSheet(f"background-color: {get_button_color('open')}; color: {get_button_text_color()}; font-weight: bold; padding: 6px;")
         self.editor_btn.setCheckable(True)
-        self.editor_btn.setToolTip("Toggle the side-docked String Editor, a larger canvas for editing the selected row's custom value")
+        self.editor_btn.setToolTip(tr("toolbar.editor_tooltip"))
         self.editor_btn.clicked.connect(self.show_editor_dock)
         button_layout.addWidget(self.editor_btn)
 
         self.help_btn = QPushButton(tr("toolbar.help_btn"))
         self.help_btn.setStyleSheet(f"background-color: {get_button_color('open')}; color: {get_button_text_color()}; font-weight: bold; padding: 6px;")
         self.help_btn.setCheckable(True)
-        self.help_btn.setToolTip("Toggle the Help side-panel")
+        self.help_btn.setToolTip(tr("toolbar.help_tooltip"))
         self.help_btn.clicked.connect(self.show_help)
         button_layout.addWidget(self.help_btn)
 
         self.tutorial_btn = QPushButton(tr("toolbar.tutorial_btn"))
         self.tutorial_btn.setStyleSheet(f"background-color: {get_button_color('open')}; color: {get_button_text_color()}; font-weight: bold; padding: 6px;")
-        self.tutorial_btn.setToolTip("Start the guided tour of Smart Citizen's workflow. Runs automatically on first launch; click here anytime to replay.")
+        self.tutorial_btn.setToolTip(tr("toolbar.tutorial_tooltip"))
         self.tutorial_btn.clicked.connect(self._start_tutorial)
         button_layout.addWidget(self.tutorial_btn)
 
@@ -612,10 +612,7 @@ class MainWindow(QMainWindow):
         self._action_restore_backup = more_menu.addAction(
             tr("toolbar.restore_backup_btn"), self.restore_backup
         )
-        self._action_restore_backup.setToolTip(
-            "Restore a previous global.ini from the backups folder. Up to 5 "
-            "timestamped backups are kept; the oldest is pruned when a new one is created."
-        )
+        self._action_restore_backup.setToolTip(tr("toolbar.restore_backup_tooltip"))
         more_menu.addSeparator()
         self._action_clear_loc = more_menu.addAction(tr("toolbar.menu_clear_localization"), self.clear_localization)
         self._action_clear_cache = more_menu.addAction(tr("toolbar.menu_clear_cache"), self.clear_cache)
@@ -630,10 +627,7 @@ class MainWindow(QMainWindow):
         self._action_test_plan = more_menu.addAction(
             tr("toolbar.menu_test_plan"), self.show_test_plan
         )
-        self._action_test_plan.setToolTip(
-            "Open the tester Test Plan: a checklist of what changed in this "
-            "release, with progress tracking and a report you can submit."
-        )
+        self._action_test_plan.setToolTip(tr("toolbar.test_plan_tooltip"))
         more_menu.addSeparator()
         # #180: jump to the simplified one-button view. Lives in the toolbar
         # (Advanced-only); the way back is the Simple page's own button.
@@ -641,16 +635,11 @@ class MainWindow(QMainWindow):
             tr("toolbar.menu_switch_to_simple"),
             lambda: self._apply_ui_mode(AppSettings.UI_MODE_SIMPLE),
         )
-        self._action_switch_to_simple.setToolTip(
-            "Switch to the simplified one-button view."
-        )
+        self._action_switch_to_simple.setToolTip(tr("toolbar.switch_to_simple_tooltip"))
 
         self.more_btn = QPushButton(tr("toolbar.more_btn"))
         self.more_btn.setStyleSheet(f"background-color: {get_button_color('clear')}; color: {get_button_text_color()}; font-weight: bold; padding: 6px;")
-        self.more_btn.setToolTip(
-            "More actions: restore a backup, clear localization or cache, "
-            "import or export, open the localization folder"
-        )
+        self.more_btn.setToolTip(tr("toolbar.more_tooltip"))
         self.more_btn.setMenu(more_menu)
         button_layout.addWidget(self.more_btn)
 
@@ -670,7 +659,7 @@ class MainWindow(QMainWindow):
         filter_layout.addWidget(self._category_label)
         self.category_combo = QComboBox()
         self.category_combo.setMinimumWidth(200)
-        self.category_combo.setToolTip("Filter rows by domain (Ships, Ship Items, Missions, Gear, Commodities, Journal, Other). Categories are derived from the loc-key prefix.")
+        self.category_combo.setToolTip(tr("filters.category_tooltip"))
         self.category_combo.currentTextChanged.connect(self.apply_filters)
         filter_layout.addWidget(self.category_combo)
 
@@ -688,23 +677,17 @@ class MainWindow(QMainWindow):
         ]:
             self.status_combo.addItem(tr(_key), userData=_internal)
         self.status_combo.setMaximumWidth(120)
-        self.status_combo.setToolTip(
-            "Filter by status. "
-            "Modified = you've set a Custom Value; "
-            "Enhanced = produced by Smart Citizen's enhancements pipeline (ship stats, mission rewards, etc.); "
-            "Unmodified = default text only; "
-            "New = key exists only in enhancements/user.ini, not in the base file."
-        )
+        self.status_combo.setToolTip(tr("filters.status_tooltip"))
         self.status_combo.currentTextChanged.connect(self.apply_filters)
         filter_layout.addWidget(self.status_combo)
 
         self.hide_unmodified_check = QCheckBox(tr("filters.hide_unmodified"))
-        self.hide_unmodified_check.setToolTip("Show only rows where you've set a Custom Value. Same as the Status filter's Modified option but togglable on its own.")
+        self.hide_unmodified_check.setToolTip(tr("filters.hide_unmodified_tooltip"))
         self.hide_unmodified_check.stateChanged.connect(self.apply_filters)
         filter_layout.addWidget(self.hide_unmodified_check)
 
         self.favorites_only_check = QCheckBox(tr("filters.favorites_only"))
-        self.favorites_only_check.setToolTip("Show only rows you've starred as favorites. Favorites get a configurable prefix prepended to their name so they sort to the top of the in-game list.")
+        self.favorites_only_check.setToolTip(tr("filters.favorites_only_tooltip"))
         self.favorites_only_check.stateChanged.connect(self.apply_filters)
         filter_layout.addWidget(self.favorites_only_check)
 
@@ -712,30 +695,30 @@ class MainWindow(QMainWindow):
         # [BP]/[BP?]; BP Descriptions keeps bodies with a POTENTIAL BLUEPRINTS
         # section. Checking both shows either.
         self.bp_titles_check = QCheckBox(tr("filters.bp_titles_only"))
-        self.bp_titles_check.setToolTip("Show only mission titles carrying the [BP] / [BP?] blueprint tag.")
+        self.bp_titles_check.setToolTip(tr("filters.bp_titles_only_tooltip"))
         self.bp_titles_check.stateChanged.connect(self.apply_filters)
         filter_layout.addWidget(self.bp_titles_check)
 
         self.bp_descs_check = QCheckBox(tr("filters.bp_descs_only"))
-        self.bp_descs_check.setToolTip("Show only mission descriptions containing a POTENTIAL BLUEPRINTS section.")
+        self.bp_descs_check.setToolTip(tr("filters.bp_descs_only_tooltip"))
         self.bp_descs_check.stateChanged.connect(self.apply_filters)
         filter_layout.addWidget(self.bp_descs_check)
 
         self.grouped_sort_btn = QPushButton(tr("filters.group_sort_btn"))
-        self.grouped_sort_btn.setToolTip("Sort titles and descriptions together for the same entity")
+        self.grouped_sort_btn.setToolTip(tr("filters.group_sort_tooltip"))
         self.grouped_sort_btn.setMaximumWidth(100)
         self.grouped_sort_btn.clicked.connect(self._on_grouped_sort)
         filter_layout.addWidget(self.grouped_sort_btn)
 
         self.clear_filters_btn = QPushButton(tr("filters.clear_filters_btn"))
         self.clear_filters_btn.setMaximumWidth(100)
-        self.clear_filters_btn.setToolTip("Reset every filter (category, status, search, per-column boxes, checkboxes) so the full table is shown.")
+        self.clear_filters_btn.setToolTip(tr("filters.clear_filters_tooltip"))
         self.clear_filters_btn.clicked.connect(self.clear_filters)
         filter_layout.addWidget(self.clear_filters_btn)
 
         self.copy_filtered_btn = QPushButton(tr("filters.copy_filtered_btn"))
         self.copy_filtered_btn.setMaximumWidth(100)
-        self.copy_filtered_btn.setToolTip("Copy all visible filtered rows to clipboard (tab-separated)")
+        self.copy_filtered_btn.setToolTip(tr("filters.copy_filtered_tooltip"))
         self.copy_filtered_btn.clicked.connect(self.copy_filtered_to_clipboard)
         filter_layout.addWidget(self.copy_filtered_btn)
 
@@ -804,7 +787,7 @@ class MainWindow(QMainWindow):
             self.osiris_button.setFixedSize(base_pixmap.size())
 
             self.osiris_button.setCursor(QCursor(Qt.CursorShape.PointingHandCursor))
-            self.osiris_button.setToolTip("Open the Osiris DevWorks GitHub organization")
+            self.osiris_button.setToolTip(tr("toolbar.osiris_github_tooltip"))
             self.osiris_button.mousePressEvent = self.open_osiris_github
             footer_layout.addWidget(self.osiris_button)
 
@@ -835,7 +818,7 @@ class MainWindow(QMainWindow):
             self._eye_glow = None
             self._eye_fadeout = None
             self.osiris_button.setCursor(QCursor(Qt.CursorShape.PointingHandCursor))
-            self.osiris_button.setToolTip("Open the Osiris DevWorks GitHub organization")
+            self.osiris_button.setToolTip(tr("toolbar.osiris_github_tooltip"))
             self.osiris_button.mousePressEvent = self.open_osiris_github
             footer_layout.addWidget(self.osiris_button)
 
@@ -854,10 +837,7 @@ class MainWindow(QMainWindow):
         else:
             self.feedback_label.setText("Feedback, Bugs, & Feature Voting")
             self.feedback_label.setStyleSheet("font-size: 12px;")
-        self.feedback_label.setToolTip(
-            "Open the Smart Citizen Discord channel for feedback, bug reports, and voting on "
-            "upcoming features (requires joining the Osiris DevWorks Discord)."
-        )
+        self.feedback_label.setToolTip(tr("toolbar.feedback_tooltip"))
         self.feedback_label.setCursor(QCursor(Qt.CursorShape.PointingHandCursor))
         self.feedback_label.mousePressEvent = self.open_feedback_link
         footer_layout.addWidget(self.feedback_label)
@@ -993,7 +973,7 @@ class MainWindow(QMainWindow):
             "font-size: 11px; padding: 0 8px; color: #c9a961; font-weight: bold;"
         )
         self._app_version_indicator.setCursor(QCursor(Qt.CursorShape.PointingHandCursor))
-        self._app_version_indicator.setToolTip(f"Open release page for v{latest}")
+        self._app_version_indicator.setToolTip(tr("status_bar.open_release_page_tooltip", version=latest))
         self._refresh_update_indicator_texts()
 
         # Auto-update needs an installer asset on the release and a registry
@@ -1512,14 +1492,14 @@ class MainWindow(QMainWindow):
         already matches what's loaded. The :disabled selector is set
         explicitly so Qt's native greyed-out look doesn't wash out the
         color — the color itself is the signal here, not the enabled state.
-
         Same enabled/disabled tooltip pattern as the Enhancements tab's
-        Generate Enhancements / Save Tag Changes buttons."""
+        Generate Enhancements / Save Tag Changes buttons; resolved via tr()
+        here (not cached class constants) so it always reflects the active
+        language."""
         self._apply_dirty = dirty
         self.apply_btn.setEnabled(dirty)
         self.apply_btn.setToolTip(
-            tr("toolbar.apply_btn_enabled_tooltip") if dirty
-            else tr("toolbar.apply_btn_disabled_tooltip")
+            tr("toolbar.apply_enabled_tooltip") if dirty else tr("toolbar.apply_disabled_tooltip")
         )
         color = get_button_color("needs_apply" if dirty else "apply")
         text = get_button_text_color()
@@ -2491,7 +2471,7 @@ class MainWindow(QMainWindow):
         input_row.addWidget(line_edit)
 
         browse_btn = QPushButton("Browse...")
-        browse_btn.setToolTip("Pick a local .ini file to import.")
+        browse_btn.setToolTip(tr("dialogs.browse_ini_tooltip"))
         def browse():
             path, _ = QFileDialog.getOpenFileName(
                 dialog, "Select INI File", "", "INI Files (*.ini);;All Files (*)")
@@ -2708,11 +2688,11 @@ class MainWindow(QMainWindow):
         btn_row = QHBoxLayout()
         btn_row.setSpacing(4)
         em3_btn = QPushButton("Underline")
-        em3_btn.setToolTip("Underline the selected text (wraps it in <EM3>...</EM3>)")
+        em3_btn.setToolTip(tr("strings_tab.editor_underline_tooltip"))
         em3_btn.clicked.connect(lambda: self._editor_dock_wrap("EM3"))
         btn_row.addWidget(em3_btn)
         em4_btn = QPushButton("Highlight")
-        em4_btn.setToolTip("Highlight the selected text with color emphasis (wraps it in <EM4>...</EM4>)")
+        em4_btn.setToolTip(tr("strings_tab.editor_highlight_tooltip"))
         em4_btn.clicked.connect(lambda: self._editor_dock_wrap("EM4"))
         btn_row.addWidget(em4_btn)
         btn_row.addStretch()
@@ -3263,6 +3243,7 @@ class MainWindow(QMainWindow):
         state, version = getattr(self, "_update_check_state", (None, None))
         if state == "available":
             label.setText(tr("status_bar.update_indicator_available", current=current))
+            label.setToolTip(tr("status_bar.open_release_page_tooltip", version=version))
             self.config_tab.set_update_status(tr("status_bar.update_available", version=version))
         elif state == "up_to_date":
             label.setText(tr("status_bar.update_indicator_up_to_date", current=current))
@@ -3378,34 +3359,55 @@ class MainWindow(QMainWindow):
 
         # Toolbar buttons
         self.apply_btn.setText(tr("toolbar.apply_btn"))
+        self._set_apply_btn_dirty(self._apply_dirty)
         self.editor_btn.setText(tr("toolbar.editor_btn"))
+        self.editor_btn.setToolTip(tr("toolbar.editor_tooltip"))
         self.help_btn.setText(tr("toolbar.help_btn"))
+        self.help_btn.setToolTip(tr("toolbar.help_tooltip"))
         self.tutorial_btn.setText(tr("toolbar.tutorial_btn"))
+        self.tutorial_btn.setToolTip(tr("toolbar.tutorial_tooltip"))
         self.more_btn.setText(tr("toolbar.more_btn"))
+        self.more_btn.setToolTip(tr("toolbar.more_tooltip"))
 
         # More-menu actions
         self._action_restore_backup.setText(tr("toolbar.restore_backup_btn"))
+        self._action_restore_backup.setToolTip(tr("toolbar.restore_backup_tooltip"))
         self._action_clear_loc.setText(tr("toolbar.menu_clear_localization"))
         self._action_clear_cache.setText(tr("toolbar.menu_clear_cache"))
         self._action_import_ini.setText(tr("toolbar.menu_import_ini"))
         self._action_export_ini.setText(tr("toolbar.menu_export_ini"))
         self._action_open_loc_dir.setText(tr("toolbar.open_loc_dir_btn"))
         self._action_test_plan.setText(tr("toolbar.menu_test_plan"))
+        self._action_test_plan.setToolTip(tr("toolbar.test_plan_tooltip"))
         self._action_switch_to_simple.setText(tr("toolbar.menu_switch_to_simple"))
+        self._action_switch_to_simple.setToolTip(tr("toolbar.switch_to_simple_tooltip"))
+
+        # Footer
+        self.osiris_button.setToolTip(tr("toolbar.osiris_github_tooltip"))
+        self.feedback_label.setToolTip(tr("toolbar.feedback_tooltip"))
 
         # Simple-mode page (#180)
         self.simple_page.retranslate_ui()
 
         # Filter row
         self._category_label.setText(tr("filters.category_label"))
+        self.category_combo.setToolTip(tr("filters.category_tooltip"))
         self._status_label.setText(tr("filters.status_label"))
+        self.status_combo.setToolTip(tr("filters.status_tooltip"))
         self.hide_unmodified_check.setText(tr("filters.hide_unmodified"))
+        self.hide_unmodified_check.setToolTip(tr("filters.hide_unmodified_tooltip"))
         self.favorites_only_check.setText(tr("filters.favorites_only"))
+        self.favorites_only_check.setToolTip(tr("filters.favorites_only_tooltip"))
         self.bp_titles_check.setText(tr("filters.bp_titles_only"))
+        self.bp_titles_check.setToolTip(tr("filters.bp_titles_only_tooltip"))
         self.bp_descs_check.setText(tr("filters.bp_descs_only"))
+        self.bp_descs_check.setToolTip(tr("filters.bp_descs_only_tooltip"))
         self.grouped_sort_btn.setText(tr("filters.group_sort_btn"))
+        self.grouped_sort_btn.setToolTip(tr("filters.group_sort_tooltip"))
         self.clear_filters_btn.setText(tr("filters.clear_filters_btn"))
+        self.clear_filters_btn.setToolTip(tr("filters.clear_filters_tooltip"))
         self.copy_filtered_btn.setText(tr("filters.copy_filtered_btn"))
+        self.copy_filtered_btn.setToolTip(tr("filters.copy_filtered_tooltip"))
 
         # Status combo display text (userData internal values are preserved)
         self.status_combo.blockSignals(True)
@@ -4042,9 +4044,9 @@ class MainWindow(QMainWindow):
         button_row = QHBoxLayout()
         generate_btn = QPushButton("Generate")
         generate_btn.setDefault(True)
-        generate_btn.setToolTip("Run the DataForge extraction + enhancements pipeline now. Takes a few minutes the first time.")
+        generate_btn.setToolTip(tr("dialogs.generate_now_tooltip"))
         skip_btn = QPushButton("Skip")
-        skip_btn.setToolTip("Continue without generating enhancements. You can run it later from the Enhancements tab.")
+        skip_btn.setToolTip(tr("dialogs.skip_generate_tooltip"))
 
         generate_btn.clicked.connect(dialog.accept)
         skip_btn.clicked.connect(dialog.reject)
@@ -4278,7 +4280,7 @@ class MainWindow(QMainWindow):
             standardize_earnable_ship_names=AppSettings.get_standardize_earnable_ship_names(),
             language=language,
         )
-        self.enhancements_tab.set_operation_running("Generating enhancements…")
+        self.enhancements_tab.set_operation_running(tr("enhancements.generating_enhancements_tooltip"))
         self.statusBar().showMessage("Generating enhancements in background…")
 
         enhancements_label = (
@@ -4371,7 +4373,7 @@ class MainWindow(QMainWindow):
         forge_dir   = AppSettings.get_dataforge_cache_dir()
 
         self._forge_worker = DataForgeExtractWorker(p4k_path, unp4k_exe, unforge_exe, forge_dir)
-        self.enhancements_tab.set_operation_running("Extracting DataForge from Data.p4k…")
+        self.enhancements_tab.set_operation_running(tr("enhancements.extracting_dataforge_tooltip"))
         self.statusBar().showMessage("Extracting DataForge in background — this takes several minutes…")
 
         self._forge_progress_dialog = AnimatedProgressDialog(

--- a/src/gui/tag_mapping_dialog.py
+++ b/src/gui/tag_mapping_dialog.py
@@ -74,7 +74,7 @@ class TagMappingDialog(QDialog):
 
         button_row = QHBoxLayout()
         reset_btn = QPushButton(tr("tag_mapping_dialog.reset_btn"))
-        reset_btn.setToolTip("Restore every cell in this mapping table to the built-in Smart Citizen defaults.")
+        reset_btn.setToolTip(tr("tag_mapping_dialog.reset_tooltip"))
         reset_btn.clicked.connect(self._reset_to_defaults)
         button_row.addWidget(reset_btn)
         button_row.addStretch()


### PR DESCRIPTION
## Summary
- Moves every hardcoded English tooltip across the app (Config, Enhancements, Blueprint Tracker, main window, filter header, import dialog, log tab, tag mapping dialog) into the `tr()` i18n system, with ~292 new keys per language translated into French, Portuguese-BR, and Spanish.

## Stacking note — merge this one LAST
The tooltip pass covers widgets introduced by the other open PRs, so this branch is **stacked on #232 (Mission Titles redesign), #233 (Blueprint Tracker), and #235 (Medical Consumables)** — their commits appear in this PR's diff until they merge. Merge those three first and this PR's diff collapses to just the tooltip/i18n work.

## Testing
- Full suite green on this branch (1102 passed, 16 skipped); all four `ui.json` files parse; app launch smoke test clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)