### PR TITLE
[#255] Fix starmap/UI name corruption: scope sync_key_variants() to item keys

### DIFF
--- a/src/merger/ini_merger.py
+++ b/src/merger/ini_merger.py
@@ -26,8 +26,10 @@ def merge_sources_by_hierarchy(
     overwrite earlier ones. User overrides (if provided) always have highest priority
     and are applied last.
 
-    Syncs values across key variants (e.g., item_Name_QDRV_RSI_S02_Hemera and
-    item_nameQDRV_RSI_S02_Hemera_SCItem get the same value).
+    Syncs values across item_Name*/item_Desc* key variants (e.g.,
+    item_Name_QDRV_RSI_S02_Hemera and item_nameQDRV_RSI_S02_Hemera_SCItem get
+    the same value) — see sync_key_variants for why this is scoped to that
+    namespace and not the whole table (#257).
 
     Args:
         sources_dict: Dictionary mapping source name to its key-value pairs.
@@ -146,6 +148,22 @@ def sync_key_variants(
 
     This modifies merged_dict in-place.
 
+    Scoped to item_Name*/item_Desc* keys only (#257). Canonicalization
+    strips ALL underscores and lowercases, which is exactly right for the
+    ship-item naming quirks this function targets — but running it over
+    every key in the ~90k-key table let two completely unrelated CIG loc
+    keys collide by coincidence: ``Stanton2`` (the Crusader planet's name
+    key) and ``Stanton_2`` (a different key, the star, holding "Stanton
+    (Star)") both canonicalize to "stanton2". The longest-value tie-break
+    then overwrote the planet's name with the star's. An audit of a real
+    base.ini found 14 more live collisions of this shape (comm-array
+    button text, a mission title, ship-interior area names, Options-menu
+    turret labels, two different thruster names merged into one, …) —
+    this was silently corrupting shipped content anywhere in the table,
+    not just item names. The item_Name/item_Desc prefix is exactly the
+    boundary every existing test case here already lives inside; nothing
+    outside it was ever an intentional target of this sync.
+
     Args:
         merged_dict: Dictionary of keys to values from merged sources
         user_edited_keys: Keys the user explicitly edited (user.ini
@@ -160,10 +178,15 @@ def sync_key_variants(
             of *those* wins (same tie-break as the no-override case — we
             have no ordering signal between two deliberate edits).
     """
-    # Build a mapping of canonical → list of actual keys with that canonical form
+    # Build a mapping of canonical → list of actual keys with that canonical
+    # form, restricted to the item_Name*/item_Desc* namespace this sync is
+    # actually for (#257) — any other key (locations, missions, UI labels,
+    # options-menu strings, ...) is left completely untouched by this pass.
     canonical_keys: Dict[str, List[str]] = {}
 
     for key in list(merged_dict.keys()):
+        if not key.lower().startswith(("item_name", "item_desc")):
+            continue
         canonical = _get_canonical_key(key)
         if canonical not in canonical_keys:
             canonical_keys[canonical] = []

--- a/tests/test_ini_merger.py
+++ b/tests/test_ini_merger.py
@@ -7,6 +7,17 @@ variant wins" pass, then a "prefer non-_SCItem" pre-filter, both wrong in
 opposite ways — see the docstring in ini_merger.py). These tests pin the
 three real-data shapes that broke it, plus the guard added so a user's
 override to a variant can't be silently outvoted by the longest-value rule.
+
+TestSyncKeyVariantsDomainScope (#257) pins a third, more severe bug: the
+canonical-key grouping used to run over EVERY key in the merged table, not
+just item_Name*/item_Desc*. Two completely unrelated CIG loc keys —
+Stanton2 (the Crusader planet) and Stanton_2 (the Stanton star) — collapsed
+to the same canonical string purely because underscore-stripping ignores
+what the underscore was actually separating, and the star's longer value
+overwrote the planet's name on the in-game starmap. A real base.ini audit
+found 14 total live corruptions of this shape. The fix scopes the sync to
+item_Name*/item_Desc* keys only; these tests lock that boundary down so it
+can never again silently expand to swallow unrelated content.
 """
 from __future__ import annotations
 
@@ -119,6 +130,96 @@ class TestSyncKeyVariantsUserEditGuard:
         }
         sync_key_variants(merged, user_edited_keys={"totally_unrelated_key"})
         assert merged["item_Name_SHLD_BEHR_S01_7SA"] == "[SHLD-S1-B] BEHR Shield"
+
+
+class TestSyncKeyVariantsDomainScope:
+    """#257: sync_key_variants must never touch a key outside item_Name*/
+    item_Desc* — that's the one guarantee this whole test class exists to
+    pin down. Real key/value pairs pulled straight from the bug's audit."""
+
+    def test_crusader_planet_not_overwritten_by_stanton_star(self):
+        """The reported bug, verbatim: Stanton2 (planet, "Crusader") and
+        Stanton_2 (star, "Stanton (Star)") canonicalize to the same string
+        after underscore-stripping. Pre-fix, the longer star value won and
+        got written into both — the starmap showed "Stanton (Star)" where
+        "Crusader" should be."""
+        merged = {"Stanton2": "Crusader", "Stanton_2": "Stanton (Star)"}
+        sync_key_variants(merged)
+        assert merged["Stanton2"] == "Crusader"
+        assert merged["Stanton_2"] == "Stanton (Star)"
+
+    def test_comm_array_button_labels_not_merged(self):
+        merged = {"CommArray_Deactivate": "Deactivate", "comm_Array_Deactivate": "Disconnect Uplink"}
+        sync_key_variants(merged)
+        assert merged["CommArray_Deactivate"] == "Deactivate"
+        assert merged["comm_Array_Deactivate"] == "Disconnect Uplink"
+
+    def test_mission_title_format_string_not_overwritten_by_body_text(self):
+        merged = {
+            "LocalDelivery_title": "~mission(Contractor|LocalDeliveryTitle) - ~mission(Reward)",
+            "Local_Delivery_Title": "Courier\\nLocal Multi-Stop Delivery\\nReward",
+        }
+        sync_key_variants(merged)
+        assert merged["LocalDelivery_title"] == "~mission(Contractor|LocalDeliveryTitle) - ~mission(Reward)"
+        assert merged["Local_Delivery_Title"] == "Courier\\nLocal Multi-Stop Delivery\\nReward"
+
+    def test_two_distinct_thruster_names_not_collapsed(self):
+        """Mid Left and Mid Lower are different thrusters — collapsing them
+        to one name would mislabel a ship component, not just cosmetic."""
+        merged = {"port_NameThrusterMavML": "Thruster Mid Left", "port_NameThrusterMavML_": "Thruster Mid Lower"}
+        sync_key_variants(merged)
+        assert merged["port_NameThrusterMavML"] == "Thruster Mid Left"
+        assert merged["port_NameThrusterMavML_"] == "Thruster Mid Lower"
+
+    def test_hardpoint_slot_suffix_not_dropped(self):
+        """Two power-plant loadout slots must stay distinguishable — losing
+        the "- 02" suffix makes them look like the same slot in the UI."""
+        merged = {
+            "itemPort_hardpoint_power_plant_02": "Power Plant",
+            "itemPort_hardpoint_powerplant_02": "Power Plant - 02",
+        }
+        sync_key_variants(merged)
+        assert merged["itemPort_hardpoint_power_plant_02"] == "Power Plant"
+        assert merged["itemPort_hardpoint_powerplant_02"] == "Power Plant - 02"
+
+    def test_options_menu_turret_labels_not_merged(self):
+        merged = {
+            "pause_OptionsLookAhead_Turret_Forward": "Turrets - Look Ahead - Strength - Forward vector",
+            "pause_options_look_ahead_turret_forward": "Turret - Look Ahead - Strength - Forward Vector",
+        }
+        sync_key_variants(merged)
+        assert merged["pause_OptionsLookAhead_Turret_Forward"] == "Turrets - Look Ahead - Strength - Forward vector"
+        assert merged["pause_options_look_ahead_turret_forward"] == "Turret - Look Ahead - Strength - Forward Vector"
+
+    def test_kiosk_label_does_not_leak_literal_underscore(self):
+        """Shop_Terminal (with a literal underscore) must never win and
+        display in a user-facing kiosk prompt."""
+        merged = {"kiosk_ShopTerminal": "Shop Terminal", "kiosk_Shop_Terminal": "Shop_Terminal"}
+        sync_key_variants(merged)
+        assert merged["kiosk_ShopTerminal"] == "Shop Terminal"
+        assert merged["kiosk_Shop_Terminal"] == "Shop_Terminal"
+
+    def test_item_desc_variants_still_sync(self):
+        """The fix must not become so narrow it stops syncing real item
+        variants — two item_Desc keys for the same entity (missing
+        underscore after "item_Desc") must still reach each other, same
+        as the item_Name case every other test in this file already pins."""
+        merged = {
+            "item_Desc_SHLD_BEHR_S01_7SA": "[SHLD-S1-B] BEHR Shield description",
+            "item_DescSHLD_BEHR_S01_7sa": "BEHR Shield description",
+        }
+        sync_key_variants(merged)
+        assert merged["item_Desc_SHLD_BEHR_S01_7SA"] == "[SHLD-S1-B] BEHR Shield description"
+        assert merged["item_DescSHLD_BEHR_S01_7sa"] == "[SHLD-S1-B] BEHR Shield description"
+
+    def test_full_merge_pipeline_preserves_crusader(self):
+        """Integration-level: the bug reproduces through the full
+        merge_sources_by_hierarchy pipeline used by the app, not just the
+        unit-level sync_key_variants."""
+        sources = {"global": {"Stanton2": "Crusader", "Stanton_2": "Stanton (Star)"}}
+        result = merge_sources_by_hierarchy(sources, ["global"])
+        assert result["Stanton2"] == "Crusader"
+        assert result["Stanton_2"] == "Stanton (Star)"
 
 
 class TestMergeSourcesByHierarchyUserOverrideSurvival:


### PR DESCRIPTION
## Summary
- **Critical bug**, reported via Discord with screenshots: after applying Smart Citizen's output, the Stanton system's **Crusader planet shows as "Stanton (Star)"** on the in-game starmap. Confirmed on a second independent install. Removing the app's `global.ini` (reverting to vanilla) restores the correct name.
- **Root cause**: `sync_key_variants()` in `src/merger/ini_merger.py` canonicalizes every key (strip `_SCItem`, lowercase, strip **all** underscores) to reconcile CIG's inconsistent naming of *ship-component* variants (`item_Name_QDRV_...` vs `item_nameQDRV..._SCItem` should carry the same value). It ran this canonicalization over the **entire merged table (~90k keys)**, not just `item_Name*`/`item_Desc*` keys. Two completely unrelated CIG loc keys collided by coincidence:
  ```
  Stanton2  = "Crusader"        (the planet, Stanton II)
  Stanton_2 = "Stanton (Star)"  (a different object, the star)
  ```
  Both canonicalize to `"stanton2"`. The "longest value wins" tie-break picked `"Stanton (Star)"` and wrote it into **both** keys.
- **This is not an isolated incident.** Audited a real installed `base.ini` (90,121 keys): 124 canonical collision groups total, 24 of them outside the `item_Name`/`item_Desc` domain this sync was ever designed for, and **14 of those hold genuinely different values — live, currently-shipping corruption**, not theoretical risk:
  - The reported Crusader/Stanton(Star) planet-name swap
  - Comm-array button labels ("Deactivate" → "Disconnect Uplink", "Login" → "Passkey Authorization")
  - A mission title format string overwritten with unrelated body text
  - Pyro system name casing collision
  - A ship-interior area name corrupted
  - A kiosk prompt that could leak a **literal underscore** (`Shop_Terminal`)
  - **Four Options-menu** turret look-ahead setting labels (visible to every player who opens graphics/control settings)
  - **Two genuinely different thrusters** ("Mid Left" vs "Mid Lower") collapsed to showing the same name
  - A ship loadout hardpoint slot losing its `"- 02"` suffix, making two power-plant slots indistinguishable in the UI
- **Fix**: scope the canonical-key grouping in `sync_key_variants()` to keys starting with `item_name`/`item_desc` (case-insensitive) — the exact domain this function was designed and tested for. Verified against the real base.ini: all 14 corrupted values now resolve correctly, zero legitimate item-variant pairs lost their sync, and zero cross-domain collisions remain touched by the merge.
- Targeted at `release/2.2.1` given severity — this corrupts core game content (including the starmap) on every affected install today.

Fixes #255.

## Testing Checklist
- [x] PR is scoped to one concern (one root cause, one fix)
- [x] `pytest tests/` passes locally (1213 passed, 16 skipped)
- [ ] App launches: `python src/main.py`
- [ ] Affected user-facing flow exercised manually (Apply to Game, then check the starmap for Crusader / Stanton II)
- [x] User-facing strings, `docs/HELP.md`, `docs/ABOUT.md`, and `src/gui/coach_mark.py` reviewed for drift (none — this is a data-merge fix, no UI changes)
- [x] New non-exempt code has matching test coverage in `tests/test_ini_merger.py` (9 new tests: the exact Crusader/Stanton reproduction, each of the other 7 corruption shapes found in the audit, and a check that legitimate item_Desc variant syncing still works)
- [x] Target branch is `release/2.2.1` (patch — bug fix only, per the branching model)
- [x] No direct `QSettings` calls, no hard-coded column indices, no `QProgressBar.setValue()` from workers
- [x] `VERSION.TXT` matches the active release branch

## Testing performed
Full suite (1213 passed, 16 skipped). Verified directly against a real installed `base.ini` pulled from a tester's machine (not just the small test fixtures): ran the actual merge pipeline before and after the fix, confirmed all 14 identified corruptions resolve to their correct original values post-fix, confirmed zero legitimate `item_Name`/`item_Desc` variant-sync pairs regressed, and confirmed zero remaining cross-domain collisions are touched by the merge. Not exercised: a live GUI Apply + starmap check in-game (no build environment here).

## Post-merge QA
- [ ] App launches from a clean checkout of the integration branch
- [ ] Extract → Apply on a clean install, then check in-game: Crusader (Stanton II) shows its correct name on the starmap
- [ ] Spot-check a couple of the other corrupted strings found in the audit still read correctly in-game (Options menu → turret look-ahead labels; a comm array interaction prompt)
- [ ] Confirm ship component name/description tags (Tag Builder output) still render correctly — this is the domain the sync still legitimately covers

---
🤖 PR description generated with [Claude Code](https://claude.com/claude-code) and reviewed by @Stealrull
