### PR TITLE
Fix: Blueprint Tracker false positives + Carnifex armor pieces in Other

### DIFF
--- a/src/utils/blueprint_meta.py
+++ b/src/utils/blueprint_meta.py
@@ -32,8 +32,16 @@ from src.models.string_model import (
 # Extra armour-piece key tokens beyond string_model's set (which is tuned for
 # the strings-table category, not blueprint classification). Armour blueprints
 # are keyed by piece (backpack / undersuit / ...) with no "armor" token, so
-# without these they fell into the "Other" type bucket (#195).
-_ARMOR_EXTRA_WORDS = ("backpack", "undersuit", "flightsuit", "torso", "_legs", "_arms")
+# without these they fell into the "Other" type bucket (#195). "core" covers
+# the torso-platform piece of newer manufacturer-prefixed FPS armor sets
+# (e.g. item_Name_qrt_specialist_heavy_core_01_01_01 -> "Antium Core",
+# item_Name_kap_combat_light_core_01_01_01 -> "Geist Armor Core") whose keys
+# carry no "armor" token either — CIG's older sets do (cds_armor_heavy_core_*),
+# so this was inconsistent rather than universally missing. Safe against ship
+# components sharing the "core" word (LuxCore, CoolCore, ThermalCore) since
+# those carry a component-type-code prefix (POWR_/COOL_) resolved earlier by
+# component_type_from_key, which always wins first.
+_ARMOR_EXTRA_WORDS = ("backpack", "undersuit", "flightsuit", "torso", "_legs", "_arms", "core")
 from src.utils.owned_items import (
     BP_SECTION_HEADER,
     extract_bp_item_names,

--- a/src/utils/blueprint_meta.py
+++ b/src/utils/blueprint_meta.py
@@ -41,7 +41,19 @@ from src.models.string_model import (
 # components sharing the "core" word (LuxCore, CoolCore, ThermalCore) since
 # those carry a component-type-code prefix (POWR_/COOL_) resolved earlier by
 # component_type_from_key, which always wins first.
-_ARMOR_EXTRA_WORDS = ("backpack", "undersuit", "flightsuit", "torso", "_legs", "_arms", "core")
+#
+# "gys_jacket" / "gys_pants" cover the Carnifex set's torso/leg pieces
+# (item_Name_gys_jacket_01_01_01 -> "Carnifex Armor Core",
+# item_Name_gys_pants_01_01_01 -> "Carnifex Armor Legs") — yet another
+# manufacturer-specific naming scheme with no "armor" token. Scoped to the
+# "gys_" prefix rather than bare "jacket"/"pants": those bare words match
+# hundreds of unrelated civilian wardrobe items (987/ALB/CTL/DMC fashion
+# lines) elsewhere in item_Name space, none of which are ever real blueprint
+# rewards today — but there's no need to gamble on that staying true.
+_ARMOR_EXTRA_WORDS = (
+    "backpack", "undersuit", "flightsuit", "torso", "_legs", "_arms", "core",
+    "gys_jacket", "gys_pants",
+)
 from src.utils.owned_items import (
     BP_SECTION_HEADER,
     extract_bp_item_names,

--- a/src/utils/blueprint_meta.py
+++ b/src/utils/blueprint_meta.py
@@ -32,16 +32,23 @@ from src.models.string_model import (
 # Extra armour-piece key tokens beyond string_model's set (which is tuned for
 # the strings-table category, not blueprint classification). Armour blueprints
 # are keyed by piece (backpack / undersuit / ...) with no "armor" token, so
-# without these they fell into the "Other" type bucket (#195). "core" covers
-# the torso-platform piece of newer manufacturer-prefixed FPS armor sets
-# (e.g. item_Name_qrt_specialist_heavy_core_01_01_01 -> "Antium Core",
+# without these they fell into the "Other" type bucket (#195). "_core" (with
+# the leading underscore) covers the torso-platform piece of newer
+# manufacturer-prefixed FPS armor sets (e.g.
+# item_Name_qrt_specialist_heavy_core_01_01_01 -> "Antium Core",
 # item_Name_kap_combat_light_core_01_01_01 -> "Geist Armor Core") whose keys
 # carry no "armor" token either — CIG's older sets do (cds_armor_heavy_core_*),
-# so this was inconsistent rather than universally missing. Safe against ship
-# components sharing the "core" word (LuxCore, CoolCore, ThermalCore) since
-# those carry a component-type-code prefix (POWR_/COOL_) resolved earlier by
-# component_type_from_key, which always wins first.
-_ARMOR_EXTRA_WORDS = ("backpack", "undersuit", "flightsuit", "torso", "_legs", "_arms", "core")
+# so this was inconsistent rather than universally missing. Every armor key
+# this targets carries the underscore form (..._core_01_...), so "_core"
+# matches everything the bare word would while ruling out "score"-shaped
+# collisions (bare "core" is a substring of "score") and any future CamelCase
+# component name ("SomethingCore") whose prefix code isn't in the component
+# map yet — same underscore-guard shape already used for "_legs"/"_arms".
+# Ship components sharing the "core" word (LuxCore, CoolCore, ThermalCore)
+# were never actually at risk either way: they carry a component-type-code
+# prefix (POWR_/COOL_) resolved earlier by component_type_from_key, which
+# always wins first.
+_ARMOR_EXTRA_WORDS = ("backpack", "undersuit", "flightsuit", "torso", "_legs", "_arms", "_core")
 from src.utils.owned_items import (
     BP_SECTION_HEADER,
     extract_bp_item_names,

--- a/src/utils/owned_items.py
+++ b/src/utils/owned_items.py
@@ -51,6 +51,33 @@ _WS_RE = re.compile(r"\s+")
 # no bullets to tag, so it passes through untouched.
 BP_SECTION_HEADER = "POTENTIAL BLUEPRINTS"
 _BP_HEADER_RE = re.compile(BP_SECTION_HEADER, re.IGNORECASE)
+# A genuine section header (POTENTIAL BLUEPRINTS, ITEM REWARDS, MISSION
+# DETAILS, BLUEPRINT DATA, ...) as opposed to a per-region sub-header inside
+# the blueprints list itself (e.g. <EM4>[Nyx]</EM4>,
+# <EM4>[Pyro RegionA, Pyro RegionB]</EM4>) — region labels always start with
+# "[" right after the tag, section headers never do.
+_SECTION_HEADER_RE = re.compile(r"<EM([34])>(?!\[)[^<]*</EM\1>")
+
+
+def _bp_section_span(value: str):
+    """Return (start, end) spanning just the POTENTIAL BLUEPRINTS section's
+    bullet content — from right after its header up to the next real section
+    header (or end of string). ``None`` when there's no such section.
+
+    Bounding the scan this way matters: CIG mission bodies sometimes carry a
+    stray "\\n- <word>" line in the flavor-text prose *before* the header
+    (e.g. "\\n- Stows\\n"), and a body with both a POTENTIAL BLUEPRINTS
+    section and a later ITEM REWARDS section (e.g. "\\n- Council Scrip")
+    puts a real bullet-shaped line after it too. Un-scoped bullet matching
+    swept both into the blueprint item set.
+    """
+    m = _BP_HEADER_RE.search(value)
+    if not m:
+        return None
+    start = m.end()
+    next_header = _SECTION_HEADER_RE.search(value, start)
+    end = next_header.start() if next_header else len(value)
+    return start, end
 
 
 def normalize_item_name(name: str) -> str:
@@ -79,11 +106,19 @@ def normalize_item_name(name: str) -> str:
 def extract_bp_item_names(value: str) -> set[str]:
     """Return the normalized item names in *value*'s POTENTIAL BLUEPRINTS list.
 
-    Empty when the value has no such section.
+    Empty when the value has no such section. Scoped to just that section's
+    span (see :func:`_bp_section_span`) so a stray prose bullet before the
+    header or a real bullet in a later section (ITEM REWARDS, ...) isn't
+    picked up as a blueprint item.
     """
-    if not value or not _BP_HEADER_RE.search(value):
+    if not value:
         return set()
-    return {normalize_item_name(m.group(1)) for m in _BULLET_RE.finditer(value)
+    span = _bp_section_span(value)
+    if span is None:
+        return set()
+    start, end = span
+    return {normalize_item_name(m.group(1))
+            for m in _BULLET_RE.finditer(value, start, end)
             if normalize_item_name(m.group(1))}
 
 
@@ -93,14 +128,21 @@ def apply_owned_to_value(value: str, owned: set[str]) -> str:
     Idempotent: any existing ``[Owned]`` tag is removed first, so the result is
     a pure function of (value, owned) and re-running never doubles the tag.
     Values without a POTENTIAL BLUEPRINTS section are returned unchanged (after
-    stripping stale owned tags, in case an item was just un-owned).
+    stripping stale owned tags, in case an item was just un-owned). Retagging
+    is scoped to just that section's span (see :func:`_bp_section_span`) so a
+    stray prose bullet before the header or a bullet in a later section can
+    never be mistaken for a blueprint item.
     """
     if not value:
         return value
     # Strip any prior owned tags first (handles un-owning + idempotency).
     value = _OWNED_STRIP_RE.sub("", value)
-    if not owned or not _BP_HEADER_RE.search(value):
+    if not owned:
         return value
+    span = _bp_section_span(value)
+    if span is None:
+        return value
+    start, end = span
 
     def _retag(m: re.Match) -> str:
         raw = m.group(1)
@@ -108,4 +150,4 @@ def apply_owned_to_value(value: str, owned: set[str]) -> str:
             return f"{_NL}- {raw}{_OWNED_TAG}"
         return m.group(0)
 
-    return _BULLET_RE.sub(_retag, value)
+    return value[:start] + _BULLET_RE.sub(_retag, value[start:end]) + value[end:]

--- a/tests/test_blueprint_meta.py
+++ b/tests/test_blueprint_meta.py
@@ -87,6 +87,22 @@ def test_blueprint_type_buckets():
     assert blueprint_type_from_key(None) is None
 
 
+def test_blueprint_type_armor_core_pieces():
+    """FPS armor torso-platform pieces ("Core") reported showing up in the
+    Blueprint Tracker's "Other" bucket instead of "Armor". Newer
+    manufacturer-prefixed armor lines carry no "armor" token in the key at
+    all (unlike CIG's older sets, which do), only "core"."""
+    assert blueprint_type_from_key("item_Name_qrt_specialist_heavy_core_01_01_01") == "Armor"
+    assert blueprint_type_from_key("item_Name_kap_combat_light_core_01_01_01") == "Armor"
+    assert blueprint_type_from_key("item_Name_GRIN_utility_medium_core_01_01_01") == "Armor"
+    # Older sets that DO carry "armor" in the key still work (no regression).
+    assert blueprint_type_from_key("item_Name_cds_armor_heavy_core_01_02_01") == "Armor"
+    # Ship components sharing the bare "core" word must not be reclassified —
+    # their component-type-code prefix (POWR_/COOL_) wins first.
+    assert blueprint_type_from_key("item_NamePOWR_ACOM_S02_LuxCore_SCItem") == "Power Plant"
+    assert blueprint_type_from_key("item_NameCOOL_JUST_S02_CoolCore") == "Cooler"
+
+
 def test_clean_mission_title_strips_reward_tags():
     raw = ("Salvager Needed (Lrg. Special Order) "
            "<EM4>[BP]</EM4> <EM4>[150 REP]</EM4>")

--- a/tests/test_blueprint_meta.py
+++ b/tests/test_blueprint_meta.py
@@ -103,6 +103,17 @@ def test_blueprint_type_armor_core_pieces():
     assert blueprint_type_from_key("item_NameCOOL_JUST_S02_CoolCore") == "Cooler"
 
 
+def test_blueprint_type_gys_jacket_and_pants():
+    """Carnifex set torso/leg pieces reported showing up in "Other" — the
+    "gys" manufacturer keys these as jacket/pants, not core/legs/armor."""
+    assert blueprint_type_from_key("item_Name_gys_jacket_01_01_01") == "Armor"
+    assert blueprint_type_from_key("item_Name_gys_pants_01_01_01") == "Armor"
+    # Scoped to "gys_" specifically — a bare "jacket"/"pants" match would also
+    # catch unrelated civilian wardrobe items from other manufacturers.
+    assert blueprint_type_from_key("item_Desc_987_Jacket_01_01_01") is None
+    assert blueprint_type_from_key("item_Desc_DMC_Pants_01_01_01") is None
+
+
 def test_clean_mission_title_strips_reward_tags():
     raw = ("Salvager Needed (Lrg. Special Order) "
            "<EM4>[BP]</EM4> <EM4>[150 REP]</EM4>")

--- a/tests/test_blueprint_meta.py
+++ b/tests/test_blueprint_meta.py
@@ -101,6 +101,12 @@ def test_blueprint_type_armor_core_pieces():
     # their component-type-code prefix (POWR_/COOL_) wins first.
     assert blueprint_type_from_key("item_NamePOWR_ACOM_S02_LuxCore_SCItem") == "Power Plant"
     assert blueprint_type_from_key("item_NameCOOL_JUST_S02_CoolCore") == "Cooler"
+    # The word is "_core" (underscore-prefixed), not bare "core" — a bare
+    # substring match would misclassify anything with "score"/"scoreboard" in
+    # the key ("score" contains "core"), and no armor set actually needs the
+    # bare form since every real armor "core" piece carries the underscore.
+    assert blueprint_type_from_key("item_Name_gys_scoreboard_01_01_01") is None
+    assert blueprint_type_from_key("item_Name_gys_highscore_01_01_01") is None
 
 
 def test_clean_mission_title_strips_reward_tags():

--- a/tests/test_owned_items.py
+++ b/tests/test_owned_items.py
@@ -24,6 +24,20 @@ _DESC = (
     "\\n\\n<EM3>MISSION DETAILS</EM3>\\n<EM4>Difficulty:</EM4> 3"
 )
 
+# A mission body reproducing the real false-positive bug: a stray "- Stows"
+# bullet in the prose BEFORE the header, multi-region sub-headers WITHIN the
+# blueprints section (which must still work), and a real bullet in a LATER
+# section (ITEM REWARDS' "- Council Scrip") that isn't a blueprint either.
+_DESC_WITH_FALSE_POSITIVES = (
+    "Handle this right and I'll give the main contractor Council Scrip."
+    "\\n\\n- Stows"
+    "\\n\\n<EM3>POTENTIAL BLUEPRINTS</EM3>"
+    "\\n<EM4>[Nyx]</EM4>\\n- Cryo-Star SL\\n- Kelvid"
+    "\\n\\n<EM4>[Pyro]</EM4>\\n- DuraJet\\n- ZapJet"
+    "\\n\\n<EM3>ITEM REWARDS</EM3>\\n- Council Scrip"
+    "\\n\\n<EM3>MISSION DETAILS</EM3>\\n<EM4>Difficulty:</EM4> 3"
+)
+
 
 class TestNormalize:
     def test_strips_leading_component_tag(self):
@@ -77,6 +91,24 @@ class TestExtract:
     def test_empty_value(self):
         assert extract_bp_item_names("") == set()
 
+    def test_excludes_prose_bullet_before_header_and_later_section_bullet(self):
+        """A stray "- Stows" line in the mission's flavor-text prose (before
+        the POTENTIAL BLUEPRINTS header) and a real bullet in a later ITEM
+        REWARDS section ("- Council Scrip") must not be picked up as
+        blueprint items — only bullets between the header and the next real
+        section boundary count."""
+        names = extract_bp_item_names(_DESC_WITH_FALSE_POSITIVES)
+        assert names == {"Cryo-Star SL", "Kelvid", "DuraJet", "ZapJet"}
+        assert "Stows" not in names
+        assert "Council Scrip" not in names
+
+    def test_multi_region_sub_headers_still_included(self):
+        """<EM4>[System]</EM4> per-region sub-headers inside the blueprints
+        section must not be mistaken for a section boundary."""
+        names = extract_bp_item_names(_DESC_WITH_FALSE_POSITIVES)
+        assert {"Cryo-Star SL", "Kelvid"} <= names  # [Nyx] region
+        assert {"DuraJet", "ZapJet"} <= names        # [Pyro] region
+
 
 class TestApply:
     def test_tags_only_owned_bullets(self):
@@ -108,6 +140,19 @@ class TestApply:
     def test_empty_owned_set_strips_and_returns(self):
         tagged = apply_owned_to_value(_DESC, {"Antium Core"})
         assert "[Owned]" not in apply_owned_to_value(tagged, set())
+
+    def test_does_not_retag_bullets_outside_the_blueprints_section(self):
+        """Even if a user's owned set happens to contain "Council Scrip" or
+        "Stows" (e.g. imported from a stray log line), retagging must stay
+        scoped to the POTENTIAL BLUEPRINTS section — a prose bullet or a
+        later-section bullet is never a real blueprint slot to tag."""
+        out = apply_owned_to_value(_DESC_WITH_FALSE_POSITIVES, {"Kelvid", "Council Scrip", "Stows"})
+        assert "- Kelvid <EM4>[Owned]</EM4>" in out
+        assert "- Council Scrip <EM4>[Owned]</EM4>" not in out
+        assert "- Stows <EM4>[Owned]</EM4>" not in out
+        # Untouched text still present, just not retagged.
+        assert "- Council Scrip" in out
+        assert "- Stows" in out
 
     def test_tags_bullets_with_nbsp_and_trailing_tag(self):
         # #222: a bullet carrying a non-breaking space or a trailing component


### PR DESCRIPTION
Stacks on #244 (fix/blueprint-armor-core-classification) since it extends the same `_ARMOR_EXTRA_WORDS` list — review as the diff on top of #244; #244's own commit already has its review there.

Two independent bugs reported together in the same screenshot.

## Bug 1: non-blueprint text leaking into the Blueprint Tracker

`extract_bp_item_names` / `apply_owned_to_value` matched every `\n- text` bullet **anywhere** in a mission body once a POTENTIAL BLUEPRINTS header existed, not just bullets inside that section. Two ways this leaked non-blueprint text in:

- A stray `- Stows` / `- Stow` / `- Stows out.` line in the mission's flavor-text prose, **before** the header (a CIG data quirk — looks like leftover fragment text).
- A real bullet from a **later** section (`- Council Scrip` / `- MG Scrip` under `ITEM REWARDS`), **after** the blueprints list.

### Fix

Scoped the bullet scan to the span between the `POTENTIAL BLUEPRINTS` header and the next genuine section header — distinguished from the per-region sub-headers that live *inside* the blueprints list itself (`<EM4>[Nyx]</EM4>`, `<EM4>[Pyro RegionA, Pyro RegionB]</EM4>`) by checking whether the tag's content starts with `"["` (sub-headers do, real section headers like `ITEM REWARDS`/`MISSION DETAILS` never do).

## Bug 2: Carnifex armor pieces in "Other"

"Carnifex Armor Core" / "Carnifex Armor Legs" (`item_Name_gys_jacket_01_01_01` / `item_Name_gys_pants_01_01_01`) fell into "Other" — yet another manufacturer-specific naming scheme (jacket/pants) with no "armor" token, same shape as #244's Core-piece fix.

### Fix

Added `"gys_jacket"` / `"gys_pants"` to `_ARMOR_EXTRA_WORDS`, scoped to the `"gys_"` prefix rather than bare `"jacket"`/`"pants"` — those bare words also match hundreds of unrelated civilian wardrobe items (987/ALB/CTL/DMC fashion lines) elsewhere in `item_Name` space. Confirmed none of those ever appear as real blueprint rewards today, but scoping to the manufacturer prefix removes the risk entirely rather than relying on that happening to stay true.

## Test plan
- [x] `pytest tests/` — 1070 passed, 16 skipped
- [x] New tests: `TestExtract`/`TestApply` false-positive scoping (prose bullet, later-section bullet, multi-region sub-headers still work) in `test_owned_items.py`; `test_blueprint_type_gys_jacket_and_pants` in `test_blueprint_meta.py`
- [x] Verified directly against the real DataForge cache: all 5 previously-leaking names (Council Scrip, MG Scrip, Stow, Stows, Stows out.) are gone from the extracted blueprint set; Carnifex Armor Core/Legs are still present and now correctly typed as "Armor"

🤖 Generated with [Claude Code](https://claude.com/claude-code)