### PR TITLE
[#259] Fix Mission Titles page: 7 checkboxes never armed Save Tag Changes

### DIFF
--- a/src/gui/enhancements_tab.py
+++ b/src/gui/enhancements_tab.py
@@ -1552,6 +1552,7 @@ class _TagBuilderPage(QWidget):
     def _on_mt_standardize_toggle(self, checked: bool) -> None:
         self.config.standardize_hauling_names = checked
         self._refresh_preview()
+        self.config_changed.emit()
 
     def _on_mt_abbrev_toggle(self, key: str, checked: bool) -> None:
         phrases = set(getattr(self.config, "abbreviated_phrases", frozenset()))
@@ -1561,6 +1562,7 @@ class _TagBuilderPage(QWidget):
             phrases.discard(key)
         self.config.abbreviated_phrases = frozenset(phrases)
         self._refresh_preview()
+        self.config_changed.emit()
 
     def _on_mt_shorten_titles_toggle(self, checked: bool) -> None:
         phrases = set(getattr(self.config, "abbreviated_phrases", frozenset()))
@@ -1568,10 +1570,12 @@ class _TagBuilderPage(QWidget):
         phrases = (phrases | keys) if checked else (phrases - keys)
         self.config.abbreviated_phrases = frozenset(phrases)
         self._refresh_preview()
+        self.config_changed.emit()
 
     def _on_mt_shorten_sizes_toggle(self, checked: bool) -> None:
         self.config.shortened_sizes = frozenset(_ALL_SIZE_WORDS) if checked else frozenset()
         self._refresh_preview()
+        self.config_changed.emit()
 
     def _on_mt_rank_sep_changed(self, _idx: int) -> None:
         self.config.rank_separator = self._mt_rank_sep.currentData() or self.config.rank_separator

--- a/tests/test_mission_titles_page_dirty_signal.py
+++ b/tests/test_mission_titles_page_dirty_signal.py
@@ -1,0 +1,94 @@
+"""Mission Titles page: checkbox toggles must mark Save Tag Changes dirty (#259).
+
+Reported: toggling "Underline Direct" on the Enhancements tab's Mission
+Titles page didn't light up the Save Tag Changes button. Every other
+control on this page (the 5 dropdowns, General Tags / Scanning checkboxes)
+emits ``config_changed`` after updating ``self.config``, and MainWindow
+wires that signal to ``_mark_tag_dirty()`` (which enables the button — it's
+disabled while not dirty). Four handler methods updated ``self.config`` and
+refreshed the preview but never emitted the signal: ``_on_mt_standardize_toggle``,
+``_on_mt_abbrev_toggle`` (backs Cargo/Haul/Rank *and* Underline Direct),
+``_on_mt_shorten_titles_toggle``, and ``_on_mt_shorten_sizes_toggle`` — 7
+checkboxes silently failed to arm the dirty state.
+
+Drives the real ``_TagBuilderPage`` widget headlessly (QT_QPA_PLATFORM=
+offscreen), same pattern as tests/test_restore_backup.py — no pytest-qt.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+from PyQt6.QtWidgets import QApplication  # noqa: E402
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO))
+sys.path.insert(0, str(REPO / "src"))
+
+from src.gui.enhancements_tab import _TagBuilderPage  # noqa: E402
+from src.utils.tag_builder import default_config  # noqa: E402
+
+pytestmark = [pytest.mark.unit, pytest.mark.regression]
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    return QApplication.instance() or QApplication([])
+
+
+@pytest.fixture
+def page(qapp):
+    return _TagBuilderPage("mission_titles", default_config("mission_titles"))
+
+
+def _emits_config_changed(page, action) -> bool:
+    fired = []
+    page.config_changed.connect(lambda: fired.append(True))
+    action()
+    return bool(fired)
+
+
+class TestMissionTitlesDirtySignal:
+    def test_underline_direct_checkbox_marks_dirty(self, page):
+        assert _emits_config_changed(
+            page, lambda: page._mt_underline_direct.setChecked(not page._mt_underline_direct.isChecked())
+        )
+
+    def test_shorten_titles_checkbox_marks_dirty(self, page):
+        assert _emits_config_changed(
+            page, lambda: page._mt_shorten_titles.setChecked(not page._mt_shorten_titles.isChecked())
+        )
+
+    def test_shorten_sizes_checkbox_marks_dirty(self, page):
+        assert _emits_config_changed(
+            page, lambda: page._mt_shorten_sizes.setChecked(not page._mt_shorten_sizes.isChecked())
+        )
+
+    def test_standardize_hauling_names_checkbox_marks_dirty(self, page):
+        assert _emits_config_changed(
+            page, lambda: page._mt_standardize.setChecked(not page._mt_standardize.isChecked())
+        )
+
+    @pytest.mark.parametrize("key", ["cargo", "haul", "rank"])
+    def test_remove_word_checkboxes_mark_dirty(self, page, key):
+        box = page._mt_abbrev_boxes[key]
+        assert _emits_config_changed(page, lambda: box.setChecked(not box.isChecked()))
+
+    def test_dropdowns_still_mark_dirty(self, page):
+        """Sanity check the fix didn't accidentally break the controls that
+        already worked — the 5 dropdowns on this page."""
+        assert _emits_config_changed(page, lambda: page._mt_placement.setCurrentIndex(
+            (page._mt_placement.currentIndex() + 1) % page._mt_placement.count()
+        ))
+
+    def test_config_actually_updates_alongside_the_signal(self, page):
+        """The signal firing is only half the bug — confirm the underlying
+        config value is the thing driving it, not a coincidental double-fire."""
+        new_state = not page._mt_underline_direct.isChecked()
+        page._mt_underline_direct.setChecked(new_state)
+        assert ("underline_direct" in page.config.abbreviated_phrases) == new_state


### PR DESCRIPTION
## Summary
- Reported: toggling **Underline "Direct"** on the Enhancements tab's Mission Titles page doesn't light up the **Save Tag Changes** button.
- Root cause: every other control on this page (the 5 dropdowns, General Tags / Scanning checkboxes) calls `self.config_changed.emit()` after updating `self.config`; MainWindow wires that signal to `_mark_tag_dirty()`, which is what enables the Save Tag Changes button (`_apply_tag_btn.setEnabled(dirty)` — it's flat-out **disabled** while not dirty). Four handlers update `self.config` and refresh the preview but never emitted the signal:
  - `_on_mt_standardize_toggle` (Standardize hauling mission names)
  - `_on_mt_abbrev_toggle` (backs Cargo / Haul / Rank *and* Underline Direct)
  - `_on_mt_shorten_titles_toggle` (Shorten original titles)
  - `_on_mt_shorten_sizes_toggle` (Shorten cargo sizes)
  
  **7 checkboxes total** silently failed to arm the dirty state — found the 4th handler (`_on_mt_standardize_toggle`) while fixing the reported one.
- Impact: the edit isn't lost forever — **Generate Enhancements** unconditionally persists the current in-memory config regardless of dirty state — but a user who only touches one of these 7 controls and expects **Save Tag Changes** to work without a full regen gets silently ignored, with the button giving no indication anything needs saving.
- Pre-existing bug, confirmed present identically on `main`, `release/2.2.1`, and `release/2.3.0` — predates this cycle's other work entirely.
- Scanned every other `_on_*` handler in the file for the same missing-emit pattern; none found.

Fixes #259.

## Testing Checklist
- [x] PR is scoped to one concern (one root cause: 4 handlers missing a signal emit)
- [x] `pytest tests/` passes locally (1213 passed, 16 skipped)
- [ ] App launches: `python src/main.py`
- [ ] Affected user-facing flow exercised manually (toggle Underline Direct on the Mission Titles page, confirm Save Tag Changes lights up)
- [x] User-facing strings, `docs/HELP.md`, `docs/ABOUT.md`, and `src/gui/coach_mark.py` reviewed for drift (none — no UI strings changed, purely a signal-wiring fix)
- [x] New non-exempt code has matching test coverage — added `tests/test_mission_titles_page_dirty_signal.py`, driving the real `_TagBuilderPage` widget headlessly (`QT_QPA_PLATFORM=offscreen`, same pattern as `tests/test_restore_backup.py`, no pytest-qt dependency needed)
- [x] Target branch is `release/2.2.1` (patch — bug fix only)
- [x] No direct `QSettings` calls, no hard-coded column indices, no `QProgressBar.setValue()` from workers
- [x] `VERSION.TXT` matches the active release branch

## Testing performed
Full suite (1213 passed, 16 skipped). Confirmed the 9 new tests fail against the pre-fix code (7 of them, exactly matching the 7 broken checkboxes) and pass after the fix, with the 2 dropdown/config-value sanity checks passing throughout — ruling out both a false-positive test and an accidental regression to the controls that already worked. Not exercised: a live GUI toggle-and-observe-the-button-light-up pass (no build environment here).

## Post-merge QA
- [ ] App launches from a clean checkout of the integration branch
- [ ] On the Mission Titles page, toggle each of: Underline Direct, Shorten original titles, Shorten cargo sizes, Standardize hauling mission names, and the Cargo/Haul/Rank checkboxes — confirm Save Tag Changes turns red/enabled after each
- [ ] Confirm the other Tag Builder pages (components, missiles, ship weapons, commodities) and their dropdowns still correctly arm Save Tag Changes — unaffected by this change, but worth a quick regression pass since they share the same button

---
🤖 PR description generated with [Claude Code](https://claude.com/claude-code) and reviewed by @Stealrull