### PR TITLE
Fix: guard installer language write-back against unrecognized saved value

### DIFF
--- a/installer.iss
+++ b/installer.iss
@@ -726,16 +726,22 @@ begin
     the chosen language rather than relying on the app's English fallback.
     Values here must stay in sync with the folder names under languages/.
 
-    Exception: skip the write entirely when the saved value didn't match any
-    option this page knows about (LanguageChoiceUnknownSaved) — the page
-    falls back to displaying English in that case, and an always-write would
+    Exception: skip the write when the saved value didn't match any option
+    this page knows about (LanguageChoiceUnknownSaved) AND the selection is
+    still sitting at the pre-selected default (index 0) — the page falls
+    back to displaying English in that case, and an always-write would
     silently downgrade the user's real (just-unrecognized) language back to
     English, both on an interactive upgrade and on a silent auto-update
-    install where nobody sees the page to correct it. Worst case with the
-    guard: the page shows English pre-selected but the saved value is left
-    untouched. }
-  if LanguageChoiceUnknownSaved then
-    Log('Skipped rewriting selected_language: saved value matched no known option, left unchanged.')
+    install where nobody sees the page to correct it. The index-0 check
+    matters: on an INTERACTIVE upgrade the user still sees the page and can
+    actively move the selection off English to a real choice, and that
+    explicit pick must win — the flag only describes the pre-selection
+    state, not anything the user did afterward. Worst case with the guard:
+    a user who deliberately re-picks English while their saved value is
+    unknown stays on the unknown value (the safe direction — they can
+    switch in-app, and this never destroys a value it doesn't understand). }
+  if LanguageChoiceUnknownSaved and (LanguageChoicePage.SelectedValueIndex = 0) then
+    Log('Skipped rewriting selected_language: saved value matched no known option and selection was left at the default, left unchanged.')
   else
   begin
     case LanguageChoicePage.SelectedValueIndex of

--- a/installer.iss
+++ b/installer.iss
@@ -83,6 +83,15 @@ var
     language selector. Options must stay in sync with the non-stub folders
     under languages/ (AppSettings.get_available_languages()). }
   LanguageChoicePage: TInputOptionWizardPage;
+  { True when a saved selected_language value was found but didn't match any
+    of the known LanguageChoicePage options below. Guards the always-write in
+    WriteInstallerChoicesToRegistry: without it, an upgrade install whose
+    saved value has fallen out of sync with this page's option list (e.g. a
+    5th language shipped in the app but not added here yet) would silently
+    overwrite the user's real saved value with 'english', since the page
+    itself falls back to displaying English (index 0) for an unrecognized
+    value. See #236 review discussion. }
+  LanguageChoiceUnknownSaved: Boolean;
 
 function IsAutoUpdate(): Boolean;
 begin
@@ -715,19 +724,33 @@ begin
   { App UI/string language, matching AppSettings.SELECTED_LANGUAGE. Always
     written (not just on a non-English choice) so a fresh install opens in
     the chosen language rather than relying on the app's English fallback.
-    Values here must stay in sync with the folder names under languages/. }
-  case LanguageChoicePage.SelectedValueIndex of
-    1: RegWriteStringValue(HKCU,
-         'Software\Osiris DevWorks\Smart Citizen', 'selected_language', 'french');
-    2: RegWriteStringValue(HKCU,
-         'Software\Osiris DevWorks\Smart Citizen', 'selected_language', 'portuguese_br');
-    3: RegWriteStringValue(HKCU,
-         'Software\Osiris DevWorks\Smart Citizen', 'selected_language', 'spanish');
+    Values here must stay in sync with the folder names under languages/.
+
+    Exception: skip the write entirely when the saved value didn't match any
+    option this page knows about (LanguageChoiceUnknownSaved) — the page
+    falls back to displaying English in that case, and an always-write would
+    silently downgrade the user's real (just-unrecognized) language back to
+    English, both on an interactive upgrade and on a silent auto-update
+    install where nobody sees the page to correct it. Worst case with the
+    guard: the page shows English pre-selected but the saved value is left
+    untouched. }
+  if LanguageChoiceUnknownSaved then
+    Log('Skipped rewriting selected_language: saved value matched no known option, left unchanged.')
   else
