### PR TITLE
Fix: FPS armor "Core" pieces showing in Blueprint Tracker's Other bucket

### DIFF
--- a/src/utils/blueprint_meta.py
+++ b/src/utils/blueprint_meta.py
@@ -32,8 +32,16 @@ from src.models.string_model import (
 # Extra armour-piece key tokens beyond string_model's set (which is tuned for
 # the strings-table category, not blueprint classification). Armour blueprints
 # are keyed by piece (backpack / undersuit / ...) with no "armor" token, so
-# without these they fell into the "Other" type bucket (#195).
-_ARMOR_EXTRA_WORDS = ("backpack", "undersuit", "flightsuit", "torso", "_legs", "_arms")
+# without these they fell into the "Other" type bucket (#195). "core" covers
+# the torso-platform piece of newer manufacturer-prefixed FPS armor sets
+# (e.g. item_Name_qrt_specialist_heavy_core_01_01_01 -> "Antium Core",
+# item_Name_kap_combat_light_core_01_01_01 -> "Geist Armor Core") whose keys
+# carry no "armor" token either — CIG's older sets do (cds_armor_heavy_core_*),
+# so this was inconsistent rather than universally missing. Safe against ship
+# components sharing the "core" word (LuxCore, CoolCore, ThermalCore) since
+# those carry a component-type-code prefix (POWR_/COOL_) resolved earlier by
+# component_type_from_key, which always wins first.
+_ARMOR_EXTRA_WORDS = ("backpack", "undersuit", "flightsuit", "torso", "_legs", "_arms", "core")
 from src.utils.owned_items import (
     BP_SECTION_HEADER,
     extract_bp_item_names,

--- a/src/utils/blueprint_meta.py
+++ b/src/utils/blueprint_meta.py
@@ -32,16 +32,23 @@ from src.models.string_model import (
 # Extra armour-piece key tokens beyond string_model's set (which is tuned for
 # the strings-table category, not blueprint classification). Armour blueprints
 # are keyed by piece (backpack / undersuit / ...) with no "armor" token, so
-# without these they fell into the "Other" type bucket (#195). "core" covers
-# the torso-platform piece of newer manufacturer-prefixed FPS armor sets
-# (e.g. item_Name_qrt_specialist_heavy_core_01_01_01 -> "Antium Core",
+# without these they fell into the "Other" type bucket (#195). "_core" (with
+# the leading underscore) covers the torso-platform piece of newer
+# manufacturer-prefixed FPS armor sets (e.g.
+# item_Name_qrt_specialist_heavy_core_01_01_01 -> "Antium Core",
 # item_Name_kap_combat_light_core_01_01_01 -> "Geist Armor Core") whose keys
 # carry no "armor" token either — CIG's older sets do (cds_armor_heavy_core_*),
-# so this was inconsistent rather than universally missing. Safe against ship
-# components sharing the "core" word (LuxCore, CoolCore, ThermalCore) since
-# those carry a component-type-code prefix (POWR_/COOL_) resolved earlier by
-# component_type_from_key, which always wins first.
-_ARMOR_EXTRA_WORDS = ("backpack", "undersuit", "flightsuit", "torso", "_legs", "_arms", "core")
+# so this was inconsistent rather than universally missing. Every armor key
+# this targets carries the underscore form (..._core_01_...), so "_core"
+# matches everything the bare word would while ruling out "score"-shaped
+# collisions (bare "core" is a substring of "score") and any future CamelCase
+# component name ("SomethingCore") whose prefix code isn't in the component
+# map yet — same underscore-guard shape already used for "_legs"/"_arms".
+# Ship components sharing the "core" word (LuxCore, CoolCore, ThermalCore)
+# were never actually at risk either way: they carry a component-type-code
+# prefix (POWR_/COOL_) resolved earlier by component_type_from_key, which
+# always wins first.
+_ARMOR_EXTRA_WORDS = ("backpack", "undersuit", "flightsuit", "torso", "_legs", "_arms", "_core")
 from src.utils.owned_items import (
     BP_SECTION_HEADER,
     extract_bp_item_names,

--- a/tests/test_blueprint_meta.py
+++ b/tests/test_blueprint_meta.py
@@ -87,6 +87,22 @@ def test_blueprint_type_buckets():
     assert blueprint_type_from_key(None) is None
 
 
+def test_blueprint_type_armor_core_pieces():
+    """FPS armor torso-platform pieces ("Core") reported showing up in the
+    Blueprint Tracker's "Other" bucket instead of "Armor". Newer
+    manufacturer-prefixed armor lines carry no "armor" token in the key at
+    all (unlike CIG's older sets, which do), only "core"."""
+    assert blueprint_type_from_key("item_Name_qrt_specialist_heavy_core_01_01_01") == "Armor"
+    assert blueprint_type_from_key("item_Name_kap_combat_light_core_01_01_01") == "Armor"
+    assert blueprint_type_from_key("item_Name_GRIN_utility_medium_core_01_01_01") == "Armor"
+    # Older sets that DO carry "armor" in the key still work (no regression).
+    assert blueprint_type_from_key("item_Name_cds_armor_heavy_core_01_02_01") == "Armor"
+    # Ship components sharing the bare "core" word must not be reclassified —
+    # their component-type-code prefix (POWR_/COOL_) wins first.
+    assert blueprint_type_from_key("item_NamePOWR_ACOM_S02_LuxCore_SCItem") == "Power Plant"
+    assert blueprint_type_from_key("item_NameCOOL_JUST_S02_CoolCore") == "Cooler"
+
+
 def test_clean_mission_title_strips_reward_tags():
     raw = ("Salvager Needed (Lrg. Special Order) "
            "<EM4>[BP]</EM4> <EM4>[150 REP]</EM4>")

--- a/tests/test_blueprint_meta.py
+++ b/tests/test_blueprint_meta.py
@@ -101,6 +101,12 @@ def test_blueprint_type_armor_core_pieces():
     # their component-type-code prefix (POWR_/COOL_) wins first.
     assert blueprint_type_from_key("item_NamePOWR_ACOM_S02_LuxCore_SCItem") == "Power Plant"
     assert blueprint_type_from_key("item_NameCOOL_JUST_S02_CoolCore") == "Cooler"
+    # The word is "_core" (underscore-prefixed), not bare "core" — a bare
+    # substring match would misclassify anything with "score"/"scoreboard" in
+    # the key ("score" contains "core"), and no armor set actually needs the
+    # bare form since every real armor "core" piece carries the underscore.
+    assert blueprint_type_from_key("item_Name_gys_scoreboard_01_01_01") is None
+    assert blueprint_type_from_key("item_Name_gys_highscore_01_01_01") is None
 
 
 def test_clean_mission_title_strips_reward_tags():


### PR DESCRIPTION
## Bug

A few FPS armor sets were showing up in the Blueprint Tracker's "Other" Type filter instead of "Armor".

## Root cause

Newer manufacturer-prefixed FPS armor sets (Antium, Testudo, Palatino, Aril, Geist, Overlord, and others) name their torso-platform piece "Core", and their loc keys carry no `"armor"` token at all:

```
item_Name_qrt_specialist_heavy_core_01_01_01  -> "Antium Core"
item_Name_kap_combat_light_core_01_01_01      -> "Geist Armor Core"
item_Name_GRIN_utility_medium_core_01_01_01   -> "Aril Core"
```

CIG's older armor lines *do* carry `"armor"` in the key (`item_Name_cds_armor_heavy_core_...`), so this was an inconsistency in CIG's own naming, not a universal gap. `blueprint_type_from_key` had no word covering `"core"`, so these pieces fell into `None` -> `"Other"`, while their Helmet/Backpack siblings from the exact same sets correctly showed as Armor (since `"helmet"` and `"backpack"` are already covered).

## Fix

Added `"core"` to `_ARMOR_EXTRA_WORDS` in `src/utils/blueprint_meta.py`.

Verified this is safe against ship components that also use "Core" in their display name (LuxCore, CoolCore, ThermalCore) — those carry a component-type-code prefix (`POWR_`/`COOL_`) that `component_type_from_key` already resolves *before* this word list is ever checked. Swept every `item_Name*` key in the real DataForge cache containing "core" (462 keys) — every single one is either an already-resolved ship component or an FPS armor torso piece; nothing else uses "core".

## Test plan
- [x] `pytest tests/` — 1066 passed, 16 skipped
- [x] New assertions in `test_blueprint_meta.py::test_blueprint_type_armor_core_pieces` covering multiple manufacturer prefixes, an older set that already had "armor" in the key (no regression), and both ship-component "Core" name collisions
- [x] Verified directly against the real DataForge cache: all previously-affected items (Antium Core, Testudo Core, Geist Armor Core, Palatino Core, Aril Core, TrueDef-Pro Core, Overlord Core Supernova) now resolve to "Armor"; ship power plant "LuxCore" still resolves to "Power Plant"

🤖 Generated with [Claude Code](https://claude.com/claude-code)