### PR TITLE
[#251] Survive corrupt/non-UTF-8 bytes in base.ini and all state files

### DIFF
--- a/scripts/generate_enhancements_ini.py
+++ b/scripts/generate_enhancements_ini.py
@@ -149,19 +149,45 @@ OUTPUT_DIR = APP_CACHE_DIR
 
 # ── INI helpers ───────────────────────────────────────────────────────────────
 
+def _read_ini_text(path: Path) -> str:
+    """Read an INI file's text, tolerating non-UTF-8 content (#251).
+
+    base.ini is normally UTF-8 (with BOM) straight out of Data.p4k, but the
+    cached copy can stop being valid UTF-8 on a user's machine — re-saved by
+    an external editor in ANSI (legacy Notepad's default), mangled by a
+    sync/AV tool, or a community-translated base saved as ANSI. CIG's text
+    is full of characters that cp1252 encodes as single high bytes (é / ™ /
+    ° / em dash / non-breaking space — the reported crash was byte 0xA0, an
+    NBSP, on a stock English install), and any one of them is an invalid
+    UTF-8 start byte, so a strict decode crashed the whole enhancements
+    run. Fall back to cp1252 (errors="replace" guards its five undefined
+    bytes) rather than dying on the first non-UTF-8 byte.
+    """
+    raw = path.read_bytes()
+    try:
+        return raw.decode("utf-8-sig")
+    except UnicodeDecodeError as e:
+        logger.warning(f"{path} is not valid UTF-8 ({e}); decoding as Windows-1252")
+        if raw.startswith(b"\xef\xbb\xbf"):
+            raw = raw[3:]
+        return raw.decode("cp1252", errors="replace")
+
+
 def parse_ini(path: Path) -> dict[str, str]:
     result = {}
-    with open(path, encoding="utf-8-sig") as f:
-        for line in f:
-            line = line.rstrip("\r\n")
-            if not line.strip() or line.strip().startswith(";"):
-                continue
-            if "=" not in line:
-                continue
-            k, _, v = line.partition("=")
-            lookup_key = k.strip().split(",")[0].strip()
-            if lookup_key:
-                result[lookup_key] = v.strip()
+    # split('\n') + rstrip('\r'), NOT str.splitlines(): splitlines also
+    # breaks on U+2028/U+0085 etc., which a loc value could legitimately
+    # contain — file iteration never split on those and neither do we.
+    for line in _read_ini_text(path).split("\n"):
+        line = line.rstrip("\r")
+        if not line.strip() or line.strip().startswith(";"):
+            continue
+        if "=" not in line:
+            continue
+        k, _, v = line.partition("=")
+        lookup_key = k.strip().split(",")[0].strip()
+        if lookup_key:
+            result[lookup_key] = v.strip()
     return result
 
 

--- a/scripts/generate_enhancements_ini.py
+++ b/scripts/generate_enhancements_ini.py
@@ -149,28 +149,42 @@ OUTPUT_DIR = APP_CACHE_DIR
 
 # ── INI helpers ───────────────────────────────────────────────────────────────
 
+# Deletion table for counting high (non-ASCII) bytes at C speed: translating
+# with this removes every byte >= 0x80, so the length delta is the count.
+_HIGH_BYTES = bytes(range(0x80, 0x100))
+
+
 def _read_ini_text(path: Path) -> str:
     """Read an INI file's text, tolerating non-UTF-8 content (#251).
 
-    base.ini is normally UTF-8 (with BOM) straight out of Data.p4k, but the
-    cached copy can stop being valid UTF-8 on a user's machine — re-saved by
-    an external editor in ANSI (legacy Notepad's default), mangled by a
-    sync/AV tool, or a community-translated base saved as ANSI. CIG's text
-    is full of characters that cp1252 encodes as single high bytes (é / ™ /
-    ° / em dash / non-breaking space — the reported crash was byte 0xA0, an
-    NBSP, on a stock English install), and any one of them is an invalid
-    UTF-8 start byte, so a strict decode crashed the whole enhancements
-    run. Fall back to cp1252 (errors="replace" guards its five undefined
-    bytes) rather than dying on the first non-UTF-8 byte.
+    Mirror of src/parser/ini_parser._read_ini_text — duplicated so this
+    script stays stdlib+lxml-only for standalone runs (same shape as the
+    existing parse_ini/parse_ini_file parallelism); see that copy for the
+    full failure-shape rationale. In short: a strict decode crashed the
+    whole enhancements run on one corrupt byte (#251). A few corrupt bytes
+    in an otherwise-UTF-8 file get UTF-8 errors="replace" (a cp1252 decode
+    would mojibake every legitimate multi-byte character); a genuinely
+    ANSI/cp1252 file gets a cp1252 decode (a UTF-8 replace-decode would
+    destroy every high byte). Discriminated by whether the UTF-8
+    replacement count tracks the file's high-byte count.
     """
     raw = path.read_bytes()
     try:
         return raw.decode("utf-8-sig")
-    except UnicodeDecodeError as e:
-        logger.warning(f"{path} is not valid UTF-8 ({e}); decoding as Windows-1252")
-        if raw.startswith(b"\xef\xbb\xbf"):
-            raw = raw[3:]
-        return raw.decode("cp1252", errors="replace")
+    except UnicodeDecodeError:
+        pass
+    body = raw[3:] if raw.startswith(b"\xef\xbb\xbf") else raw
+    utf8_replaced = body.decode("utf-8", errors="replace")
+    bad = utf8_replaced.count("�")
+    high = len(body) - len(body.translate(None, _HIGH_BYTES))
+    if bad * 2 <= high:
+        logger.warning(
+            f"{path} is UTF-8 with {bad} corrupt byte(s) "
+            f"(of {high} non-ASCII); replaced with U+FFFD"
+        )
+        return utf8_replaced
+    logger.warning(f"{path} is not UTF-8 (looks ANSI); decoding as Windows-1252")
+    return body.decode("cp1252", errors="replace")
 
 
 def parse_ini(path: Path) -> dict[str, str]:
@@ -336,7 +350,9 @@ def _dataforge_cache_key(forge_dir: Path) -> str:
     if stamp.exists():
         try:
             return stamp.read_text(encoding="utf-8").strip()
-        except OSError:
+        except (OSError, ValueError):
+            # ValueError: a corrupt stamp raises UnicodeDecodeError (#251
+            # bug class) — fall through to the records-dir heuristic.
             pass
     records = forge_dir / "raw" / "libs" / "foundry" / "records"
     if records.exists():

--- a/src/merger/ini_merger.py
+++ b/src/merger/ini_merger.py
@@ -3,6 +3,7 @@ from functools import lru_cache
 from pathlib import Path
 from typing import Dict, List, Optional
 
+from src.utils.ini_io import read_ini_text
 from src.utils.perf import timed
 
 # Component type codes used to canonicalize item_name*/item_desc* key variants.
@@ -234,13 +235,31 @@ def merge_ini_files(
     output_path.parent.mkdir(parents=True, exist_ok=True)
 
     try:
-        with open(source_path, 'r', encoding='utf-8') as infile, \
-             open(output_path, 'w', encoding='utf-8') as outfile:
+        # read_ini_text (#251) tolerates non-UTF-8 content — the previous
+        # strict open() meant one corrupt byte in base.ini failed the whole
+        # Apply to Game. Normalize newlines to match the old open() default
+        # (universal newlines translated \r\n and \r to \n on read), then
+        # re-attach a trailing \n per line like file iteration yielded.
+        source_lines = (
+            read_ini_text(source_path)
+            .replace('\r\n', '\n').replace('\r', '\n')
+            .split('\n')
+        )
+        # split('\n') yields one trailing '' when the file ends with a
+        # newline — file iteration never yielded that empty last line.
+        if source_lines and source_lines[-1] == '':
+            trailing_newline = True
+            source_lines.pop()
+        else:
+            trailing_newline = False
 
-            for line in infile:
-                # Preserve line ending style, but work with stripped version
-                line_rstrip = line.rstrip('\n\r')
-                original_ending = line[len(line_rstrip):]
+        with open(output_path, 'w', encoding='utf-8') as outfile:
+            for i, line_rstrip in enumerate(source_lines):
+                # Match the old per-line shape: every line ended with '\n'
+                # except a final line with no trailing newline.
+                is_last = i == len(source_lines) - 1
+                original_ending = '\n' if (not is_last or trailing_newline) else ''
+                line = line_rstrip + original_ending
 
                 # Skip processing for comments and empty lines
                 if not line_rstrip.strip() or line_rstrip.strip().startswith(';'):

--- a/src/parser/ini_parser.py
+++ b/src/parser/ini_parser.py
@@ -10,6 +10,33 @@ from src.utils.perf import timed
 logger = logging.getLogger(__name__)
 
 
+def _read_ini_text(path: Path) -> str:
+    """Read an INI file's text, tolerating non-UTF-8 content (#251).
+
+    base.ini is normally UTF-8 (with BOM) straight out of Data.p4k, but the
+    cached copy can stop being valid UTF-8 on a user's machine — re-saved by
+    an external editor in ANSI (legacy Notepad's default), mangled by a
+    sync/AV tool, or a community-translated base saved as ANSI. CIG's text
+    is full of characters that cp1252 encodes as single high bytes (é / ™ /
+    ° / em dash / non-breaking space — the reported crash was byte 0xA0, an
+    NBSP, on a stock English install), and any one of them is an invalid
+    UTF-8 start byte. A strict streaming decode used to raise mid-iteration,
+    and the broad except below then returned a silently TRUNCATED result:
+    every key after the first bad byte vanished with only a log warning.
+    Decode the whole file up front instead, falling back to cp1252
+    (errors="replace" guards its five undefined bytes) so no entry is ever
+    dropped.
+    """
+    raw = path.read_bytes()
+    try:
+        return raw.decode("utf-8-sig")
+    except UnicodeDecodeError as e:
+        logger.warning(f"{path} is not valid UTF-8 ({e}); decoding as Windows-1252")
+        if raw.startswith(b"\xef\xbb\xbf"):
+            raw = raw[3:]
+        return raw.decode("cp1252", errors="replace")
+
+
 @timed
 def parse_ini_file(path: str | Path, *, strip_values: bool = True) -> Dict[str, str]:
     """Parse INI file line-by-line, preserving efficiency.
@@ -37,29 +64,31 @@ def parse_ini_file(path: str | Path, *, strip_values: bool = True) -> Dict[str, 
         return result
 
     try:
-        with open(path, 'r', encoding='utf-8-sig') as f:
-            for line in f:
-                line = line.rstrip('\n\r')
+        # split('\n') + rstrip('\r'), NOT str.splitlines(): splitlines also
+        # breaks on U+2028/U+0085 etc., which a loc value could legitimately
+        # contain — file iteration never split on those and neither do we.
+        for line in _read_ini_text(path).split('\n'):
+            line = line.rstrip('\r')
 
-                # Skip empty lines and comments
-                if not line.strip() or line.strip().startswith(';'):
-                    continue
+            # Skip empty lines and comments
+            if not line.strip() or line.strip().startswith(';'):
+                continue
 
-                # Split on first '=' only
-                if '=' not in line:
-                    continue
+            # Split on first '=' only
+            if '=' not in line:
+                continue
 
-                key, value = line.split('=', 1)
-                key = key.strip()
-                if strip_values:
-                    value = value.strip()
+            key, value = line.split('=', 1)
+            key = key.strip()
+            if strip_values:
+                value = value.strip()
 
-                if key:
-                    # Strip comma-based metadata suffix (e.g., "key,P" → "key")
-                    # This is used in some source files to track properties
-                    clean_key = key.split(',')[0].strip()
-                    if clean_key:
-                        result[clean_key] = value
+            if key:
+                # Strip comma-based metadata suffix (e.g., "key,P" → "key")
+                # This is used in some source files to track properties
+                clean_key = key.split(',')[0].strip()
+                if clean_key:
+                    result[clean_key] = value
     except Exception as e:
         logger.warning(f"Error parsing INI file {path}: {e}")
 

--- a/src/parser/ini_parser.py
+++ b/src/parser/ini_parser.py
@@ -5,36 +5,10 @@ from typing import Dict, List, Optional
 
 from src.models.string_model import StringEntry
 from src.merger.ini_merger import merge_sources_by_hierarchy
+from src.utils.ini_io import read_ini_text
 from src.utils.perf import timed
 
 logger = logging.getLogger(__name__)
-
-
-def _read_ini_text(path: Path) -> str:
-    """Read an INI file's text, tolerating non-UTF-8 content (#251).
-
-    base.ini is normally UTF-8 (with BOM) straight out of Data.p4k, but the
-    cached copy can stop being valid UTF-8 on a user's machine — re-saved by
-    an external editor in ANSI (legacy Notepad's default), mangled by a
-    sync/AV tool, or a community-translated base saved as ANSI. CIG's text
-    is full of characters that cp1252 encodes as single high bytes (é / ™ /
-    ° / em dash / non-breaking space — the reported crash was byte 0xA0, an
-    NBSP, on a stock English install), and any one of them is an invalid
-    UTF-8 start byte. A strict streaming decode used to raise mid-iteration,
-    and the broad except below then returned a silently TRUNCATED result:
-    every key after the first bad byte vanished with only a log warning.
-    Decode the whole file up front instead, falling back to cp1252
-    (errors="replace" guards its five undefined bytes) so no entry is ever
-    dropped.
-    """
-    raw = path.read_bytes()
-    try:
-        return raw.decode("utf-8-sig")
-    except UnicodeDecodeError as e:
-        logger.warning(f"{path} is not valid UTF-8 ({e}); decoding as Windows-1252")
-        if raw.startswith(b"\xef\xbb\xbf"):
-            raw = raw[3:]
-        return raw.decode("cp1252", errors="replace")
 
 
 @timed
@@ -67,7 +41,10 @@ def parse_ini_file(path: str | Path, *, strip_values: bool = True) -> Dict[str, 
         # split('\n') + rstrip('\r'), NOT str.splitlines(): splitlines also
         # breaks on U+2028/U+0085 etc., which a loc value could legitimately
         # contain — file iteration never split on those and neither do we.
-        for line in _read_ini_text(path).split('\n'):
+        # read_ini_text (#251) tolerates non-UTF-8 content; the previous
+        # strict streaming decode raised mid-iteration and the except below
+        # silently truncated the result at the first bad byte.
+        for line in read_ini_text(path).split('\n'):
             line = line.rstrip('\r')
 
             # Skip empty lines and comments

--- a/src/utils/dataforge_diff.py
+++ b/src/utils/dataforge_diff.py
@@ -23,12 +23,15 @@ from __future__ import annotations
 
 import hashlib
 import json
+import logging
 import os
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 from typing import Callable, Optional
 
 from src.utils.win_paths import win_long_path
+
+logger = logging.getLogger(__name__)
 
 MANIFEST_FILE = ".diff_manifest.json"
 
@@ -181,8 +184,16 @@ def dirty_categories(cache_dir: Path) -> Optional[set[str]]:
     if not manifest_file.exists():
         return None  # first run — regenerate everything
 
-    with open(manifest_file, encoding="utf-8") as f:
-        old: dict[str, dict] = json.load(f)
+    try:
+        with open(manifest_file, encoding="utf-8") as f:
+            old: dict[str, dict] = json.load(f)
+    except (OSError, ValueError) as e:
+        # ValueError covers both JSONDecodeError and UnicodeDecodeError — a
+        # corrupt manifest (#251 bug class) previously crashed the whole
+        # enhancements run. Treat it like a missing manifest: regenerate
+        # everything, and update_manifest rewrites a clean one afterwards.
+        logger.warning(f"Unreadable diff manifest {manifest_file} ({e}); regenerating all")
+        return None
 
     new = _build_snapshot(cache_dir)
 

--- a/src/utils/dataforge_patcher.py
+++ b/src/utils/dataforge_patcher.py
@@ -266,7 +266,9 @@ def load_locstring_workarounds(patch_root: Path) -> list[LocstringWorkaround]:
         try:
             with patch_file.open(encoding="utf-8") as f:
                 patch = json.load(f)
-        except (json.JSONDecodeError, OSError) as e:
+        except (ValueError, OSError) as e:
+            # ValueError covers both JSONDecodeError and UnicodeDecodeError
+            # (a patch file with corrupt bytes — #251 bug class).
             logger.warning(f"Could not parse {patch_file.name}: {e}")
             continue
         for entry in patch.get("locstring_workarounds", []):

--- a/src/utils/ini_io.py
+++ b/src/utils/ini_io.py
@@ -1,0 +1,65 @@
+"""Encoding-tolerant INI text reading (#251).
+
+base.ini is normally UTF-8 (with BOM) straight out of Data.p4k, but the
+cached copy can stop being clean UTF-8 on a user's machine. The #251 report
+(a stock English install; byte 0xA0 at one position in an otherwise-valid
+file, while a healthy install's extraction of the same LIVE data decodes
+perfectly) was machine-local corruption — possibly in the user's own
+Data.p4k, so re-extracting can reintroduce it. A file re-saved by an
+external editor in ANSI (legacy Notepad's default) is the other realistic
+shape. Strict decodes crashed the enhancements generator and Apply to Game,
+and silently truncated the strings table — a full blocker from one bad byte.
+
+Shared by ``src/parser/ini_parser.py`` and ``src/merger/ini_merger.py``.
+``scripts/generate_enhancements_ini.py`` carries its own mirror so it stays
+stdlib+lxml-only for standalone runs (same tolerated-duplication shape as
+CATEGORY_SUBTREES ↔ DATAFORGE_KEEP_SUBPATHS); keep the two in sync.
+"""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# Deletion table for counting high (non-ASCII) bytes at C speed: translating
+# with this removes every byte >= 0x80, so the length delta is the count.
+_HIGH_BYTES = bytes(range(0x80, 0x100))
+
+
+def read_ini_text(path: Path) -> str:
+    """Read an INI file's text, tolerating non-UTF-8 content.
+
+    The two realistic failure shapes need OPPOSITE fallbacks, so we pick by
+    measuring:
+
+    * A few corrupt bytes in an otherwise-UTF-8 file -> decode UTF-8 with
+      errors="replace". Only the corrupt byte degrades (to U+FFFD); a cp1252
+      decode here would instead mojibake every legitimate multi-byte
+      character in the file ("é" -> "Ã©", thousands of them).
+    * A genuinely ANSI/cp1252 file -> decode cp1252. Here it's reversed:
+      nearly EVERY high byte is an invalid UTF-8 start byte, so a UTF-8
+      replace-decode would destroy all of them.
+
+    Discriminator: in a real cp1252 file the replacement count tracks the
+    high-byte count (each high byte fails UTF-8 on its own); in corrupted
+    UTF-8 it's a tiny fraction (most high bytes sit inside valid multi-byte
+    sequences). Split at half.
+    """
+    raw = Path(path).read_bytes()
+    try:
+        return raw.decode("utf-8-sig")
+    except UnicodeDecodeError:
+        pass
+    body = raw[3:] if raw.startswith(b"\xef\xbb\xbf") else raw
+    utf8_replaced = body.decode("utf-8", errors="replace")
+    bad = utf8_replaced.count("�")
+    high = len(body) - len(body.translate(None, _HIGH_BYTES))
+    if bad * 2 <= high:
+        logger.warning(
+            f"{path} is UTF-8 with {bad} corrupt byte(s) "
+            f"(of {high} non-ASCII); replaced with U+FFFD"
+        )
+        return utf8_replaced
+    logger.warning(f"{path} is not UTF-8 (looks ANSI); decoding as Windows-1252")
+    return body.decode("cp1252", errors="replace")

--- a/src/utils/json_settings.py
+++ b/src/utils/json_settings.py
@@ -76,7 +76,13 @@ class JsonSettings:
                     "(got %s); starting empty",
                     self._path, type(loaded).__name__,
                 )
-        except (OSError, json.JSONDecodeError) as e:
+        except (OSError, ValueError) as e:
+            # ValueError, not just JSONDecodeError: a settings.json whose
+            # bytes are corrupt raises UnicodeDecodeError during the read —
+            # a ValueError but NOT a JSONDecodeError — which previously
+            # escaped this guard and crashed the portable app at startup
+            # (#251 bug class). JSONDecodeError is itself a ValueError, so
+            # this catches both.
             logger.warning(
                 "JsonSettings could not load %s (%s); starting empty",
                 self._path, e,

--- a/src/utils/settings.py
+++ b/src/utils/settings.py
@@ -2325,7 +2325,9 @@ class AppSettings:
         stamp = AppSettings.get_enhancements_dir(language) / AppSettings.ENHANCEMENTS_STAMP_NAME
         try:
             return stamp.read_text(encoding="utf-8").strip()
-        except OSError:
+        except (OSError, ValueError):
+            # ValueError: a corrupt stamp raises UnicodeDecodeError (#251
+            # bug class) — treat it like a missing stamp, not a crash.
             return ""
 
     @staticmethod
@@ -2611,7 +2613,9 @@ class AppSettings:
             text = stamp.read_text(encoding="utf-8").strip()
             if text:
                 return text
-        except OSError:
+        except (OSError, ValueError):
+            # ValueError: a corrupt stamp raises UnicodeDecodeError (#251
+            # bug class) — fall through to the records-dir heuristic.
             pass
         records = forge_dir / "raw" / "libs" / "foundry" / "records"
         try:

--- a/src/utils/user_ini_manager.py
+++ b/src/utils/user_ini_manager.py
@@ -247,7 +247,22 @@ def _backup_if_changing(user_ini_path: Path, new_text: str) -> None:
     """
     try:
         if user_ini_path.exists() and user_ini_path.stat().st_size > 0:
-            if user_ini_path.read_text(encoding="utf-8") != new_text:
+            # Compare bytes, not decoded text: read_text(encoding="utf-8")
+            # raises UnicodeDecodeError (a ValueError, so it sailed past the
+            # OSError guard below) if the on-disk file is corrupt — and this
+            # runs on EVERY save, so one bad byte bricked all saves (#251
+            # bug class). Byte inequality also correctly treats a corrupt
+            # file as "changing", so it gets snapshotted before the clean
+            # rewrite replaces it. Newlines are normalized first: the save
+            # below uses text mode, which writes \n as \r\n on Windows,
+            # while new_text carries bare \n — without this every identical
+            # save would look "changed" and churn real history out of the
+            # 5-slot backup rotation.
+            on_disk = (
+                user_ini_path.read_bytes()
+                .replace(b"\r\n", b"\n").replace(b"\r", b"\n")
+            )
+            if on_disk != new_text.encode("utf-8"):
                 backup_user_ini(user_ini_path)
     except OSError as e:
         logger.warning(

--- a/tests/test_ini_encoding_fallback.py
+++ b/tests/test_ini_encoding_fallback.py
@@ -1,0 +1,122 @@
+"""Non-UTF-8 base.ini tolerance (#251).
+
+A 2.2.0 user's Generate Enhancements crashed with ``UnicodeDecodeError:
+'utf-8' codec can't decode byte 0xa0`` — their base.ini wasn't clean UTF-8,
+on a stock English install. 0xA0 is the Windows-1252 non-breaking space:
+CIG's text carries plenty of characters that cp1252 encodes as single high
+bytes (é / ™ / ° / em dash / NBSP), so a cached base.ini re-saved by an
+external editor in ANSI (legacy Notepad's default) or mangled by a sync/AV
+tool decodes as invalid UTF-8 at the first such character. Both INI readers
+now decode UTF-8 first and fall back to cp1252 instead of failing:
+
+  * ``scripts/generate_enhancements_ini.parse_ini`` crashed the whole
+    enhancements run on the first bad byte.
+  * ``src/parser/ini_parser.parse_ini_file`` was quietly worse: its broad
+    except caught the mid-iteration decode error and returned a silently
+    TRUNCATED result — every key after the bad byte vanished.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+from src.parser.ini_parser import parse_ini_file  # noqa: E402
+
+pytestmark = [pytest.mark.unit, pytest.mark.regression]
+
+
+def _generator_parse_ini():
+    """Import the standalone generator script's parse_ini lazily so a missing
+    lxml (its only third-party dep) skips these cases instead of erroring."""
+    pytest.importorskip("lxml")
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+    import generate_enhancements_ini as gen
+    return gen.parse_ini
+
+
+# The reported failure shape: an NBSP (0xA0) written as a bare cp1252 byte,
+# with keys after the bad byte that a truncating parser would lose. The
+# values here are French-flavored only because NBSP-heavy text makes the
+# dense case; the actual report was a stock English install.
+_CP1252_CONTENT = (
+    "vehicle_NameHunter=Drake Cutlass Black\n"
+    "mission_prompt=Continuer\xa0?\n"
+    "item_NameSHLD_Aspirum=Bouclier «\xa0Aspirum\xa0»\n"
+    "key_after_bad_byte=must survive\n"
+)
+
+
+@pytest.fixture
+def cp1252_ini(tmp_path) -> Path:
+    p = tmp_path / "base.ini"
+    p.write_bytes(_CP1252_CONTENT.encode("cp1252"))
+    return p
+
+
+@pytest.fixture
+def utf8_bom_ini(tmp_path) -> Path:
+    p = tmp_path / "base.ini"
+    p.write_bytes("﻿vehicle_NameHunter=Drake Cutlass Black\nk2=v2\n".encode("utf-8"))
+    return p
+
+
+class TestAppParser:
+    def test_cp1252_file_parses_completely(self, cp1252_ini):
+        result = parse_ini_file(cp1252_ini)
+        # Pre-fix this returned only the keys before the 0xA0 byte.
+        assert result["key_after_bad_byte"] == "must survive"
+        assert result["mission_prompt"] == "Continuer\xa0?"
+        assert result["item_NameSHLD_Aspirum"] == "Bouclier «\xa0Aspirum\xa0»"
+        assert len(result) == 4
+
+    def test_utf8_bom_still_parses(self, utf8_bom_ini):
+        result = parse_ini_file(utf8_bom_ini)
+        assert result == {"vehicle_NameHunter": "Drake Cutlass Black", "k2": "v2"}
+
+    def test_utf8_without_bom_still_parses(self, tmp_path):
+        p = tmp_path / "base.ini"
+        p.write_text("clé=révisé — ✓\n", encoding="utf-8")
+        assert parse_ini_file(p) == {"clé": "révisé — ✓"}
+
+    def test_cp1252_undefined_byte_does_not_crash(self, tmp_path):
+        # 0x81 is undefined even in cp1252; errors="replace" must absorb it.
+        p = tmp_path / "base.ini"
+        p.write_bytes(b"good_key=ok\nweird=\x81\nlater_key=still here\n")
+        result = parse_ini_file(p)
+        assert result["good_key"] == "ok"
+        assert result["later_key"] == "still here"
+
+    def test_bom_then_cp1252_body_strips_bom(self, tmp_path):
+        # An editor can prepend a UTF-8 BOM and still save the body as ANSI.
+        p = tmp_path / "base.ini"
+        p.write_bytes(b"\xef\xbb\xbf" + "k=v\xa0!\n".encode("cp1252"))
+        result = parse_ini_file(p)
+        assert result == {"k": "v\xa0!"}
+        assert "﻿k" not in result
+
+
+class TestGeneratorParser:
+    def test_cp1252_file_parses_completely(self, cp1252_ini):
+        parse_ini = _generator_parse_ini()
+        result = parse_ini(cp1252_ini)
+        # Pre-fix this raised UnicodeDecodeError (the #251 traceback).
+        assert result["key_after_bad_byte"] == "must survive"
+        assert result["mission_prompt"] == "Continuer\xa0?"
+        assert len(result) == 4
+
+    def test_utf8_bom_still_parses(self, utf8_bom_ini):
+        parse_ini = _generator_parse_ini()
+        assert parse_ini(utf8_bom_ini) == {
+            "vehicle_NameHunter": "Drake Cutlass Black", "k2": "v2",
+        }
+
+    def test_metadata_suffix_still_stripped(self, tmp_path):
+        parse_ini = _generator_parse_ini()
+        p = tmp_path / "base.ini"
+        p.write_bytes("key,P=value\xa0x\n".encode("cp1252"))
+        assert parse_ini(p) == {"key": "value\xa0x"}

--- a/tests/test_ini_encoding_fallback.py
+++ b/tests/test_ini_encoding_fallback.py
@@ -262,3 +262,19 @@ class TestCorruptStateFileGuards:
         _backup_if_changing(user_ini, "key=value\n")
         backups_dir = tmp_path / "backups"
         assert not backups_dir.exists() or not list(backups_dir.glob("*"))
+
+    def test_locstring_workarounds_skip_corrupt_patch_file(self, tmp_path):
+        """A *.patch.json with corrupt bytes raises UnicodeDecodeError (a
+        ValueError but NOT a JSONDecodeError), which previously escaped the
+        (JSONDecodeError, OSError) guard and crashed the patch scan. It must
+        instead be skipped like any malformed patch, with valid sibling
+        patch files still loading."""
+        from src.utils.dataforge_patcher import load_locstring_workarounds
+
+        (tmp_path / "corrupt.patch.json").write_bytes(b'{"locstring\xa0broken"}')
+        (tmp_path / "valid.patch.json").write_text(
+            '{"locstring_workarounds": [{"target": "key_a", "append_from": "key_b"}]}',
+            encoding="utf-8",
+        )
+        out = load_locstring_workarounds(tmp_path)
+        assert [w.target for w in out] == ["key_a"]

--- a/tests/test_ini_encoding_fallback.py
+++ b/tests/test_ini_encoding_fallback.py
@@ -1,19 +1,28 @@
 """Non-UTF-8 base.ini tolerance (#251).
 
 A 2.2.0 user's Generate Enhancements crashed with ``UnicodeDecodeError:
-'utf-8' codec can't decode byte 0xa0`` — their base.ini wasn't clean UTF-8,
-on a stock English install. 0xA0 is the Windows-1252 non-breaking space:
-CIG's text carries plenty of characters that cp1252 encodes as single high
-bytes (é / ™ / ° / em dash / NBSP), so a cached base.ini re-saved by an
-external editor in ANSI (legacy Notepad's default) or mangled by a sync/AV
-tool decodes as invalid UTF-8 at the first such character. Both INI readers
-now decode UTF-8 first and fall back to cp1252 instead of failing:
+'utf-8' codec can't decode byte 0xa0`` — one bad byte in an
+otherwise-valid-UTF-8 base.ini, on a stock English install. A healthy
+install's extraction of the same LIVE data decodes perfectly, so the file
+was machine-local corruption (possibly in the user's own Data.p4k, meaning
+re-extraction can reintroduce it). Both INI readers now tolerate bad input
+instead of failing:
 
   * ``scripts/generate_enhancements_ini.parse_ini`` crashed the whole
     enhancements run on the first bad byte.
   * ``src/parser/ini_parser.parse_ini_file`` was quietly worse: its broad
     except caught the mid-iteration decode error and returned a silently
     TRUNCATED result — every key after the bad byte vanished.
+
+The two realistic failure shapes need OPPOSITE fallbacks, discriminated by
+whether the UTF-8 replacement count tracks the file's high-byte count:
+
+  * corrupted UTF-8 (the #251 report) -> UTF-8 errors="replace": only the
+    corrupt byte degrades; a cp1252 decode would mojibake every legitimate
+    multi-byte character in the file ("é" -> "Ã©").
+  * genuinely ANSI/cp1252 file (e.g. re-saved by legacy Notepad) -> cp1252:
+    here nearly every high byte is individually invalid UTF-8, and a UTF-8
+    replace-decode would destroy all of them.
 """
 from __future__ import annotations
 
@@ -39,16 +48,37 @@ def _generator_parse_ini():
     return gen.parse_ini
 
 
-# The reported failure shape: an NBSP (0xA0) written as a bare cp1252 byte,
-# with keys after the bad byte that a truncating parser would lose. The
-# values here are French-flavored only because NBSP-heavy text makes the
-# dense case; the actual report was a stock English install.
+# ── Fixture files ─────────────────────────────────────────────────────────────
+
+# The #251 shape: valid UTF-8 throughout (with plenty of legitimate multi-byte
+# characters) except ONE bare corrupt byte, with keys after it that a
+# truncating parser would lose.
+def _corrupted_utf8_bytes() -> bytes:
+    good = (
+        "vehicle_NameHunter=Drake Cutlass Black\n"
+        "item_NameSHLD_Aspirum=Aspirum™ Shield — Mk. II\n"
+        "npc_name=Sebastián Muñoz\n"
+    ).encode("utf-8")
+    bad_line = b"corrupt_line=before\xa0after\n"
+    tail = "key_after_bad_byte=must survive\nlast=entrée\n".encode("utf-8")
+    return good + bad_line + tail
+
+
+# The ANSI shape: the whole file written in cp1252 (every high byte is a
+# standalone character, individually invalid as UTF-8).
 _CP1252_CONTENT = (
     "vehicle_NameHunter=Drake Cutlass Black\n"
     "mission_prompt=Continuer\xa0?\n"
     "item_NameSHLD_Aspirum=Bouclier «\xa0Aspirum\xa0»\n"
     "key_after_bad_byte=must survive\n"
 )
+
+
+@pytest.fixture
+def corrupted_utf8_ini(tmp_path) -> Path:
+    p = tmp_path / "base.ini"
+    p.write_bytes(_corrupted_utf8_bytes())
+    return p
 
 
 @pytest.fixture
@@ -65,7 +95,23 @@ def utf8_bom_ini(tmp_path) -> Path:
     return p
 
 
+# ── App parser (src/parser/ini_parser.py) ─────────────────────────────────────
+
 class TestAppParser:
+    def test_corrupted_utf8_preserves_valid_multibyte_chars(self, corrupted_utf8_ini):
+        """The actual #251 file shape. Pre-fix this silently truncated at the
+        bad byte; and a naive whole-file cp1252 fallback would mojibake every
+        legitimate é/™/— in the file. Only the corrupt byte may degrade."""
+        result = parse_ini_file(corrupted_utf8_ini)
+        assert result["key_after_bad_byte"] == "must survive"
+        # Legitimate multi-byte characters must survive intact, NOT as mojibake.
+        assert result["item_NameSHLD_Aspirum"] == "Aspirum™ Shield — Mk. II"
+        assert result["npc_name"] == "Sebastián Muñoz"
+        assert result["last"] == "entrée"
+        # The corrupt byte itself degrades to U+FFFD, nothing more.
+        assert result["corrupt_line"] == "before�after"
+        assert len(result) == 6
+
     def test_cp1252_file_parses_completely(self, cp1252_ini):
         result = parse_ini_file(cp1252_ini)
         # Pre-fix this returned only the keys before the 0xA0 byte.
@@ -100,11 +146,21 @@ class TestAppParser:
         assert "﻿k" not in result
 
 
+# ── Generator parser (scripts/generate_enhancements_ini.py) ──────────────────
+
 class TestGeneratorParser:
+    def test_corrupted_utf8_preserves_valid_multibyte_chars(self, corrupted_utf8_ini):
+        parse_ini = _generator_parse_ini()
+        # Pre-fix this raised UnicodeDecodeError (the #251 traceback).
+        result = parse_ini(corrupted_utf8_ini)
+        assert result["key_after_bad_byte"] == "must survive"
+        assert result["item_NameSHLD_Aspirum"] == "Aspirum™ Shield — Mk. II"
+        assert result["corrupt_line"] == "before�after"
+        assert len(result) == 6
+
     def test_cp1252_file_parses_completely(self, cp1252_ini):
         parse_ini = _generator_parse_ini()
         result = parse_ini(cp1252_ini)
-        # Pre-fix this raised UnicodeDecodeError (the #251 traceback).
         assert result["key_after_bad_byte"] == "must survive"
         assert result["mission_prompt"] == "Continuer\xa0?"
         assert len(result) == 4
@@ -120,3 +176,89 @@ class TestGeneratorParser:
         p = tmp_path / "base.ini"
         p.write_bytes("key,P=value\xa0x\n".encode("cp1252"))
         assert parse_ini(p) == {"key": "value\xa0x"}
+
+
+# ── Apply path (src/merger/ini_merger.py) ─────────────────────────────────────
+
+class TestMergerAppliesCorruptedBase:
+    def test_merge_ini_files_survives_corrupted_utf8_source(self, corrupted_utf8_ini, tmp_path):
+        """merge_ini_files reads base.ini on Apply to Game — pre-fix a corrupt
+        byte there raised IOError and failed the whole apply."""
+        from src.merger.ini_merger import merge_ini_files
+
+        out = tmp_path / "global.ini"
+        merge_ini_files(corrupted_utf8_ini, {"vehicle_NameHunter": "OVERRIDDEN"}, out)
+        text = out.read_text(encoding="utf-8")
+        assert "vehicle_NameHunter=OVERRIDDEN" in text
+        # Untouched keys pass through with their multi-byte chars intact.
+        assert "item_NameSHLD_Aspirum=Aspirum™ Shield — Mk. II" in text
+        assert "key_after_bad_byte=must survive" in text
+
+    def test_merge_ini_files_preserves_trailing_newline_shape(self, tmp_path):
+        from src.merger.ini_merger import merge_ini_files
+
+        src = tmp_path / "base.ini"
+        src.write_text("a=1\nb=2\n", encoding="utf-8")
+        out = tmp_path / "out.ini"
+        merge_ini_files(src, {}, out)
+        assert out.read_text(encoding="utf-8") == "a=1\nb=2\n"
+
+        src.write_text("a=1\nb=2", encoding="utf-8")  # no trailing newline
+        merge_ini_files(src, {}, out)
+        assert out.read_text(encoding="utf-8") == "a=1\nb=2"
+
+
+# ── Sibling #251-class guards (corrupt bytes in app-written state files) ──────
+
+class TestCorruptStateFileGuards:
+    def test_json_settings_corrupt_bytes_start_empty(self, tmp_path):
+        """Portable-mode settings.json with corrupt bytes previously escaped
+        the (OSError, JSONDecodeError) guard as UnicodeDecodeError and crashed
+        the portable app at startup."""
+        from src.utils.json_settings import JsonSettings
+
+        p = tmp_path / "settings.json"
+        p.write_bytes(b'{"key": "val\xa0ue"}')
+        s = JsonSettings(p)
+        assert s.value("key", "default") == "default"
+
+    def test_dirty_categories_corrupt_manifest_regenerates_all(self, tmp_path):
+        """A corrupt diff manifest previously crashed the enhancements run;
+        it must instead read as 'no manifest' (regenerate everything)."""
+        from src.utils.dataforge_diff import MANIFEST_FILE, dirty_categories
+
+        (tmp_path / MANIFEST_FILE).write_bytes(b"{corrupt\xa0json")
+        assert dirty_categories(tmp_path) is None
+
+    def test_enhancements_stamp_corrupt_bytes_reads_empty(self, tmp_path, monkeypatch):
+        from src.utils.settings import AppSettings
+
+        monkeypatch.setattr(
+            AppSettings, "get_enhancements_dir", staticmethod(lambda language=None: tmp_path)
+        )
+        (tmp_path / AppSettings.ENHANCEMENTS_STAMP_NAME).write_bytes(b"stamp\xa0value")
+        assert AppSettings.get_enhancements_stamp() == ""
+
+    def test_backup_if_changing_survives_corrupt_user_ini(self, tmp_path):
+        """_backup_if_changing runs on EVERY save; a corrupt user.ini raised
+        UnicodeDecodeError past its OSError guard and bricked all saves. It
+        must instead treat the corrupt file as 'changing' and snapshot it."""
+        from src.utils.user_ini_manager import _backup_if_changing
+
+        user_ini = tmp_path / "user.ini"
+        user_ini.write_bytes(b"key=broken\xa0value\n")
+        _backup_if_changing(user_ini, "key=clean value\n")
+        backups = list((tmp_path / "backups").glob("*")) if (tmp_path / "backups").exists() else []
+        assert backups, "corrupt file should have been snapshotted before overwrite"
+
+    def test_backup_if_changing_identical_save_does_not_snapshot(self, tmp_path):
+        """The byte comparison must normalize \\r\\n (text-mode writes) so an
+        identical re-save doesn't churn history out of the backup rotation."""
+        from src.utils.user_ini_manager import _backup_if_changing
+
+        user_ini = tmp_path / "user.ini"
+        # Simulate what text-mode open() writes on Windows: \r\n on disk.
+        user_ini.write_bytes(b"key=value\r\n")
+        _backup_if_changing(user_ini, "key=value\n")
+        backups_dir = tmp_path / "backups"
+        assert not backups_dir.exists() or not list(backups_dir.glob("*"))


### PR DESCRIPTION
## Summary
- Fixes the 2.2.0 blocker in #251: one corrupt byte (`0xA0`) in a user's cached `base.ini` crashed Generate Enhancements with `UnicodeDecodeError`. Investigation (comparing against a healthy install's extraction of the same LIVE data, which decodes as perfectly valid UTF-8) points to **machine-local corruption** — possibly in the user's own `Data.p4k`, so re-extraction can reintroduce the bad byte. The app must tolerate it.
- **Smart decode fallback, not a blanket one:** the two realistic failure shapes need opposite handling, discriminated by measuring whether the UTF-8 replacement count tracks the file's high-byte count:
  - *Corrupted UTF-8* (the actual report: one bad byte in 10.4 MB of valid UTF-8) → UTF-8 `errors="replace"`. Only the corrupt byte degrades to U+FFFD. A blanket cp1252 fallback here would mojibake every legitimate `é`/`™`/em-dash in the file (thousands of strings) to repair one byte.
  - *Genuinely ANSI file* (e.g. re-saved by legacy Notepad) → cp1252 decode, since there nearly every high byte is individually invalid UTF-8.
- **Audit of every other read of user-mutable/corruptible state found five more members of the same bug class, all fixed** — this was a full app blocker and each of these was an independent way to stay blocked:
  - `src/merger/ini_merger.py` — the same corrupt `base.ini` also failed **Apply to Game** (strict `open()` → `IOError`).
  - `src/utils/user_ini_manager.py` — `_backup_if_changing` runs on **every save**; a corrupt `user.ini` raised `UnicodeDecodeError` past its `OSError`-only guard, bricking all saves. Now compares newline-normalized bytes (no decode at all); a corrupt file counts as "changing" and is snapshotted before the clean rewrite.
  - `src/utils/json_settings.py` — a corrupt `settings.json` escaped the `(OSError, JSONDecodeError)` guard and **crashed the portable app at startup**.
  - `src/utils/dataforge_diff.py` — a corrupt diff manifest crashed the enhancements run; now treated as "no manifest" (regenerate everything; `update_manifest` rewrites a clean one — self-healing).
  - Stamp/patch reads in `settings.py`, the generator, and `dataforge_patcher.py` — `OSError`/`JSONDecodeError`-only guards widened to `ValueError`.
- The shared helper lives in `src/utils/ini_io.read_ini_text` (parser + merger both use it; merger already imports `src.utils`, and the parser→merger import direction forbids the reverse). The generator script keeps its own documented mirror to stay stdlib+lxml-only for standalone runs — same tolerated-duplication shape as `CATEGORY_SUBTREES` ↔ `DATAFORGE_KEEP_SUBPATHS`.
- Paths audited and already safe: `blueprint_log_scanner` (`errors="replace"`), `user_cfg` (broad except; skipping is safer than rewriting a mangled decode into the game's own config), i18n/tutorial/docs loads, `pak_extractor` stamps, `applied_file_validator`, `should_autosave_user_ini` (stat only). Registry-mode settings have no file decode to corrupt, so both build modes are covered.

**Release-target note:** opened against `release/2.3.0` per the branching model. This is a self-contained bug fix affecting current 2.2.0 users (full blocker for the affected user), but with `release/2.2.1` retired, all fixes are consolidating onto 2.3.0 rather than a separate hotfix branch.

Fixes #251.

## Testing Checklist
- [x] PR is scoped to one concern (one bug class: strict decodes of user-mutable state)
- [x] `pytest tests/` passes locally (1204 passed, 16 skipped)
- [ ] App launches: `python src/main.py`
- [ ] Affected user-facing flow exercised manually (Generate Enhancements / Apply with a deliberately corrupted base.ini)
- [x] User-facing strings, `docs/HELP.md`, `docs/ABOUT.md`, and `src/gui/coach_mark.py` reviewed for drift (no UI strings changed)
- [x] New non-exempt code has matching test coverage in `tests/` (17 tests in `test_ini_encoding_fallback.py` covering both parsers, the Apply-path merger, portable settings, the diff manifest, stamps, and the save-path backup guard)
- [x] Target branch is the active `release/2.3.0`, not `main` (see release-target note above)
- [x] No direct `QSettings` calls, no hard-coded column indices, no `QProgressBar.setValue()` from workers
- [x] `VERSION.TXT` matches the active release branch

## Testing performed
Full suite (1204 passed, 16 skipped). The new tests reproduce the exact #251 file shape (one bare `0xA0` in otherwise-valid UTF-8 with multi-byte characters that must survive un-mojibake'd, and keys after the bad byte that a truncating parser would lose), plus the ANSI-file shape, BOM hybrids, cp1252's undefined bytes, the Apply-path merger read, portable-mode settings corruption, corrupt diff-manifest self-healing, corrupt-stamp reads, and the every-save backup guard (including that identical re-saves still don't churn the backup rotation). Not exercised: a live GUI run against a real corrupted install.

## Post-merge QA
- [ ] App launches from a clean checkout of the integration branch
- [ ] With a deliberately corrupted `base.ini` (flip one byte ≥ 0x80): app loads all strings, Generate Enhancements completes, Apply to Game completes; Log tab shows the corruption warning
- [ ] Portable build: corrupt `settings.json` by hand → app starts with default settings instead of crashing
- [ ] For the original reporter: RSI Launcher **Verify** remains the real cure if their `Data.p4k` is corrupt — the app now degrades one string instead of dying, but their game files are still damaged

---
🤖 PR description generated with [Claude Code](https://claude.com/claude-code) and reviewed by @Stealrull