-    RegWriteStringValue(HKCU,
-      'Software\Osiris DevWorks\Smart Citizen', 'selected_language', 'english');
+  begin
+    case LanguageChoicePage.SelectedValueIndex of
+      1: RegWriteStringValue(HKCU,
+           'Software\Osiris DevWorks\Smart Citizen', 'selected_language', 'french');
+      2: RegWriteStringValue(HKCU,
+           'Software\Osiris DevWorks\Smart Citizen', 'selected_language', 'portuguese_br');
+      3: RegWriteStringValue(HKCU,
+           'Software\Osiris DevWorks\Smart Citizen', 'selected_language', 'spanish');
+    else
+      RegWriteStringValue(HKCU,
+        'Software\Osiris DevWorks\Smart Citizen', 'selected_language', 'english');
+    end;
+    Log('Saved selected_language to registry.');
   end;
-  Log('Saved selected_language to registry.');
 end;
 
 procedure CurStepChanged(CurStep: TSetupStep);
@@ -921,6 +944,7 @@ begin
     English (index 0) when nothing is saved yet or the saved value
     doesn't match a known option. }
   LanguageIndex := 0;
+  LanguageChoiceUnknownSaved := False;
   if RegQueryStringValue(HKCU, 'Software\Osiris DevWorks\Smart Citizen',
        'selected_language', SavedLanguage) then
   begin
@@ -929,7 +953,13 @@ begin
     else if CompareText(SavedLanguage, 'portuguese_br') = 0 then
       LanguageIndex := 2
     else if CompareText(SavedLanguage, 'spanish') = 0 then
-      LanguageIndex := 3;
+      LanguageIndex := 3
+    else if CompareText(SavedLanguage, 'english') <> 0 then
+      { A saved value that matches none of this page's options — e.g. a
+        newer app version shipped a 5th language before this installer's
+        option list caught up. Flag it so the write-back below leaves the
+        real saved value alone instead of clobbering it with 'english'. }
+      LanguageChoiceUnknownSaved := True;
   end;
   LanguageChoicePage.SelectedValueIndex := LanguageIndex;
 


### PR DESCRIPTION
Follow-up on [#236's review note](https://github.com/Osiris-DevWorks/smart-citizen/pull/236#discussion_r3583770395):

> There's a future trap in the always-write plus the unknown-value fallback. The day a fifth language ships in the app but this page's list lags behind... an upgrade install will read the user's saved value, fail to map it, pre-select English, and this block will overwrite their choice with 'english'. Silent installs through the auto-update chain hit the same path.

## Fix

Added a `LanguageChoiceUnknownSaved` flag: when the read side finds a saved `selected_language` value that doesn't match any of this page's known options (and isn't `'english'` either), it flags it instead of just silently defaulting to English. The write side then skips the write-back entirely when that flag is set, leaving the real saved value alone.

Worst case with the guard: the page shows English pre-selected for that one install, but the actual saved value in the registry survives untouched — matching Osiris's suggested behavior exactly.

## Test plan
- [x] `pytest tests/` — 1065 passed, 16 skipped (installer.iss has no Python test coverage; this is Inno Setup Pascal Script)
- [x] `ISCC.exe installer.iss` compiles clean end-to-end (installed Inno Setup 6.7.3 to verify) — the `[Code]` section including the new `LanguageChoiceUnknownSaved` guard parses/compiles with no errors, and a full compile against a stubbed `dist/SmartCitizen/` produces a valid Setup.exe
- [ ] Manual: install with a real build and a stubbed unrecognized `selected_language` registry value, confirm the value survives after setup runs — worth a real run before merge since I only verified the script compiles, not the runtime registry behavior end-to-end (but I'm unsure how to do this if I'm honest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
