### PR TITLE
[#261] Write applied global.ini with a UTF-8 BOM — fixes @KeyName corruption

### DIFF
--- a/src/merger/ini_merger.py
+++ b/src/merger/ini_merger.py
@@ -215,8 +215,9 @@ def merge_ini_files(
     """Merge source INI with overrides, preserving all lines.
 
     Reads source file line-by-line, replaces values for matching keys,
-    and writes to output as UTF-8. Strips comma-based metadata suffixes
-    (e.g., "key,P") from keys to match normalized override keys.
+    and writes to output as UTF-8 **with a BOM** (#261). Strips comma-based
+    metadata suffixes (e.g., "key,P") from keys to match normalized
+    override keys.
 
     Note: Variant key syncing happens in merge_sources_by_hierarchy(), so
     the overrides_dict already has synced values when this is called.
@@ -253,7 +254,21 @@ def merge_ini_files(
         else:
             trailing_newline = False
 
-        with open(output_path, 'w', encoding='utf-8') as outfile:
+        # utf-8-sig, NOT utf-8 (#261): Data.p4k's own extracted global.ini
+        # ships with a UTF-8 BOM (confirmed: raw unp4k output starts with
+        # \xef\xbb\xbf), and Star Citizen's own loc-string loader appears to
+        # need that BOM to reliably detect the file's encoding. Every prior
+        # release wrote plain utf-8 (no BOM) here — Python's own readers
+        # (read_ini_text / parse_ini_file, both utf-8-sig-aware) never
+        # noticed the mismatch, so validate_applied_file's key-presence
+        # check always reported success even when the applied file was
+        # missing the BOM CIG's engine relies on. Symptom when it bites: the
+        # game shows every string as its raw @KeyName placeholder — not
+        # garbled individual values, because the failure is at the
+        # whole-file encoding-detection stage, before any per-key lookup
+        # happens. See validate_applied_file's BOM check for the second half
+        # of this fix — a safety net in case this write path regresses again.
+        with open(output_path, 'w', encoding='utf-8-sig') as outfile:
             for i, line_rstrip in enumerate(source_lines):
                 # Match the old per-line shape: every line ended with '\n'
                 # except a final line with no trailing newline.

--- a/src/utils/applied_file_validator.py
+++ b/src/utils/applied_file_validator.py
@@ -11,6 +11,21 @@ from src.parser.ini_parser import parse_ini_file
 
 logger = logging.getLogger(__name__)
 
+# Data.p4k's own extracted global.ini ships with this UTF-8 BOM, and Star
+# Citizen's own loc-string loader appears to need it to reliably detect the
+# file's encoding — without it, the game can fail to resolve ANY key (every
+# string shows its raw @KeyName placeholder) rather than degrading per-key
+# (#261). merge_ini_files writes with utf-8-sig specifically to include this,
+# but our OWN readers (parse_ini_file/read_ini_text) are utf-8-sig-aware and
+# silently accept a file with the BOM stripped — so the key-presence check
+# below would report a BOM-less file as fully valid even though the game
+# can't parse it. This is a second, independent line of defense: if the BOM
+# is ever dropped again (a future refactor, a hand-edited file, an external
+# tool overwriting the output), this check fails loudly and the caller rolls
+# back to the last known-good backup instead of leaving a file installed
+# that Python can read fine but the game engine cannot.
+_UTF8_BOM = b"\xef\xbb\xbf"
+
 
 def validate_applied_file(
     written_path: Path,
@@ -19,9 +34,11 @@ def validate_applied_file(
 ) -> str:
     """Validate the written global.ini against the stock base.ini.
 
-    Checks that every key in base.ini is present in the written file.
-    Values are allowed to differ. Extra keys (from components/contracts/
-    commodities sources) are expected and not treated as errors.
+    Checks (1) that the file starts with a UTF-8 BOM — required by the
+    game's own loc-string loader, see ``_UTF8_BOM`` above — and (2) that
+    every key in base.ini is present in the written file. Values are
+    allowed to differ. Extra keys (from components/contracts/commodities
+    sources) are expected and not treated as errors.
 
     Args:
         written_path: Path to the global.ini just written to the game directory.
@@ -34,8 +51,15 @@ def validate_applied_file(
 
     Returns:
         Empty string if validation passed, or a human-readable warning message
-        describing any missing or unexpected keys.
+        describing the problem (missing BOM, and/or missing or unexpected keys).
     """
+    try:
+        with open(written_path, "rb") as f:
+            has_bom = f.read(3) == _UTF8_BOM
+    except OSError as e:
+        logger.warning(f"Validation error reading written file for BOM check: {e}")
+        return ""
+
     if stock_keys is None:
         stock_path = cache_dir / "base.ini"
         if not stock_path.exists():
@@ -59,13 +83,22 @@ def validate_applied_file(
     logger.info(
         f"Validation: stock={len(stock_keys)} keys, "
         f"written={len(written_keys)} keys, "
-        f"missing={len(missing)}, extra={len(extra)}"
+        f"missing={len(missing)}, extra={len(extra)}, has_bom={has_bom}"
     )
 
-    if not missing and not extra:
+    if has_bom and not missing and not extra:
         return ""
 
     lines = []
+
+    if not has_bom:
+        lines += [
+            "The written file is missing its UTF-8 BOM. Star Citizen's own "
+            "localization loader needs this to detect the file's encoding — "
+            "without it the game can fail to resolve every string (shown as "
+            "raw @KeyName placeholders instead of text) rather than just the "
+            "ones that changed.",
+        ]
 
     if missing:
         sample = sorted(missing)[:20]

--- a/tests/test_applied_file_validator.py
+++ b/tests/test_applied_file_validator.py
@@ -11,7 +11,7 @@ pytestmark = pytest.mark.unit
 
 def test_missing_base_ini_returns_empty(tmp_path):
     written = tmp_path / "written.ini"
-    written.write_text("key=val\n", encoding="utf-8")
+    written.write_text("key=val\n", encoding="utf-8-sig")
     result = validate_applied_file(written, tmp_path)
     assert result == ""
 
@@ -19,7 +19,7 @@ def test_missing_base_ini_returns_empty(tmp_path):
 def test_perfect_match_returns_empty(tmp_path):
     (tmp_path / "base.ini").write_text("key=val\n", encoding="utf-8")
     written = tmp_path / "written.ini"
-    written.write_text("key=val\n", encoding="utf-8")
+    written.write_text("key=val\n", encoding="utf-8-sig")
     result = validate_applied_file(written, tmp_path)
     assert result == ""
 
@@ -27,7 +27,7 @@ def test_perfect_match_returns_empty(tmp_path):
 def test_missing_keys_reported(tmp_path):
     (tmp_path / "base.ini").write_text("key1=a\nkey2=b\n", encoding="utf-8")
     written = tmp_path / "written.ini"
-    written.write_text("key1=a\n", encoding="utf-8")
+    written.write_text("key1=a\n", encoding="utf-8-sig")
     result = validate_applied_file(written, tmp_path)
     assert "1 key(s) from base.ini" in result
     assert "key2" in result
@@ -37,7 +37,7 @@ def test_missing_keys_reported(tmp_path):
 def test_extra_keys_reported(tmp_path):
     (tmp_path / "base.ini").write_text("key1=a\n", encoding="utf-8")
     written = tmp_path / "written.ini"
-    written.write_text("key1=a\nextra=b\n", encoding="utf-8")
+    written.write_text("key1=a\nextra=b\n", encoding="utf-8-sig")
     result = validate_applied_file(written, tmp_path)
     assert "1 unexpected key(s)" in result
     assert "extra" in result
@@ -45,7 +45,7 @@ def test_extra_keys_reported(tmp_path):
 
 def test_precomputed_stock_keys_skips_cache_dir(tmp_path):
     written = tmp_path / "written.ini"
-    written.write_text("key1=a\n", encoding="utf-8")
+    written.write_text("key1=a\n", encoding="utf-8-sig")
     result = validate_applied_file(written, tmp_path, stock_keys={"key1", "key2"})
     assert "key2" in result
 
@@ -53,7 +53,7 @@ def test_precomputed_stock_keys_skips_cache_dir(tmp_path):
 def test_more_than_20_missing_shows_truncation(tmp_path):
     stock_keys = {f"key{i}" for i in range(25)}
     written = tmp_path / "written.ini"
-    written.write_text("", encoding="utf-8")
+    written.write_text("", encoding="utf-8-sig")
     result = validate_applied_file(written, tmp_path, stock_keys=stock_keys)
     assert "... and" in result
 
@@ -61,13 +61,13 @@ def test_more_than_20_missing_shows_truncation(tmp_path):
 def test_values_may_differ(tmp_path):
     """Validation passes when keys match even if values diverge."""
     written = tmp_path / "written.ini"
-    written.write_text("k1=different_value\n", encoding="utf-8")
+    written.write_text("k1=different_value\n", encoding="utf-8-sig")
     assert validate_applied_file(written, tmp_path, stock_keys={"k1"}) == ""
 
 
 def test_stock_parse_exception_returns_empty(tmp_path):
     (tmp_path / "base.ini").write_text("key=val\n", encoding="utf-8")
-    (tmp_path / "written.ini").write_text("key=val\n", encoding="utf-8")
+    (tmp_path / "written.ini").write_text("key=val\n", encoding="utf-8-sig")
     with patch(
         "src.utils.applied_file_validator.parse_ini_file",
         side_effect=Exception("boom"),
@@ -78,10 +78,53 @@ def test_stock_parse_exception_returns_empty(tmp_path):
 
 def test_written_parse_exception_returns_empty(tmp_path):
     written = tmp_path / "written.ini"
-    written.write_text("key=val\n", encoding="utf-8")
+    written.write_text("key=val\n", encoding="utf-8-sig")
     with patch(
         "src.utils.applied_file_validator.parse_ini_file",
         side_effect=Exception("boom"),
     ):
         result = validate_applied_file(written, tmp_path, stock_keys={"key"})
     assert result == ""
+
+
+class TestBomCheck:
+    """#261: the game's own loc-string loader needs the UTF-8 BOM Data.p4k's
+    own extracted global.ini ships with to reliably detect encoding — without
+    it the game can fail to resolve every key (shown as raw @KeyName
+    placeholders) rather than degrading per-key. This was the actual
+    mechanism behind a real "whole in-game UI shows raw loc keys" report:
+    merge_ini_files wrote plain utf-8 (no BOM), and our own readers are
+    utf-8-sig-aware so parse_ini_file accepted the BOM-less file fine —
+    meaning the key-presence check alone reported success on a file the game
+    itself couldn't parse. This class is the safety net: a missing BOM must
+    fail validation and trigger the caller's rollback-to-backup path, even
+    when every key is present and every value matches."""
+
+    def test_missing_bom_fails_even_with_perfect_key_match(self, tmp_path):
+        (tmp_path / "base.ini").write_text("key=val\n", encoding="utf-8")
+        written = tmp_path / "written.ini"
+        written.write_text("key=val\n", encoding="utf-8")  # no BOM — the bug
+        result = validate_applied_file(written, tmp_path)
+        assert result != ""
+        assert "BOM" in result
+
+    def test_present_bom_with_perfect_key_match_passes(self, tmp_path):
+        (tmp_path / "base.ini").write_text("key=val\n", encoding="utf-8")
+        written = tmp_path / "written.ini"
+        written.write_text("key=val\n", encoding="utf-8-sig")
+        assert validate_applied_file(written, tmp_path) == ""
+
+    def test_missing_bom_reported_alongside_missing_keys(self, tmp_path):
+        (tmp_path / "base.ini").write_text("key1=a\nkey2=b\n", encoding="utf-8")
+        written = tmp_path / "written.ini"
+        written.write_text("key1=a\n", encoding="utf-8")  # no BOM, and missing key2
+        result = validate_applied_file(written, tmp_path)
+        assert "BOM" in result
+        assert "key2" in result
+
+    def test_unreadable_file_for_bom_check_does_not_crash(self, tmp_path):
+        """A file that vanishes between the caller's write and validation
+        (or any other read error) must not blow up validation — same
+        fail-open posture as the other exception guards in this module."""
+        missing = tmp_path / "does_not_exist.ini"
+        assert validate_applied_file(missing, tmp_path) == ""

--- a/tests/test_ini_encoding_fallback.py
+++ b/tests/test_ini_encoding_fallback.py
@@ -188,7 +188,7 @@ class TestMergerAppliesCorruptedBase:
 
         out = tmp_path / "global.ini"
         merge_ini_files(corrupted_utf8_ini, {"vehicle_NameHunter": "OVERRIDDEN"}, out)
-        text = out.read_text(encoding="utf-8")
+        text = out.read_text(encoding="utf-8-sig")
         assert "vehicle_NameHunter=OVERRIDDEN" in text
         # Untouched keys pass through with their multi-byte chars intact.
         assert "item_NameSHLD_Aspirum=Aspirum™ Shield — Mk. II" in text
@@ -201,11 +201,43 @@ class TestMergerAppliesCorruptedBase:
         src.write_text("a=1\nb=2\n", encoding="utf-8")
         out = tmp_path / "out.ini"
         merge_ini_files(src, {}, out)
-        assert out.read_text(encoding="utf-8") == "a=1\nb=2\n"
+        # utf-8-sig on read strips the BOM merge_ini_files now writes (#261) —
+        # this test is about newline shape, not the BOM, which has its own
+        # dedicated coverage below.
+        assert out.read_text(encoding="utf-8-sig") == "a=1\nb=2\n"
 
         src.write_text("a=1\nb=2", encoding="utf-8")  # no trailing newline
         merge_ini_files(src, {}, out)
-        assert out.read_text(encoding="utf-8") == "a=1\nb=2"
+        assert out.read_text(encoding="utf-8-sig") == "a=1\nb=2"
+
+    def test_merge_ini_files_writes_utf8_bom(self, tmp_path):
+        """#261: Data.p4k's own extracted global.ini ships with a UTF-8 BOM,
+        and Star Citizen's own loc-string loader appears to need it to
+        reliably detect the file's encoding — without it the game can fail
+        to resolve every string (shown as raw @KeyName placeholders)
+        instead of just degrading the ones that changed. merge_ini_files
+        previously wrote plain utf-8 (no BOM); our own readers are
+        utf-8-sig-aware so they never noticed the mismatch, but the game's
+        own parser apparently does."""
+        from src.merger.ini_merger import merge_ini_files
+
+        src = tmp_path / "base.ini"
+        src.write_text("a=1\n", encoding="utf-8")
+        out = tmp_path / "out.ini"
+        merge_ini_files(src, {}, out)
+        assert out.read_bytes().startswith(b"\xef\xbb\xbf")
+
+    def test_merge_ini_files_writes_bom_even_when_source_lacks_one(self, tmp_path):
+        """The BOM in the output must not depend on the source file having
+        one — read_ini_text (#251) already strips a source BOM if present,
+        so the output's BOM always comes from the write side, not a passthrough."""
+        from src.merger.ini_merger import merge_ini_files
+
+        src = tmp_path / "base.ini"
+        src.write_bytes(b"a=1\n")  # deliberately no BOM on the source
+        out = tmp_path / "out.ini"
+        merge_ini_files(src, {}, out)
+        assert out.read_bytes().startswith(b"\xef\xbb\xbf")
 
 
 # ── Sibling #251-class guards (corrupt bytes in app-written state files) ──────


### PR DESCRIPTION
## Summary
- **Critical bug**, confirmed on a tester's real Star Citizen install (caught during internal testing of the v2.2.1 portable build — not published to end users): after Apply, the entire in-game UI showed raw loc keys instead of resolved text (\`@Frontend_PU_SubHeader_Desc\`, \`@FRONTEND_JOIN_THE_UNIVERSE\`, \`@FRONTEND_PLAY_STAR_CITIZEN\`, etc. — every visible string). Deleting Smart Citizen's \`global.ini\` restored correct text immediately.
- **Root cause**: Data.p4k's own extracted \`global.ini\` ships with a UTF-8 BOM (confirmed directly: raw unp4k output starts with \`\xef\xbb\xbf\`). Star Citizen's own localization loader appears to require that BOM to reliably detect the file's encoding — without it, the engine can fail to resolve the **entire** loc table rather than degrading per-key, which is exactly the observed symptom (every string, not just changed ones). \`merge_ini_files\` — the function that writes the final applied \`global.ini\` — has written plain UTF-8 with **no BOM** in every prior release, not something introduced this cycle.
- **Why nothing caught it**: the existing rollback-on-failure safety net, \`validate_applied_file\`, only checked stock-key *presence*. Our own readers (\`parse_ini_file\`/\`read_ini_text\`) are \`utf-8-sig\`-aware, so a BOM-less file parses back with every key intact and passes validation cleanly — the game's own parser is apparently stricter than ours, so validation reported success on a file the game couldn't actually load.
- **Fix, two parts**:
  1. \`merge_ini_files\` now writes with \`encoding='utf-8-sig'\`, matching Data.p4k's own format byte-for-byte.
  2. \`validate_applied_file\` now treats a missing BOM as its own validation failure (independent of key presence), triggering the existing rollback-to-backup path. If this write path ever regresses again, it fails loudly instead of silently installing a file the game can't read.
- Verified by replaying the exact Extract→Apply pipeline against the reporting tester's real cached \`base.ini\`, enhancement files, and \`user.ini\`: pre-fix code reproduces a byte-for-byte no-BOM output; post-fix code produces a correctly-BOM'd file that \`validate_applied_file\` confirms as PASS.

Fixes #261.

## Testing Checklist
- [x] PR is scoped to one concern (one root cause, two-part fix + hardened safety net)
- [x] \`pytest tests/\` passes locally (1210 passed, 16 skipped)
- [ ] App launches: \`python src/main.py\`
- [ ] Affected user-facing flow exercised manually (Apply to Game, then check in-game that the main menu/mobiGlas render normal text, not raw @KeyName)
- [x] User-facing strings, \`docs/HELP.md\`, \`docs/ABOUT.md\`, and \`src/gui/coach_mark.py\` reviewed for drift (none — no UI strings changed)
- [x] New non-exempt code has matching test coverage — 2 new tests in \`tests/test_ini_encoding_fallback.py\` (BOM is written; BOM is written even when the source lacks one) and 4 new tests in \`tests/test_applied_file_validator.py\` (missing BOM fails validation even with a perfect key match; present BOM + perfect match passes; BOM failure reports alongside missing-key failures; a read error during the BOM check doesn't crash). Updated all pre-existing validator tests to write their "valid" fixture files with the BOM, since that's now part of what "valid" means.
- [x] Target branch is \`release/2.2.1\` (patch — bug fix only)
- [x] No direct \`QSettings\` calls, no hard-coded column indices, no \`QProgressBar.setValue()\` from workers
- [x] \`VERSION.TXT\` matches the active release branch

## Testing performed
Full suite (1210 passed, 16 skipped). Reproduced the actual bug and its fix end-to-end using a tester's real files (not synthetic fixtures): pulled their cached \`base.ini\`, all 9 enhancement INIs, and \`user.ini\` from their portable install's data folder, replayed the exact merge pipeline \`apply_to_game\` runs, and confirmed (a) the pre-fix code path produces a byte-for-byte BOM-less file matching what's on disk after their actual Apply, and (b) the fixed code produces output starting with \`\xef\xbb\xbf\` that \`validate_applied_file\` now reports as a clean PASS. Not exercised: an actual live-game screenshot confirming the fixed build resolves strings correctly (no build/deploy environment here) — that's the one item on the post-merge checklist below.

## Post-merge QA
- [ ] App launches from a clean checkout of the integration branch
- [ ] Apply to a real Star Citizen install, launch the game, confirm the main menu/mobiGlas/contacts panel show real text — this is the one thing that must be re-verified in a live game session, since it's the whole point of the fix
- [ ] Confirm Export Loc-Pack (which reads the already-applied file directly) also produces a BOM'd zip — should be automatic since it doesn't re-write the file, but worth a quick sanity check
- [ ] Spot-check that re-applying over an already-BOM'd file (the normal "user clicks Apply again" case) still validates cleanly

---
🤖 PR description generated with [Claude Code](https://claude.com/claude-code) and reviewed by @Stealrull