### PR TITLE
Fix: crossbow FPS weapons showing in Blueprint Tracker's Other bucket

### DIFF
--- a/src/models/string_model.py
+++ b/src/models/string_model.py
@@ -12,7 +12,7 @@ from functools import lru_cache
 
 _FPS_WEAPON_WORDS = (
     "_rifle_", "_pistol_", "_smg_", "_shotgun_", "_sniper_",
-    "_launcher_", "_lmg_", "_hmg_", "_knife_", "_multi_",
+    "_launcher_", "_lmg_", "_hmg_", "_knife_", "_multi_", "_crossbow_",
 )
 _ARMOR_GEAR_WORDS = (
     "armor", "helmet", "suit", "vest", "glasses", "_optics_", "_barrel_",

--- a/tests/test_blueprint_meta.py
+++ b/tests/test_blueprint_meta.py
@@ -69,6 +69,7 @@ def test_blueprint_type_buckets():
     # FPS weapon and armor by key tokens.
     assert blueprint_type_from_key("item_Name_rifle_behr_p4ar") == "FPS Weapon"
     assert blueprint_type_from_key("item_Name_pistol_gmni") == "FPS Weapon"
+    assert blueprint_type_from_key("item_Nameutfl_crossbow_ballistic_01") == "FPS Weapon"
     assert blueprint_type_from_key("item_Name_armor_rsi_torso") == "Armor"
     assert blueprint_type_from_key("item_Name_helmet_xyz") == "Armor"
     # Ship weapons (#212): uppercase manufacturer + weapon size designator,


### PR DESCRIPTION
## Bug

New crossbow FPS weapons showing under "Other" in the Blueprint Tracker's Type dropdown instead of "FPS Weapon".

## Root cause

Same shape as #244 (armor "Core" pieces) — CIG's crossbow weapon (`utfl_crossbow_ballistic_01`, plus `_mag`/`_short`/`_sota01` skin variants) has no matching token in `_FPS_WEAPON_WORDS`:

```
item_Nameutfl_crossbow_ballistic_01        -> falls through to None -> "Other"
item_Nameutfl_crossbow_ballistic_01_mag
item_Nameutfl_crossbow_ballistic_01_short
item_Nameutfl_crossbow_ballistic_01_sota01
```

## Fix

Added `"_crossbow_"` to `_FPS_WEAPON_WORDS` in `src/models/string_model.py` (shared between the main table's category classifier and `blueprint_meta.py`'s Blueprint Tracker Type classifier).

The main String Editor table's Category column was already unaffected — its broader lowercase-fallback rule already returned "Gear" for these keys regardless of the specific word-list match. Only the Blueprint Tracker's more granular Type bucket (which has no such fallback) was actually broken.

## Test plan
- [x] `pytest tests/` — 1065 passed, 16 skipped
- [x] New assertion in `test_blueprint_meta.py::test_blueprint_type_buckets`
- [x] Verified directly against the real DataForge cache: all 4 crossbow item keys now resolve to "FPS Weapon"

🤖 Generated with [Claude Code](https://claude.com/claude-code)