### PR TITLE
[#266] Tags for fuel nozzles, mining lasers, and scraper modules

### DIFF
--- a/scripts/generate_enhancements_ini.py
+++ b/scripts/generate_enhancements_ini.py
@@ -5676,7 +5676,11 @@ def enhancements_medical_consumables(ctx: dict) -> dict[str, str]:
 # name" -- items like Shield Generator already get tagged via the strict
 # Class-based DataForge scan path (_component_name_tag), and blindly
 # matching their Item Type text here too would double-tag them.
-_BARE_TYPE_NAMES: frozenset[str] = frozenset({"Fuel Nozzle"})
+#
+# Scraper Module (Trawler/Cinch/Abrade, item_scraper_GRIN_*) shares the
+# exact same shape -- "Item Type: Scraper Module" with no Size:/Grade:/
+# Class: line -- confirmed via tests/fixtures/kraken_global_latest.ini.
+_BARE_TYPE_NAMES: frozenset[str] = frozenset({"Fuel Nozzle", "Scraper Module"})
 
 
 def _component_element(cfg: "TagConfig", kind: str) -> "ElementSpec | None":

--- a/scripts/generate_enhancements_ini.py
+++ b/scripts/generate_enhancements_ini.py
@@ -938,21 +938,26 @@ def _ship_weapon_name_tag_factory(ammo_lookup: dict, config: "TagConfig | None" 
     ship-weapon shape.
     """
     cfg = config or DEFAULT_TAG_CONFIGS.get("ship_weapons")
+    # Mining laser tagging is gated by the same Components > Type toggle as
+    # every other DEFAULT_COMPONENT_TYPE_MAPPING entry -- opt-in, not
+    # force-shown (#266). Size rides along too if the user also has the
+    # Components > Size element enabled (true by default).
     mining_cfg_src = mining_laser_config or DEFAULT_TAG_CONFIGS.get("components")
     mining_tag_cfg = None
     if mining_cfg_src is not None and ElementSpec is not None:
-        mining_tag_cfg = TagConfig(
-            elements=[
-                ElementSpec(kind="type", enabled=True,
-                            style=_element_style(mining_cfg_src, "type", "med")),
-                ElementSpec(kind="size", enabled=True,
-                            style=_element_style(mining_cfg_src, "size", "sn")),
-            ],
-            separator=mining_cfg_src.separator,
-            enclosing=mining_cfg_src.enclosing,
-            placement=mining_cfg_src.placement,
-            class_mapping=mining_cfg_src.class_mapping,
-        )
+        type_el = _component_element(mining_cfg_src, "type")
+        if type_el is not None and type_el.enabled:
+            elements = [ElementSpec(kind="type", enabled=True, style=type_el.style or "med")]
+            size_el = _component_element(mining_cfg_src, "size")
+            if size_el is not None and size_el.enabled:
+                elements.append(ElementSpec(kind="size", enabled=True, style=size_el.style or "sn"))
+            mining_tag_cfg = TagConfig(
+                elements=elements,
+                separator=mining_cfg_src.separator,
+                enclosing=mining_cfg_src.enclosing,
+                placement=mining_cfg_src.placement,
+                class_mapping=mining_cfg_src.class_mapping,
+            )
 
     def _tag(desc_value: str, root: ET.Element | None = None) -> str | None:
         if cfg is None or render_tag is None or root is None:
@@ -5653,9 +5658,11 @@ def enhancements_medical_consumables(ctx: dict) -> dict[str, str]:
 # ── Bare-type tags for size-less components (#266) ──────────────────────────
 # Some component-adjacent items (fuel nozzles so far; more may follow) carry
 # no Size:/Grade:/Class: of their own -- there's nothing to hang the usual
-# [MIL-S1-A] shape off of, and the optional "Type" element
-# (DEFAULT_COMPONENT_TYPE_MAPPING) is disabled by default, so without this
-# they'd never show any tag at all ("What is an R7?" -- issue #266).
+# [MIL-S1-A] shape off of, so a Type-only tag is their only option. Gated
+# by the same "Type" element toggle as every other DEFAULT_COMPONENT_TYPE_
+# MAPPING entry (Shield Generator, Cooler, ...) -- users opt in via the
+# Tag Builder's Components > Type checkbox like any other component, they
+# don't get force-shown just because they'd otherwise have no other tag.
 # Identified purely by loc-key prefix, no DataForge scan needed -- these
 # items already carry real stock item_Name/item_Desc entries in base.ini,
 # same "base.ini is the only input" shape as
@@ -5665,29 +5672,21 @@ _BARE_TYPE_KEY_PREFIXES: dict[str, str] = {
 }
 
 
-def _element_style(cfg: "TagConfig", kind: str, default: str) -> str:
-    """Read the style a user has picked for one element kind of a
-    TagConfig, even when that element is currently disabled.
-
-    Used to force-enable an element (Type for bare-type items, Type+Size
-    for mining lasers) while still honouring whatever abbreviation length
-    the user chose for it rather than silently resetting to a default.
-    """
+def _component_element(cfg: "TagConfig", kind: str) -> "ElementSpec | None":
+    """Look up one element kind (its enabled flag + style) on a TagConfig."""
     for el in cfg.elements:
         if el.kind == kind:
-            return el.style or default
-    return default
+            return el
+    return None
 
 
 def enhancements_bare_type_tags(ctx: dict) -> dict[str, str]:
     """Tag size-less component items with a Type-only bracket tag (#266).
 
-    Forces the Type element on for just this tag, regardless of whether the
-    user has the optional Type element enabled for regular (sized)
-    components -- these items have no other way to ever show a tag, so
-    respecting a default-off toggle here would leave them permanently blank.
-    Still respects the user's chosen bracket/separator style and whatever
-    abbreviation length they've picked for Type, if they've touched it.
+    Only fires when the user has the Components > Type element enabled --
+    same opt-in switch that gates Shield Generator/Cooler/Power Plant/etc.
+    Type tags. Respects whatever abbreviation length (short/medium/long)
+    they've chosen for it.
     """
     loc = ctx["loc"]
     tag_configs = ctx.get("tag_configs") or {}
@@ -5695,10 +5694,12 @@ def enhancements_bare_type_tags(ctx: dict) -> dict[str, str]:
     if comp_cfg is None or ElementSpec is None or render_tag is None:
         return {}
 
-    type_style = _element_style(comp_cfg, "type", "med")
+    type_el = _component_element(comp_cfg, "type")
+    if type_el is None or not type_el.enabled:
+        return {}
 
     tag_cfg = TagConfig(
-        elements=[ElementSpec(kind="type", enabled=True, style=type_style)],
+        elements=[ElementSpec(kind="type", enabled=True, style=type_el.style or "med")],
         separator=comp_cfg.separator,
         enclosing=comp_cfg.enclosing,
         placement=comp_cfg.placement,

--- a/scripts/generate_enhancements_ini.py
+++ b/scripts/generate_enhancements_ini.py
@@ -51,7 +51,8 @@ try:
     from src.utils.tag_builder import (
         CRAFT_USAGE_CATEGORIES, DAMAGE_LABEL_TO_MAPPING_KEY,
         DEFAULT_COMMODITY_USAGE_MAPPING, DEFAULT_COMPONENT_CLASS_MAPPING,
-        DEFAULT_TAG_CONFIGS, SIZE_ABBREV_BY_WORD, TagConfig, USAGE_INPUT_SEP,
+        DEFAULT_COMPONENT_TYPE_MAPPING, DEFAULT_TAG_CONFIGS, ElementSpec,
+        SIZE_ABBREV_BY_WORD, TagConfig, USAGE_INPUT_SEP,
         abbreviate_title, apply_mission_title, render_route, render_tag,
         route_enabled,
     )
@@ -60,7 +61,9 @@ except ImportError:  # pragma: no cover — only triggers if src/ is removed
     DAMAGE_LABEL_TO_MAPPING_KEY = {}  # type: ignore[assignment]
     DEFAULT_COMMODITY_USAGE_MAPPING = {}  # type: ignore[assignment]
     DEFAULT_COMPONENT_CLASS_MAPPING = {}  # type: ignore[assignment]
+    DEFAULT_COMPONENT_TYPE_MAPPING = {}  # type: ignore[assignment]
     DEFAULT_TAG_CONFIGS = {}  # type: ignore[assignment]
+    ElementSpec = None  # type: ignore[assignment]
     TagConfig = None  # type: ignore[assignment]
     USAGE_INPUT_SEP = "\x1f"  # type: ignore[assignment]
     render_tag = None  # type: ignore[assignment]
@@ -919,15 +922,37 @@ def _missile_name_tag(desc_value: str, root: ET.Element | None = None,
     return out or None
 
 
-def _ship_weapon_name_tag_factory(ammo_lookup: dict, config: "TagConfig | None" = None):
+def _ship_weapon_name_tag_factory(ammo_lookup: dict, config: "TagConfig | None" = None,
+                                   mining_laser_config: "TagConfig | None" = None):
     """Build a closure-tagger for ship weapons.
 
     Needs the ammo_lookup to resolve the dominant damage type, so it can't
     use the bare ``(desc, root)`` shape the other taggers use. Returns a
     function with the standard ``(desc_value, root)`` signature for
     ``scan_entity_dir``.
+
+    ``mining_laser_config`` is the user's "components" Tag Builder config
+    (not "ship_weapons") -- mining lasers live in ships/weapons/ alongside
+    combat weapons but aren't combat weapons themselves (#266), so they're
+    tagged with the component Type+Size shape instead of the damage-keyed
+    ship-weapon shape.
     """
     cfg = config or DEFAULT_TAG_CONFIGS.get("ship_weapons")
+    mining_cfg_src = mining_laser_config or DEFAULT_TAG_CONFIGS.get("components")
+    mining_tag_cfg = None
+    if mining_cfg_src is not None and ElementSpec is not None:
+        mining_tag_cfg = TagConfig(
+            elements=[
+                ElementSpec(kind="type", enabled=True,
+                            style=_element_style(mining_cfg_src, "type", "med")),
+                ElementSpec(kind="size", enabled=True,
+                            style=_element_style(mining_cfg_src, "size", "sn")),
+            ],
+            separator=mining_cfg_src.separator,
+            enclosing=mining_cfg_src.enclosing,
+            placement=mining_cfg_src.placement,
+            class_mapping=mining_cfg_src.class_mapping,
+        )
 
     def _tag(desc_value: str, root: ET.Element | None = None) -> str | None:
         if cfg is None or render_tag is None or root is None:
@@ -973,11 +998,18 @@ def _ship_weapon_name_tag_factory(ammo_lookup: dict, config: "TagConfig | None" 
                     )
 
         # Require a resolvable damage label. Items in ships/weapons/ that
-        # lack a damage breakdown — EMP devices, tractor / towing beams,
-        # mining lasers (which have their own enhancements_mining_laser
-        # pipeline) — would otherwise emit a size-only tag like ``[S1]``
-        # that's meaningless next to the entity's own name. Skip those.
+        # lack a damage breakdown — EMP devices, tractor / towing beams —
+        # would otherwise emit a size-only tag like ``[S1]`` that's
+        # meaningless next to the entity's own name. Skip those. Mining
+        # lasers are the one exception: they're not combat weapons (no
+        # damage breakdown) but ARE a real component type with a real
+        # Size, so tag them via the component Type+Size shape instead of
+        # skipping outright (#266).
         if not damage_label:
+            if mining_tag_cfg is not None and render_tag is not None and \
+                    _find(root, "SEntityComponentMiningLaserParams") is not None:
+                out = render_tag(mining_tag_cfg, {"type": "Mining Laser", "size": size or ""})
+                return out or None
             return None
         out = render_tag(cfg, {"damage": damage_label, "size": size or ""})
         return out or None
@@ -5618,6 +5650,91 @@ def enhancements_medical_consumables(ctx: dict) -> dict[str, str]:
     return out
 
 
+# ── Bare-type tags for size-less components (#266) ──────────────────────────
+# Some component-adjacent items (fuel nozzles so far; more may follow) carry
+# no Size:/Grade:/Class: of their own -- there's nothing to hang the usual
+# [MIL-S1-A] shape off of, and the optional "Type" element
+# (DEFAULT_COMPONENT_TYPE_MAPPING) is disabled by default, so without this
+# they'd never show any tag at all ("What is an R7?" -- issue #266).
+# Identified purely by loc-key prefix, no DataForge scan needed -- these
+# items already carry real stock item_Name/item_Desc entries in base.ini,
+# same "base.ini is the only input" shape as
+# enhancements_medical_consumables above.
+_BARE_TYPE_KEY_PREFIXES: dict[str, str] = {
+    "item_fuelnozzle_": "Fuel Nozzle",
+}
+
+
+def _element_style(cfg: "TagConfig", kind: str, default: str) -> str:
+    """Read the style a user has picked for one element kind of a
+    TagConfig, even when that element is currently disabled.
+
+    Used to force-enable an element (Type for bare-type items, Type+Size
+    for mining lasers) while still honouring whatever abbreviation length
+    the user chose for it rather than silently resetting to a default.
+    """
+    for el in cfg.elements:
+        if el.kind == kind:
+            return el.style or default
+    return default
+
+
+def enhancements_bare_type_tags(ctx: dict) -> dict[str, str]:
+    """Tag size-less component items with a Type-only bracket tag (#266).
+
+    Forces the Type element on for just this tag, regardless of whether the
+    user has the optional Type element enabled for regular (sized)
+    components -- these items have no other way to ever show a tag, so
+    respecting a default-off toggle here would leave them permanently blank.
+    Still respects the user's chosen bracket/separator style and whatever
+    abbreviation length they've picked for Type, if they've touched it.
+    """
+    loc = ctx["loc"]
+    tag_configs = ctx.get("tag_configs") or {}
+    comp_cfg = tag_configs.get("components") or DEFAULT_TAG_CONFIGS.get("components")
+    if comp_cfg is None or ElementSpec is None or render_tag is None:
+        return {}
+
+    type_style = _element_style(comp_cfg, "type", "med")
+
+    tag_cfg = TagConfig(
+        elements=[ElementSpec(kind="type", enabled=True, style=type_style)],
+        separator=comp_cfg.separator,
+        enclosing=comp_cfg.enclosing,
+        placement=comp_cfg.placement,
+        class_mapping=comp_cfg.class_mapping,
+    )
+    placement = getattr(comp_cfg, "placement", "prepend")
+
+    out: dict[str, str] = {}
+    for key, name_value in loc.items():
+        if not name_value:
+            continue
+        kl = key.lower()
+        if not kl.endswith("_name"):
+            continue
+        type_name = next(
+            (t for prefix, t in _BARE_TYPE_KEY_PREFIXES.items() if kl.startswith(prefix)),
+            None,
+        )
+        if type_name is None:
+            continue
+        tag = render_tag(tag_cfg, {"type": type_name})
+        if not tag:
+            continue
+        if placement == "append":
+            out[key] = f"{name_value} {tag}"
+        else:
+            out[key] = f"{tag} {name_value}"
+        short_key = f"{key}_short"
+        short_value = loc.get(short_key)
+        if short_value:
+            out[short_key] = f"{short_value} {tag}" if placement == "append" else f"{tag} {short_value}"
+
+    logger.info(f"Finished bare-type tags ({len(out)} entries)")
+    return out
+
+
 def _run_gen_components(ctx: dict) -> dict[str, str]:
     loc             = ctx["loc"]
     ships_scitem    = ctx["ships_scitem"]
@@ -5663,6 +5780,14 @@ def _run_gen_components(ctx: dict) -> dict[str, str]:
             f"Propagated enhancements to {sibling_count} _SCItem siblings "
             f"and {inv_sibling_count} legacy no-underscore siblings"
         )
+
+    # #266: size-less components (fuel nozzles, ...) -- base.ini-only, no
+    # DataForge scan, so run and merge separately from the entity-dir walk
+    # above rather than trying to force them through _mirror_scitem_siblings,
+    # which targets the SHLD_/POWR_-style variant-naming quirk these items
+    # don't share.
+    out.update(enhancements_bare_type_tags(ctx))
+
     return out
 
 
@@ -5734,9 +5859,12 @@ def _run_gen_ship_weapons(ctx: dict) -> dict[str, str]:
     ship_weapon_placement = (
         getattr(ship_weapon_cfg, "placement", "prepend") if ship_weapon_cfg else "prepend"
     )
+    mining_laser_cfg = tag_configs.get("components") or DEFAULT_TAG_CONFIGS.get("components")
     # Ship weapons gain name tags in 1.3.x (issue #31). The factory captures
     # ammo_lookup so the tagger can resolve the dominant damage type.
-    ship_weapon_tagger = _ship_weapon_name_tag_factory(vehicle_ammo, config=ship_weapon_cfg)
+    ship_weapon_tagger = _ship_weapon_name_tag_factory(
+        vehicle_ammo, config=ship_weapon_cfg, mining_laser_config=mining_laser_cfg,
+    )
 
     out: dict[str, str] = {}
     weapons_dir = ships_scitem / "weapons"

--- a/scripts/generate_enhancements_ini.py
+++ b/scripts/generate_enhancements_ini.py
@@ -5663,13 +5663,20 @@ def enhancements_medical_consumables(ctx: dict) -> dict[str, str]:
 # MAPPING entry (Shield Generator, Cooler, ...) -- users opt in via the
 # Tag Builder's Components > Type checkbox like any other component, they
 # don't get force-shown just because they'd otherwise have no other tag.
-# Identified purely by loc-key prefix, no DataForge scan needed -- these
-# items already carry real stock item_Name/item_Desc entries in base.ini,
-# same "base.ini is the only input" shape as
-# enhancements_medical_consumables above.
-_BARE_TYPE_KEY_PREFIXES: dict[str, str] = {
-    "item_fuelnozzle_": "Fuel Nozzle",
-}
+#
+# Identified by the description's own "Item Type: X" line, NOT by loc-key
+# naming -- fuel nozzles alone ship under at least two different key
+# conventions for different manufacturers (item_fuelnozzle_MISC_Standard_*
+# for MISC/RN-7s, but Nozzle_FuelGiver_GRIN_NozzleSecure_* for Greycat's
+# Marlin/Lindstrom and Nozzle_FuelGiver_SHIN_*  for Shubin's Bendix/Torrez/
+# Ezra -- confirmed via the String Editor and tests/fixtures/kraken_global_
+# latest.ini). Matching the stock "Item Type:" text is the only approach
+# that generalises across manufacturer-specific key names. Deliberately a
+# small explicit allow-list rather than "any DEFAULT_COMPONENT_TYPE_MAPPING
+# name" -- items like Shield Generator already get tagged via the strict
+# Class-based DataForge scan path (_component_name_tag), and blindly
+# matching their Item Type text here too would double-tag them.
+_BARE_TYPE_NAMES: frozenset[str] = frozenset({"Fuel Nozzle"})
 
 
 def _component_element(cfg: "TagConfig", kind: str) -> "ElementSpec | None":
@@ -5714,11 +5721,12 @@ def enhancements_bare_type_tags(ctx: dict) -> dict[str, str]:
         kl = key.lower()
         if not kl.endswith("_name"):
             continue
-        type_name = next(
-            (t for prefix, t in _BARE_TYPE_KEY_PREFIXES.items() if kl.startswith(prefix)),
-            None,
-        )
-        if type_name is None:
+        desc_value = loc.get(f"{key[:-len('_Name')]}_Desc", "")
+        if not desc_value:
+            continue
+        type_m = re.search(r"Item Type:\s*([^\\\n]+?)\s*(?:\\n|\n|$)", desc_value)
+        type_name = type_m.group(1).strip() if type_m else None
+        if type_name not in _BARE_TYPE_NAMES:
             continue
         tag = render_tag(tag_cfg, {"type": type_name})
         if not tag:

--- a/scripts/generate_enhancements_ini.py
+++ b/scripts/generate_enhancements_ini.py
@@ -922,6 +922,65 @@ def _missile_name_tag(desc_value: str, root: ET.Element | None = None,
     return out or None
 
 
+def _build_mining_laser_tag_cfg(mining_cfg_src: "TagConfig | None") -> "TagConfig | None":
+    """Build the Type(+Size) TagConfig used to tag ship-mounted mining
+    lasers, gated by the same Components > Type toggle as every other
+    DEFAULT_COMPONENT_TYPE_MAPPING entry -- opt-in, not force-shown
+    (#266). Size rides along too only if the user's Components > Size
+    element is also enabled (true by default). None when Type is
+    disabled or no builder config is available.
+
+    Shared by _ship_weapon_name_tag_factory (tags the mining laser's own
+    item_Name) and build_scitem_lookups (tags its mission-blueprint
+    bullet), so the two Type+Size tagging paths can't drift out of sync.
+    """
+    if mining_cfg_src is None or ElementSpec is None:
+        return None
+    type_el = _component_element(mining_cfg_src, "type")
+    if type_el is None or not type_el.enabled:
+        return None
+    elements = [ElementSpec(kind="type", enabled=True, style=type_el.style or "med")]
+    size_el = _component_element(mining_cfg_src, "size")
+    if size_el is not None and size_el.enabled:
+        elements.append(ElementSpec(kind="size", enabled=True, style=size_el.style or "sn"))
+    return TagConfig(
+        elements=elements,
+        separator=mining_cfg_src.separator,
+        enclosing=mining_cfg_src.enclosing,
+        placement=mining_cfg_src.placement,
+        class_mapping=mining_cfg_src.class_mapping,
+    )
+
+
+def _mining_laser_component_tag(desc_value: str, root: "ET.Element | None",
+                                 mining_tag_cfg: "TagConfig | None") -> str | None:
+    """Render the component-style Type(+Size) tag for a ship-mounted
+    mining laser entity (e.g. ``[Mining Laser-S1]``), or None when the
+    entity isn't a mining laser, no tag config is available, or
+    render_tag can't be imported.
+
+    Size prefers the entity class name attribute (matches
+    _extract_item_size elsewhere), falling back to a Size: N line in the
+    description. Shared by _ship_weapon_name_tag_factory and
+    build_scitem_lookups -- see _build_mining_laser_tag_cfg.
+    """
+    if mining_tag_cfg is None or render_tag is None or root is None:
+        return None
+    if _find(root, "SEntityComponentMiningLaserParams") is None:
+        return None
+    size = None
+    name_attr = root.get("Name") or root.get("name") or ""
+    m = re.search(r"_S0*(\d+)_", name_attr)
+    if m:
+        size = str(int(m.group(1)))
+    if not size:
+        ds = re.search(r"Size:\s*(\d+)", desc_value)
+        if ds:
+            size = ds.group(1)
+    out = render_tag(mining_tag_cfg, {"type": "Mining Laser", "size": size or ""})
+    return out or None
+
+
 def _ship_weapon_name_tag_factory(ammo_lookup: dict, config: "TagConfig | None" = None,
                                    mining_laser_config: "TagConfig | None" = None):
     """Build a closure-tagger for ship weapons.
@@ -938,26 +997,8 @@ def _ship_weapon_name_tag_factory(ammo_lookup: dict, config: "TagConfig | None" 
     ship-weapon shape.
     """
     cfg = config or DEFAULT_TAG_CONFIGS.get("ship_weapons")
-    # Mining laser tagging is gated by the same Components > Type toggle as
-    # every other DEFAULT_COMPONENT_TYPE_MAPPING entry -- opt-in, not
-    # force-shown (#266). Size rides along too if the user also has the
-    # Components > Size element enabled (true by default).
     mining_cfg_src = mining_laser_config or DEFAULT_TAG_CONFIGS.get("components")
-    mining_tag_cfg = None
-    if mining_cfg_src is not None and ElementSpec is not None:
-        type_el = _component_element(mining_cfg_src, "type")
-        if type_el is not None and type_el.enabled:
-            elements = [ElementSpec(kind="type", enabled=True, style=type_el.style or "med")]
-            size_el = _component_element(mining_cfg_src, "size")
-            if size_el is not None and size_el.enabled:
-                elements.append(ElementSpec(kind="size", enabled=True, style=size_el.style or "sn"))
-            mining_tag_cfg = TagConfig(
-                elements=elements,
-                separator=mining_cfg_src.separator,
-                enclosing=mining_cfg_src.enclosing,
-                placement=mining_cfg_src.placement,
-                class_mapping=mining_cfg_src.class_mapping,
-            )
+    mining_tag_cfg = _build_mining_laser_tag_cfg(mining_cfg_src)
 
     def _tag(desc_value: str, root: ET.Element | None = None) -> str | None:
         if cfg is None or render_tag is None or root is None:
@@ -1011,11 +1052,7 @@ def _ship_weapon_name_tag_factory(ammo_lookup: dict, config: "TagConfig | None" 
         # Size, so tag them via the component Type+Size shape instead of
         # skipping outright (#266).
         if not damage_label:
-            if mining_tag_cfg is not None and render_tag is not None and \
-                    _find(root, "SEntityComponentMiningLaserParams") is not None:
-                out = render_tag(mining_tag_cfg, {"type": "Mining Laser", "size": size or ""})
-                return out or None
-            return None
+            return _mining_laser_component_tag(desc_value, root, mining_tag_cfg)
         out = render_tag(cfg, {"damage": damage_label, "size": size or ""})
         return out or None
 
@@ -5238,14 +5275,21 @@ def build_scitem_lookups(
       filename in CIG's authored layout.
     * entity_name_tags: __ref UUID → ``[CLASS-Sx-grade]`` tag (e.g.
       ``[MIL-S1-A]``) when the entity is a ship component whose
-      description carries the Size:/Grade:/Class: header trio.
-      Only populated for components that ``_component_name_tag``
-      can classify — FPS gear, weapons, ships, missiles, ammo, etc.
-      get no entry. Used by blueprint pool resolution to apply the
-      same annotation to blueprint reward names that the components
-      pipeline applies to stock component titles, so a mission's
-      "POTENTIAL BLUEPRINTS" list reads e.g. "Norfield [MIL-S1-A]"
-      instead of bare "Norfield".
+      description carries the Size:/Grade:/Class: header trio, plus
+      three narrower exceptions (#266 follow-up): a Type-only tag for
+      size-less Fuel Nozzle/Scraper Module entities (matching
+      enhancements_bare_type_tags), and a Type+Size tag for ship-mounted
+      Mining Laser entities (matching _ship_weapon_name_tag_factory's own
+      mining-laser branch) despite living under the excluded "weapons"
+      subtree. Everything else under "weapons" (combat weapons, FPS
+      gear, missiles, ammo) still gets no entry. Used by blueprint pool
+      resolution to apply the same annotation to blueprint reward names
+      that the components/ship-weapon pipelines apply to stock item
+      titles, so a mission's "POTENTIAL BLUEPRINTS" list reads e.g.
+      "Norfield [MIL-S1-A]" or "Norfield [Fuel Nozzle]" instead of bare
+      "Norfield" -- without this, the tag only ever appeared on the
+      item's own name, never inside the mission text a player actually
+      reads.
 
     Walking the scitem tree once instead of twice (magazines + entity names
     used to iterate independently) cuts ~30s off the run since there are
@@ -5258,6 +5302,8 @@ def build_scitem_lookups(
     loc = loc or {}
     if not scitem_dir.exists():
         return mag_lookup, entity_names, entity_names_by_filename, entity_name_tags
+
+    mining_tag_cfg = _build_mining_laser_tag_cfg(tag_config)
 
     null_uuid = "00000000-0000-0000-0000-000000000000"
     xml_files = (
@@ -5331,18 +5377,38 @@ def build_scitem_lookups(
             # Weapons/missiles are meant to pass through bare (per request +
             # the docstring above) since they have their own tag mechanisms
             # (or none) that aren't wired into blueprint-pool weaving.
-            if desc_value and "weapons" not in _parts:
-                # Derive the component type from the entity's subdir so the
-                # blueprint-list tag carries the same Type element the
-                # standalone component path emits (#101). Non-component
-                # entities won't be under these subdirs (comp_type stays "")
-                # and _component_name_tag returns None for them regardless.
-                comp_type = next(
-                    (t for sd, t in _SUBDIR_TO_TYPE.items() if sd in _parts), ""
-                )
-                tag = _component_name_tag(
-                    desc_value, root, config=tag_config, component_type=comp_type
-                )
+            #
+            # Mining lasers are the one "weapons" exception (#266 follow-up):
+            # they're not combat weapons (no damage breakdown, so
+            # _component_name_tag would never fire for them anyway) but ARE
+            # a real component type with a real Size, tagged via the same
+            # Type+Size shape _ship_weapon_name_tag_factory already applies
+            # to their own item_Name.
+            is_mining_laser = "weapons" in _parts and _find(
+                root, "SEntityComponentMiningLaserParams"
+            ) is not None
+            if desc_value and ("weapons" not in _parts or is_mining_laser):
+                if is_mining_laser:
+                    tag = _mining_laser_component_tag(desc_value, root, mining_tag_cfg)
+                else:
+                    # Derive the component type from the entity's subdir so the
+                    # blueprint-list tag carries the same Type element the
+                    # standalone component path emits (#101). Non-component
+                    # entities won't be under these subdirs (comp_type stays "")
+                    # and _component_name_tag returns None for them regardless.
+                    comp_type = next(
+                        (t for sd, t in _SUBDIR_TO_TYPE.items() if sd in _parts), ""
+                    )
+                    tag = _component_name_tag(
+                        desc_value, root, config=tag_config, component_type=comp_type
+                    )
+                    # #266 follow-up: Fuel Nozzle and Scraper Module carry no
+                    # Size:/Grade:/Class: at all, so _component_name_tag above
+                    # always returns None for them -- fall back to the same
+                    # Type-only bare-type tag enhancements_bare_type_tags
+                    # applies to their own item_Name.
+                    if not tag:
+                        tag = _bare_type_tag_from_desc(desc_value, tag_config)
                 # #160: armour, magazines, salvage/mining heads and other FPS
                 # gear expose Size + Grade in their AttachDef but no ship
                 # component CLASS, so _component_name_tag falls back to a
@@ -5691,6 +5757,37 @@ def _component_element(cfg: "TagConfig", kind: str) -> "ElementSpec | None":
     return None
 
 
+def _bare_type_tag_from_desc(desc_value: str, comp_cfg: "TagConfig | None") -> str | None:
+    """Render a Type-only tag (e.g. ``[Fuel Nozzle]``) for a size-less
+    item (Fuel Nozzle, Scraper Module) from its raw description text, or
+    None when the description's Item Type isn't in the small bare-type
+    allow-list (_BARE_TYPE_NAMES) or the user hasn't enabled the
+    Components > Type element.
+
+    Shared by enhancements_bare_type_tags (per base.ini Name/Desc pair,
+    tags the item's own name) and build_scitem_lookups (per scanned
+    entity XML, tags its mission-blueprint bullet) so the two Type-only
+    tagging paths can't drift out of sync (#266 follow-up).
+    """
+    if comp_cfg is None or ElementSpec is None or render_tag is None:
+        return None
+    type_el = _component_element(comp_cfg, "type")
+    if type_el is None or not type_el.enabled:
+        return None
+    type_m = re.search(r"Item Type:\s*([^\\\n]+?)\s*(?:\\n|\n|$)", desc_value)
+    type_name = type_m.group(1).strip() if type_m else None
+    if type_name not in _BARE_TYPE_NAMES:
+        return None
+    tag_cfg = TagConfig(
+        elements=[ElementSpec(kind="type", enabled=True, style=type_el.style or "med")],
+        separator=comp_cfg.separator,
+        enclosing=comp_cfg.enclosing,
+        placement=comp_cfg.placement,
+        class_mapping=comp_cfg.class_mapping,
+    )
+    return render_tag(tag_cfg, {"type": type_name})
+
+
 def enhancements_bare_type_tags(ctx: dict) -> dict[str, str]:
     """Tag size-less component items with a Type-only bracket tag (#266).
 
@@ -5702,20 +5799,8 @@ def enhancements_bare_type_tags(ctx: dict) -> dict[str, str]:
     loc = ctx["loc"]
     tag_configs = ctx.get("tag_configs") or {}
     comp_cfg = tag_configs.get("components") or DEFAULT_TAG_CONFIGS.get("components")
-    if comp_cfg is None or ElementSpec is None or render_tag is None:
+    if comp_cfg is None:
         return {}
-
-    type_el = _component_element(comp_cfg, "type")
-    if type_el is None or not type_el.enabled:
-        return {}
-
-    tag_cfg = TagConfig(
-        elements=[ElementSpec(kind="type", enabled=True, style=type_el.style or "med")],
-        separator=comp_cfg.separator,
-        enclosing=comp_cfg.enclosing,
-        placement=comp_cfg.placement,
-        class_mapping=comp_cfg.class_mapping,
-    )
     placement = getattr(comp_cfg, "placement", "prepend")
 
     out: dict[str, str] = {}
@@ -5728,11 +5813,7 @@ def enhancements_bare_type_tags(ctx: dict) -> dict[str, str]:
         desc_value = loc.get(f"{key[:-len('_Name')]}_Desc", "")
         if not desc_value:
             continue
-        type_m = re.search(r"Item Type:\s*([^\\\n]+?)\s*(?:\\n|\n|$)", desc_value)
-        type_name = type_m.group(1).strip() if type_m else None
-        if type_name not in _BARE_TYPE_NAMES:
-            continue
-        tag = render_tag(tag_cfg, {"type": type_name})
+        tag = _bare_type_tag_from_desc(desc_value, comp_cfg)
         if not tag:
             continue
         if placement == "append":

--- a/src/utils/blueprint_meta.py
+++ b/src/utils/blueprint_meta.py
@@ -131,6 +131,24 @@ _TYPE_LABELS = {
     "BOMB": "Bomb",
 }
 
+# Extra Name-key conventions for #266's bare-type components, which don't
+# follow the item_Name<code> / vehicle_Name prefix every other component
+# uses. Fuel nozzles ship under two different manufacturer-specific
+# prefixes (MISC's item_fuelnozzle_* vs Greycat/Shubin's
+# Nozzle_FuelGiver_*); mining lasers share one prefix across all
+# manufacturers but carry no "_Name" marker at all -- the bare key IS the
+# name entry. Without these, the Blueprint Tracker's tagged_name fell back
+# to the untagged bare name for these items even though the String Editor
+# showed the real tag correctly (the enhancement generator's output was
+# fine — this module just never recognised the key as a Name entry).
+# Extend this alongside _BARE_TYPE_NAMES in generate_enhancements_ini.py
+# whenever a new bare-type category ships (fuel tank, mining module, ...).
+_EXTRA_NAME_KEY_PREFIXES = (
+    "item_fuelnozzle_",
+    "nozzle_fuelgiver_",
+    "item_mining_mininglaser_",
+)
+
 # The bracketed component tag, e.g. "[MIL-S3-B]" or the user-reconfigured
 # "[CMP.S1.B.PW]". Parsed by tokenizing the contents rather than a fixed
 # pattern, because the tag's separator, element order, and which elements
@@ -301,7 +319,8 @@ def build_blueprint_metadata(entries) -> dict:
         cat = getattr(e, "category", "") or ""
         kl = key.lower()
 
-        if kl.startswith("item_name") or kl.startswith("vehicle_name"):
+        if (kl.startswith("item_name") or kl.startswith("vehicle_name")
+                or kl.startswith(_EXTRA_NAME_KEY_PREFIXES)):
             nm = normalize_item_name(val)
             if nm:
                 # Prefer the longest value when multiple distinct keys

--- a/src/utils/blueprint_meta.py
+++ b/src/utils/blueprint_meta.py
@@ -62,8 +62,8 @@ _ARMOR_EXTRA_WORDS = (
     "gys_jacket", "gys_pants",
 )
 from src.utils.owned_items import (
-    BP_SECTION_HEADER,
     extract_bp_item_names,
+    has_bp_section,
     normalize_item_name,
 )
 from src.utils.tag_builder import DEFAULT_COMPONENT_CLASS_MAPPING
@@ -356,7 +356,7 @@ def build_blueprint_metadata(entries) -> dict:
             titles[_title_pair_key(tm.group("base"), tm.group("num"))] = \
                 clean_mission_title(val)
 
-        if BP_SECTION_HEADER in val.upper():
+        if has_bp_section(val):
             dm = _DESC_KEY_RE.match(key)
             pair = _title_pair_key(dm.group("base"), dm.group("num")) if dm else None
             bp_descs.append((pair, val))

--- a/src/utils/blueprint_meta.py
+++ b/src/utils/blueprint_meta.py
@@ -150,6 +150,39 @@ _EXTRA_NAME_KEY_PREFIXES = (
     "item_scraper_",
 )
 
+
+def _key_slug(key: str) -> str:
+    """Title-case each underscore-separated segment of a loc key (after
+    dropping a trailing "_Name" segment, if present) and join with spaces
+    -- e.g. ``Nozzle_FuelGiver_GRIN_NozzleVeryFast_Name`` -> ``Nozzle
+    Fuelgiver Grin Nozzleveryfast``.
+
+    Reproduces a real CIG bug: some mission POTENTIAL BLUEPRINTS bullets
+    list this exact de-slugified KEY instead of the item's actual
+    localized name (confirmed via a live mission body reporting "Nozzle
+    Fuelgiver Grin Nozzleveryfast" as a blueprint reward -- the real item
+    is "Lindstrom", key ``Nozzle_FuelGiver_GRIN_NozzleVeryFast_Name``).
+    Deterministic and reversible, so rather than hardcoding aliases per
+    affected item, every bullet name that doesn't match a real item
+    directly is checked against this transform of every known Name key.
+    """
+    segments = key.split("_")
+    if segments and segments[-1].lower() == "name":
+        segments = segments[:-1]
+    return " ".join(seg.capitalize() for seg in segments)
+
+
+# Known one-off mismatches between a mission bullet's name and the item's
+# real localized display name that AREN'T explained by _key_slug's fallback
+# pattern -- just a mission author typing a short/informal name. Confirmed
+# via a live "Crew Hasn't Checked In" mining mission body listing "Helix" as
+# a blueprint reward; the real item is "S0 Helix"
+# (item_NameMining_Head_S00_Helix_SCItem). Extend this dict for any other
+# reported mismatch that isn't a key-slug case.
+_BULLET_NAME_ALIASES: dict[str, str] = {
+    "Helix": "S0 Helix",
+}
+
 # The bracketed component tag, e.g. "[MIL-S3-B]" or the user-reconfigured
 # "[CMP.S1.B.PW]". Parsed by tokenizing the contents rather than a fixed
 # pattern, because the tag's separator, element order, and which elements
@@ -313,6 +346,7 @@ def build_blueprint_metadata(entries) -> dict:
     attrs: dict = {}            # normalized name -> (cls, size, grade)
     titles: dict = {}           # (base_lower, num) -> cleaned mission name
     bp_descs: list = []         # (pair_key | None, value)
+    keyslug_to_name: dict = {}  # _key_slug(key) -> normalized display name
 
     for e in entries:
         key = getattr(e, "key", "") or ""
@@ -324,6 +358,7 @@ def build_blueprint_metadata(entries) -> dict:
                 or kl.startswith(_EXTRA_NAME_KEY_PREFIXES)):
             nm = normalize_item_name(val)
             if nm:
+                keyslug_to_name[_key_slug(key)] = nm
                 # Prefer the longest value when multiple distinct keys
                 # normalize to the same display name — e.g. two ship weapons
                 # with different manufacturer codes/sizes that happen to
@@ -362,10 +397,18 @@ def build_blueprint_metadata(entries) -> dict:
             bp_descs.append((pair, val))
 
     # Pass 2: gather each blueprint item's missions, then attach type + attrs.
+    # A bullet name that doesn't match any real item directly is checked
+    # against the known one-off aliases, then against the key-slug fallback
+    # (see _BULLET_NAME_ALIASES / _key_slug) before falling back to itself —
+    # so a mismatched bullet still joins the real, tagged item instead of
+    # creating a separate untagged "Other" entry.
     missions_by_name: dict = {}
     for pair, val in bp_descs:
         title = titles.get(pair) if pair else None
-        for nm in extract_bp_item_names(val):
+        for raw_nm in extract_bp_item_names(val):
+            nm = raw_nm if raw_nm in name_to_value else (
+                _BULLET_NAME_ALIASES.get(raw_nm) or keyslug_to_name.get(raw_nm, raw_nm)
+            )
             bucket = missions_by_name.setdefault(nm, set())
             if title:
                 bucket.add(title)

--- a/src/utils/blueprint_meta.py
+++ b/src/utils/blueprint_meta.py
@@ -175,12 +175,20 @@ def _key_slug(key: str) -> str:
 # Known one-off mismatches between a mission bullet's name and the item's
 # real localized display name that AREN'T explained by _key_slug's fallback
 # pattern -- just a mission author typing a short/informal name. Confirmed
-# via a live "Crew Hasn't Checked In" mining mission body listing "Helix" as
-# a blueprint reward; the real item is "S0 Helix"
-# (item_NameMining_Head_S00_Helix_SCItem). Extend this dict for any other
-# reported mismatch that isn't a key-slug case.
+# via a live "Crew Hasn't Checked In" mining mission body listing "Helix" and
+# "Hofstede" as blueprint rewards; the real items are "S0 Helix" and "S00
+# Hofstede" (item_NameMining_Head_S00_<Name>_SCItem). All four "Mining Head"
+# variants share this exact bullet-uses-bare-manufacturer-name pattern
+# (confirmed via tests/fixtures/kraken_global_latest.ini: item_NameMining_
+# Head_S00_Arbor_SCItem=S0 Arbor, ..._Klein_SCItem=Lawson Mining Laser),
+# added preemptively rather than waiting for each to be individually
+# reported. Extend this dict for any other reported mismatch that isn't a
+# key-slug case.
 _BULLET_NAME_ALIASES: dict[str, str] = {
+    "Arbor": "S0 Arbor",
     "Helix": "S0 Helix",
+    "Hofstede": "S00 Hofstede",
+    "Klein": "Lawson Mining Laser",
 }
 
 # The bracketed component tag, e.g. "[MIL-S3-B]" or the user-reconfigured

--- a/src/utils/blueprint_meta.py
+++ b/src/utils/blueprint_meta.py
@@ -189,6 +189,17 @@ _BULLET_NAME_ALIASES: dict[str, str] = {
     "Helix": "S0 Helix",
     "Hofstede": "S00 Hofstede",
     "Klein": "Lawson Mining Laser",
+    # Fuel nozzles (#266 follow-up): most manufacturer variants resolve
+    # generically via _key_slug (their real key genuinely follows
+    # Nozzle_FuelGiver_<MFR>_Nozzle<Variant>_Name), but these three still
+    # showed up ungarbled/untagged after that fix -- their real underlying
+    # key must not match that exact pattern. Confirmed via a live Blueprint
+    # Tracker screenshot listing all three as separate untagged entries
+    # while their siblings (Marlin, Lindstrom, Bendix, Torrez, Ezra) had
+    # already resolved correctly.
+    "Nozzle Fuelgiver Grin Nozzlefast": "Norfield",
+    "Nozzle Fuelgiver Grin Nozzleverysecure": "Harkin",
+    "Nozzle Fuelgiver Misc Nozzlestandard": "RN-7s",
 }
 
 # The bracketed component tag, e.g. "[MIL-S3-B]" or the user-reconfigured

--- a/src/utils/blueprint_meta.py
+++ b/src/utils/blueprint_meta.py
@@ -142,11 +142,12 @@ _TYPE_LABELS = {
 # showed the real tag correctly (the enhancement generator's output was
 # fine — this module just never recognised the key as a Name entry).
 # Extend this alongside _BARE_TYPE_NAMES in generate_enhancements_ini.py
-# whenever a new bare-type category ships (fuel tank, mining module, ...).
+# whenever a new bare-type category ships.
 _EXTRA_NAME_KEY_PREFIXES = (
     "item_fuelnozzle_",
     "nozzle_fuelgiver_",
     "item_mining_mininglaser_",
+    "item_scraper_",
 )
 
 # The bracketed component tag, e.g. "[MIL-S3-B]" or the user-reconfigured

--- a/src/utils/entry_filter.py
+++ b/src/utils/entry_filter.py
@@ -8,7 +8,7 @@ import logging
 
 from src.gui.string_table_model import NUM_COLUMNS
 from src.models.string_model import StringEntry
-from src.utils.owned_items import BP_SECTION_HEADER
+from src.utils.owned_items import has_bp_section
 from src.utils.ship_sort_prefix import get_order
 
 logger = logging.getLogger(__name__)
@@ -106,7 +106,7 @@ def filter_entry_indices(
         if bp_titles_only or bp_descs_only:
             val = entry.custom_value or entry.original_value
             is_bp_title = bp_titles_only and "[BP" in val
-            is_bp_desc = bp_descs_only and BP_SECTION_HEADER.lower() in val.lower()
+            is_bp_desc = bp_descs_only and has_bp_section(val)
             if not (is_bp_title or is_bp_desc):
                 continue
         if active_filter_fns:

--- a/src/utils/owned_items.py
+++ b/src/utils/owned_items.py
@@ -64,7 +64,7 @@ _TRAILING_CATEGORY_RE = re.compile(
     r"\s*\((" + "|".join(re.escape(w) for w in _BULLET_CATEGORY_ANNOTATIONS) + r")\)\s*$"
 )
 
-# Marks the start of a POTENTIAL BLUEPRINTS section. The header text is
+# Marks the start of a blueprint-bearing section. The header text is
 # user-configurable (AppSettings.MISSION_HEADER_DEFAULTS["blueprints"]) but the
 # default is BP_SECTION_HEADER; we match that default case-insensitively. This
 # module stays settings-free by design, so it owns the default literal rather
@@ -72,37 +72,73 @@ _TRAILING_CATEGORY_RE = re.compile(
 # blueprint_meta.py and entry_filter.py import BP_SECTION_HEADER from here so
 # the three matchers share one source of truth. A value with no such header has
 # no bullets to tag, so it passes through untouched.
+#
+# CIG uses a SECOND, entirely different header for missions that offer more
+# than one blueprint pool (confirmed via tests/fixtures/kraken_global_
+# latest.ini: "MULTIPLE BLUEPRINT POOLS" appears on 35 missions in the
+# fixture, vs. 237 using "POTENTIAL BLUEPRINTS" -- e.g. the mining-laser
+# purchase-order contracts that award a weapon/armor Pool 1 alongside a
+# mining-laser/radar Pool 2). Missions using this header were entirely
+# unscanned before this fix -- not just untagged, absent from the Blueprint
+# Tracker altogether, regardless of any per-item fix.
+_ALT_BP_SECTION_HEADER = "MULTIPLE BLUEPRINT POOLS"
 BP_SECTION_HEADER = "POTENTIAL BLUEPRINTS"
-_BP_HEADER_RE = re.compile(BP_SECTION_HEADER, re.IGNORECASE)
+_BP_HEADER_RE = re.compile(
+    "(?:" + re.escape(BP_SECTION_HEADER) + "|" + re.escape(_ALT_BP_SECTION_HEADER) + ")",
+    re.IGNORECASE,
+)
+
+
+def has_bp_section(value: str) -> bool:
+    """True if *value* contains a recognised blueprint-section header.
+
+    Single source of truth for the "is this a blueprint-bearing mission
+    body" gate used by blueprint_meta.py (before collecting a Desc for
+    bullet scanning) and entry_filter.py (the String Editor's "BP
+    Descriptions" checkbox) -- both used to do their own raw ``BP_SECTION_
+    HEADER in value.upper()`` substring check, which missed the
+    "MULTIPLE BLUEPRINT POOLS" header entirely.
+    """
+    return bool(_BP_HEADER_RE.search(value or ""))
+
+
 # A tag that MIGHT be a genuine section header (POTENTIAL BLUEPRINTS, ITEM
 # REWARDS, MISSION DETAILS, BLUEPRINT DATA, ...) — filtered further in
-# _bp_section_span against the two known non-header sub-header shapes:
-# region labels (<EM4>[Nyx]</EM4>) and reputation-tier labels
-# (<EM4>Awarded from Contractor level variants</EM4>).
+# _bp_section_span against the known non-header sub-header shapes: region
+# labels (<EM4>[Nyx]</EM4>), reputation-tier labels (<EM4>Awarded from
+# Contractor level variants</EM4>), and blueprint-pool labels (<EM4>Pool
+# 1</EM4>, <EM4>Pool 2</EM4> -- appear under a MULTIPLE BLUEPRINT POOLS
+# header, grouping that mission's several independent bullet lists).
 _SECTION_HEADER_RE = re.compile(r"<EM([34])>([^<]*)</EM\1>")
 # Reputation-tiered contracts (Adagio Industrial salvage, Bounty Hunters
-# Guild, Security, ...) group their POTENTIAL BLUEPRINTS bullets under one
-# of these per-tier sub-headers *inside* the section — e.g. "Awarded from
-# Contractor level variants" followed by that tier's bullet list, sometimes
-# repeated for multiple tiers in one mission body. None of these are section
+# Guild, Security, ...) group their blueprint bullets under one of these
+# per-tier sub-headers *inside* the section — e.g. "Awarded from Contractor
+# level variants" followed by that tier's bullet list, sometimes repeated
+# for multiple tiers in one mission body. None of these are section
 # boundaries; treating them as one silently truncated the span before any
 # bullets were ever reached, so items awarded this way (Scraper Modules —
 # Trawler/Cinch/Abrade — among others) never surfaced in the Blueprint
 # Tracker at all, tag or no tag.
 _AWARDED_FROM_RE = re.compile(r"^awarded from .+ variants$", re.IGNORECASE)
+# "Pool 1", "Pool 2", ... under a MULTIPLE BLUEPRINT POOLS header.
+_POOL_LABEL_RE = re.compile(r"^pool \d+$", re.IGNORECASE)
 
 
 def _bp_section_span(value: str):
-    """Return (start, end) spanning just the POTENTIAL BLUEPRINTS section's
-    bullet content — from right after its header up to the next real section
-    header (or end of string). ``None`` when there's no such section.
+    """Return (start, end) spanning just the blueprint section's bullet
+    content — from right after its header (POTENTIAL BLUEPRINTS or MULTIPLE
+    BLUEPRINT POOLS) up to the next real section header (or end of string).
+    ``None`` when there's no such section.
 
     Bounding the scan this way matters: CIG mission bodies sometimes carry a
     stray "\\n- <word>" line in the flavor-text prose *before* the header
-    (e.g. "\\n- Stows\\n"), and a body with both a POTENTIAL BLUEPRINTS
-    section and a later ITEM REWARDS section (e.g. "\\n- Council Scrip")
-    puts a real bullet-shaped line after it too. Un-scoped bullet matching
-    swept both into the blueprint item set.
+    (e.g. "\\n- Stows\\n"), and a body with both a blueprint section and a
+    later ITEM REWARDS section (e.g. "\\n- Council Scrip") puts a real
+    bullet-shaped line after it too. Un-scoped bullet matching swept both
+    into the blueprint item set. Bullets across ALL pools/tiers within one
+    section are pooled into a single set -- this module doesn't track which
+    specific pool/tier a bullet belongs to, matching the pre-existing
+    region-label behaviour.
     """
     m = _BP_HEADER_RE.search(value)
     if not m:
@@ -110,8 +146,8 @@ def _bp_section_span(value: str):
     start = m.end()
     end = len(value)
     for hm in _SECTION_HEADER_RE.finditer(value, start):
-        text = hm.group(2)
-        if text.startswith("[") or _AWARDED_FROM_RE.match(text.strip()):
+        text = hm.group(2).strip()
+        if text.startswith("[") or _AWARDED_FROM_RE.match(text) or _POOL_LABEL_RE.match(text):
             continue
         end = hm.start()
         break

--- a/src/utils/owned_items.py
+++ b/src/utils/owned_items.py
@@ -43,6 +43,27 @@ _TRAILING_TAG_RE = re.compile(r"\s*\[[^\]]*\]\s*$")
 # plain space, so the same item from a log and from loc data normalize alike.
 _WS_RE = re.compile(r"\s+")
 
+# CIG's own POTENTIAL BLUEPRINTS bullet text appends a category annotation to
+# some items -- "Bendix (Fuel Nozzle)", "Arbor MH1 Mining Laser (Mining
+# Laser)", "5CA 'Akura' (Shield)", "Trawler Scraper Module (Salvage Mod)" --
+# that never appears on the item's own item_Name value. Left unstripped, the
+# bullet-extracted name never matches the real (tagged) item, so it shows up
+# as a separate, untagged "Other"-type entry in the Blueprint Tracker instead
+# of joining with the real one (confirmed via tests/fixtures/kraken_global_
+# latest.ini across at least these 8 categories -- almost certainly a
+# systemic gap, not specific to any one item type). A small explicit
+# allow-list rather than "strip any trailing (...)": some items carry a
+# parenthetical that IS part of their real distinguishing name (e.g. "Artimex
+# Arms (Modified)"), and blindly stripping those would collide two actually
+# different items into one.
+_BULLET_CATEGORY_ANNOTATIONS = frozenset({
+    "Cooler", "Fuel Nozzle", "Mining Laser", "Powerplant", "Quantum Drive",
+    "Radar", "Salvage Mod", "Shield",
+})
+_TRAILING_CATEGORY_RE = re.compile(
+    r"\s*\((" + "|".join(re.escape(w) for w in _BULLET_CATEGORY_ANNOTATIONS) + r")\)\s*$"
+)
+
 # Marks the start of a POTENTIAL BLUEPRINTS section. The header text is
 # user-configurable (AppSettings.MISSION_HEADER_DEFAULTS["blueprints"]) but the
 # default is BP_SECTION_HEADER; we match that default case-insensitively. This
@@ -53,12 +74,22 @@ _WS_RE = re.compile(r"\s+")
 # no bullets to tag, so it passes through untouched.
 BP_SECTION_HEADER = "POTENTIAL BLUEPRINTS"
 _BP_HEADER_RE = re.compile(BP_SECTION_HEADER, re.IGNORECASE)
-# A genuine section header (POTENTIAL BLUEPRINTS, ITEM REWARDS, MISSION
-# DETAILS, BLUEPRINT DATA, ...) as opposed to a per-region sub-header inside
-# the blueprints list itself (e.g. <EM4>[Nyx]</EM4>,
-# <EM4>[Pyro RegionA, Pyro RegionB]</EM4>) — region labels always start with
-# "[" right after the tag, section headers never do.
-_SECTION_HEADER_RE = re.compile(r"<EM([34])>(?!\[)[^<]*</EM\1>")
+# A tag that MIGHT be a genuine section header (POTENTIAL BLUEPRINTS, ITEM
+# REWARDS, MISSION DETAILS, BLUEPRINT DATA, ...) — filtered further in
+# _bp_section_span against the two known non-header sub-header shapes:
+# region labels (<EM4>[Nyx]</EM4>) and reputation-tier labels
+# (<EM4>Awarded from Contractor level variants</EM4>).
+_SECTION_HEADER_RE = re.compile(r"<EM([34])>([^<]*)</EM\1>")
+# Reputation-tiered contracts (Adagio Industrial salvage, Bounty Hunters
+# Guild, Security, ...) group their POTENTIAL BLUEPRINTS bullets under one
+# of these per-tier sub-headers *inside* the section — e.g. "Awarded from
+# Contractor level variants" followed by that tier's bullet list, sometimes
+# repeated for multiple tiers in one mission body. None of these are section
+# boundaries; treating them as one silently truncated the span before any
+# bullets were ever reached, so items awarded this way (Scraper Modules —
+# Trawler/Cinch/Abrade — among others) never surfaced in the Blueprint
+# Tracker at all, tag or no tag.
+_AWARDED_FROM_RE = re.compile(r"^awarded from .+ variants$", re.IGNORECASE)
 
 
 def _bp_section_span(value: str):
@@ -77,8 +108,13 @@ def _bp_section_span(value: str):
     if not m:
         return None
     start = m.end()
-    next_header = _SECTION_HEADER_RE.search(value, start)
-    end = next_header.start() if next_header else len(value)
+    end = len(value)
+    for hm in _SECTION_HEADER_RE.finditer(value, start):
+        text = hm.group(2)
+        if text.startswith("[") or _AWARDED_FROM_RE.match(text.strip()):
+            continue
+        end = hm.start()
+        break
     return start, end
 
 
@@ -88,13 +124,18 @@ def normalize_item_name(name: str) -> str:
     Applies, in order: NFKC unicode folding (so a non-breaking space becomes a
     plain space), removal of any ``[Owned]`` tag, removal of a leading *and* a
     trailing bracketed component tag (``[Mil-S1-A] Norfield`` and
-    ``Norfield [Mil-S1-A]`` both reduce to the bare name), and whitespace
-    collapse. Used for both the owned set and bullet matching, so a tagged
-    bullet, a log-imported name, and a bare item row all resolve to one key.
+    ``Norfield [Mil-S1-A]`` both reduce to the bare name), removal of a
+    trailing bullet-only category annotation (``Bendix (Fuel Nozzle)`` ->
+    ``Bendix``), and whitespace collapse. Used for both the owned set and
+    bullet matching, so a tagged bullet, a log-imported name, and a bare item
+    row all resolve to one key.
 
     Both sides of every comparison pass through here (the owned-set entries and
     the mission bullets in ``apply_owned_to_value``), so the folding is
-    symmetric and can never introduce a one-sided mismatch.
+    symmetric and can never introduce a one-sided mismatch. The category-
+    annotation strip is safe on both sides even though it's bullet-specific:
+    the allow-listed words never appear as a real item_Name's own trailing
+    parenthetical, so it's a no-op wherever it doesn't apply.
     """
     if not name:
         return ""
@@ -102,6 +143,7 @@ def normalize_item_name(name: str) -> str:
     s = _OWNED_STRIP_RE.sub("", s)
     s = _LEADING_TAG_RE.sub("", s)
     s = _TRAILING_TAG_RE.sub("", s)
+    s = _TRAILING_CATEGORY_RE.sub("", s)
     return _WS_RE.sub(" ", s).strip()
 
 

--- a/src/utils/tag_builder.py
+++ b/src/utils/tag_builder.py
@@ -450,6 +450,16 @@ DEFAULT_COMPONENT_TYPE_MAPPING: dict[str, tuple[str, str, str]] = {
     "Power Plant":      ("PW",  "POWR", "Power"),
     "Quantum Drive":    ("QD",  "QDRV", "Quantum"),
     "Radar":            ("RD",  "RADR", "Radar"),
+    # #266: components with no Class:/Size:/Grade: of their own -- the
+    # generator always forces this element on for them (see
+    # enhancements_bare_type_tags in generate_enhancements_ini.py), since
+    # otherwise they'd never get a tag at all while Type stays off by default.
+    "Fuel Nozzle":      ("FN",  "FNoz", "Fuel Nozzle"),
+    # #266: mining lasers live in ships/weapons/ (routed through
+    # _ship_weapon_name_tag_factory) but aren't combat weapons -- no
+    # resolvable damage type, so they're tagged as a component Type+Size
+    # instead of the ship-weapon damage-keyed style.
+    "Mining Laser":     ("ML",  "MineL", "Mining Laser"),
 }
 
 DEFAULT_COMMODITY_LABEL_MAPPING: dict[str, tuple[str, str, str]] = {

--- a/src/utils/tag_builder.py
+++ b/src/utils/tag_builder.py
@@ -450,16 +450,18 @@ DEFAULT_COMPONENT_TYPE_MAPPING: dict[str, tuple[str, str, str]] = {
     "Power Plant":      ("PW",  "POWR", "Power"),
     "Quantum Drive":    ("QD",  "QDRV", "Quantum"),
     "Radar":            ("RD",  "RADR", "Radar"),
-    # #266: components with no Class:/Size:/Grade: of their own -- the
-    # generator always forces this element on for them (see
-    # enhancements_bare_type_tags in generate_enhancements_ini.py), since
-    # otherwise they'd never get a tag at all while Type stays off by default.
+    # #266: components with no Class:/Size:/Grade: of their own -- tagged via
+    # enhancements_bare_type_tags in generate_enhancements_ini.py, gated by
+    # this same Type element toggle (opt-in, same as every entry above).
     "Fuel Nozzle":      ("FN",  "FNoz", "Fuel Nozzle"),
     # #266: mining lasers live in ships/weapons/ (routed through
     # _ship_weapon_name_tag_factory) but aren't combat weapons -- no
     # resolvable damage type, so they're tagged as a component Type+Size
     # instead of the ship-weapon damage-keyed style.
     "Mining Laser":     ("ML",  "MineL", "Mining Laser"),
+    # #266: scraper modules (Trawler/Cinch/Abrade) -- same size-less shape
+    # as Fuel Nozzle, tagged via enhancements_bare_type_tags.
+    "Scraper Module":   ("SCM", "ScrMod", "Scraper Module"),
 }
 
 DEFAULT_COMMODITY_LABEL_MAPPING: dict[str, tuple[str, str, str]] = {

--- a/tests/test_bare_type_tags.py
+++ b/tests/test_bare_type_tags.py
@@ -6,8 +6,16 @@ off of, so a Type-only tag is their only option. Gated by the same
 Components > Type element toggle as every other DEFAULT_COMPONENT_TYPE_
 MAPPING entry (Shield Generator, Cooler, ...) -- users opt in or out, they
 aren't force-shown just because they'd otherwise have no other tag.
-Identified purely by loc-key prefix, no DataForge XML dependency -- same
-"base.ini is the only input" shape as enhancements_medical_consumables.
+
+Identified by the paired ``_Desc`` entry's own "Item Type: X" line, NOT by
+loc-key naming -- fuel nozzles ship under at least two different key
+conventions for different manufacturers (``item_fuelnozzle_MISC_Standard_*``
+for MISC's RN-7s, but ``Nozzle_FuelGiver_GRIN_NozzleSecure_*`` for
+Greycat's Marlin and ``Nozzle_FuelGiver_SHIN_*`` for Shubin's nozzles --
+confirmed via tests/fixtures/kraken_global_latest.ini). An earlier
+key-prefix-only version of this pass silently missed every
+``Nozzle_FuelGiver_*`` entry (issue #266 follow-up report: "only some fuel
+nozzles worked").
 """
 from __future__ import annotations
 
@@ -52,28 +60,60 @@ def _components_cfg_with_type(gen_module, style="short", placement=None):
     )
 
 
+# Real stock text (tests/fixtures/kraken_global_latest.ini) -- the "\n"
+# here is the literal two-character escape CIG ships in base.ini, not a
+# real newline.
+_RN7S_DESC = "Manufacturer: MISC\\nItem Type: Fuel Nozzle\\nHydrogen Flow Speed: 1.65 SCU/s\\n"
+_MARLIN_DESC = "Manufacturer: Greycat Industrial\\nItem Type: Fuel Nozzle\\nHydrogen Flow Speed: 1.05 SCU/s\\n"
+
+
 class TestEnhancementsBareTypeTags:
     def test_no_tag_when_type_disabled_by_default(self, gen_module):
         """Type is disabled by default for "components" -- with no explicit
         config, fuel nozzles get no tag at all, same as any other
         DEFAULT_COMPONENT_TYPE_MAPPING entry the user hasn't opted into."""
-        loc = {"item_fuelnozzle_MISC_Standard_Name": "RN-7s"}
+        loc = {
+            "item_fuelnozzle_MISC_Standard_Name": "RN-7s",
+            "item_fuelnozzle_MISC_Standard_Desc": _RN7S_DESC,
+        }
         out = gen_module.enhancements_bare_type_tags({"loc": loc, "tag_configs": {}})
         assert out == {}
 
     def test_tags_fuel_nozzle_when_type_enabled(self, gen_module):
         cfg = _components_cfg_with_type(gen_module, style="short")
-        loc = {"item_fuelnozzle_MISC_Standard_Name": "RN-7s"}
+        loc = {
+            "item_fuelnozzle_MISC_Standard_Name": "RN-7s",
+            "item_fuelnozzle_MISC_Standard_Desc": _RN7S_DESC,
+        }
         out = gen_module.enhancements_bare_type_tags(
             {"loc": loc, "tag_configs": {"components": cfg}}
         )
         assert out == {"item_fuelnozzle_MISC_Standard_Name": "[FN] RN-7s"}
 
+    @pytest.mark.regression
+    def test_tags_nozzle_fuelgiver_naming_convention_too(self, gen_module):
+        """Regression guard: Greycat/Shubin fuel nozzles ship under the
+        Nozzle_FuelGiver_* key convention, not item_fuelnozzle_* -- both
+        must get tagged since detection keys off the Desc's Item Type
+        text, not the Name key's prefix."""
+        cfg = _components_cfg_with_type(gen_module, style="short")
+        loc = {
+            "Nozzle_FuelGiver_GRIN_NozzleSecure_Name": "Marlin",
+            "Nozzle_FuelGiver_GRIN_NozzleSecure_Desc": _MARLIN_DESC,
+        }
+        out = gen_module.enhancements_bare_type_tags(
+            {"loc": loc, "tag_configs": {"components": cfg}}
+        )
+        assert out == {"Nozzle_FuelGiver_GRIN_NozzleSecure_Name": "[FN] Marlin"}
+
     def test_respects_users_configured_type_style(self, gen_module):
         """A user who's enabled Type gets their chosen abbreviation length
         (short/medium/long) applied here too."""
         cfg = _components_cfg_with_type(gen_module, style="long")
-        loc = {"item_fuelnozzle_MISC_Standard_Name": "RN-7s"}
+        loc = {
+            "item_fuelnozzle_MISC_Standard_Name": "RN-7s",
+            "item_fuelnozzle_MISC_Standard_Desc": _RN7S_DESC,
+        }
         out = gen_module.enhancements_bare_type_tags(
             {"loc": loc, "tag_configs": {"components": cfg}}
         )
@@ -81,7 +121,10 @@ class TestEnhancementsBareTypeTags:
 
     def test_respects_append_placement(self, gen_module):
         cfg = _components_cfg_with_type(gen_module, style="short", placement="append")
-        loc = {"item_fuelnozzle_MISC_Standard_Name": "RN-7s"}
+        loc = {
+            "item_fuelnozzle_MISC_Standard_Name": "RN-7s",
+            "item_fuelnozzle_MISC_Standard_Desc": _RN7S_DESC,
+        }
         out = gen_module.enhancements_bare_type_tags(
             {"loc": loc, "tag_configs": {"components": cfg}}
         )
@@ -92,6 +135,7 @@ class TestEnhancementsBareTypeTags:
         loc = {
             "item_fuelnozzle_MISC_Standard_Name": "RN-7s",
             "item_fuelnozzle_MISC_Standard_Name_short": "RN-7s",
+            "item_fuelnozzle_MISC_Standard_Desc": _RN7S_DESC,
         }
         out = gen_module.enhancements_bare_type_tags(
             {"loc": loc, "tag_configs": {"components": cfg}}
@@ -99,12 +143,27 @@ class TestEnhancementsBareTypeTags:
         assert out["item_fuelnozzle_MISC_Standard_Name"] == "[FN] RN-7s"
         assert out["item_fuelnozzle_MISC_Standard_Name_short"] == "[FN] RN-7s"
 
-    def test_unrelated_keys_untouched(self, gen_module):
+    def test_missing_desc_is_skipped(self, gen_module):
+        """No paired _Desc entry at all -- can't determine Item Type, so
+        no tag (rather than guessing from the key name)."""
+        cfg = _components_cfg_with_type(gen_module, style="short")
+        loc = {"item_fuelnozzle_MISC_Standard_Name": "RN-7s"}
+        out = gen_module.enhancements_bare_type_tags(
+            {"loc": loc, "tag_configs": {"components": cfg}}
+        )
+        assert out == {}
+
+    def test_unrelated_item_type_untouched(self, gen_module):
+        """A component with a real Item Type that isn't in the small
+        bare-type allow-list (e.g. Shield Generator, tagged elsewhere via
+        the strict Class-based DataForge scan) must not get double-tagged
+        here."""
         cfg = _components_cfg_with_type(gen_module, style="short")
         loc = {
             "item_fuelnozzle_MISC_Standard_Name": "RN-7s",
-            "item_fuelnozzle_MISC_Standard_Desc": "Manufacturer: MISC\\nItem Type: Fuel Nozzle",
+            "item_fuelnozzle_MISC_Standard_Desc": _RN7S_DESC,
             "item_NameSHLD_ASAS_S01_Shimmer": "Shimmer",
+            "item_NameSHLD_ASAS_S01_Shimmer_Desc": "Item Type: Shield Generator\\nSize: 1\\nGrade: A\\n",
             "some_unrelated_key": "unrelated value",
         }
         out = gen_module.enhancements_bare_type_tags(
@@ -121,7 +180,10 @@ class TestEnhancementsBareTypeTags:
 
     def test_missing_name_value_is_skipped(self, gen_module):
         cfg = _components_cfg_with_type(gen_module, style="short")
-        loc = {"item_fuelnozzle_MISC_Standard_Name": ""}
+        loc = {
+            "item_fuelnozzle_MISC_Standard_Name": "",
+            "item_fuelnozzle_MISC_Standard_Desc": _RN7S_DESC,
+        }
         out = gen_module.enhancements_bare_type_tags(
             {"loc": loc, "tag_configs": {"components": cfg}}
         )

--- a/tests/test_bare_type_tags.py
+++ b/tests/test_bare_type_tags.py
@@ -2,8 +2,10 @@
 
 Some component-adjacent items (fuel nozzles so far) carry no Size:/Grade:/
 Class: of their own -- there's nothing to hang the usual "[MIL-S1-A]" shape
-off of, and the optional "Type" element is disabled by default, so without
-this dedicated pass they'd never show any tag at all ("What is an R7?").
+off of, so a Type-only tag is their only option. Gated by the same
+Components > Type element toggle as every other DEFAULT_COMPONENT_TYPE_
+MAPPING entry (Shield Generator, Cooler, ...) -- users opt in or out, they
+aren't force-shown just because they'd otherwise have no other tag.
 Identified purely by loc-key prefix, no DataForge XML dependency -- same
 "base.ini is the only input" shape as enhancements_medical_consumables.
 """
@@ -29,70 +31,98 @@ def gen_module():
     return mod
 
 
+def _components_cfg_with_type(gen_module, style="short", placement=None):
+    """DEFAULT_TAG_CONFIGS["components"] with the Type element switched on
+    (it's disabled by default) at the given style, same knob a real user
+    flips via the Tag Builder's Components > Type checkbox."""
+    comp_cfg = gen_module.DEFAULT_TAG_CONFIGS["components"]
+    elements = [
+        gen_module.ElementSpec(el.kind, el.enabled, el.style)
+        for el in comp_cfg.elements
+    ]
+    for i, el in enumerate(elements):
+        if el.kind == "type":
+            elements[i] = gen_module.ElementSpec("type", True, style)
+    return gen_module.TagConfig(
+        elements=elements,
+        separator=comp_cfg.separator,
+        enclosing=comp_cfg.enclosing,
+        placement=placement or comp_cfg.placement,
+        class_mapping=comp_cfg.class_mapping,
+    )
+
+
 class TestEnhancementsBareTypeTags:
-    def test_tags_fuel_nozzle_with_default_config(self, gen_module):
-        """Default Tag Builder config: Type element is disabled but stored
-        at "short" style -- this pass forces it on regardless, producing
-        the short abbreviation ("FN"), prepended (the default placement)."""
+    def test_no_tag_when_type_disabled_by_default(self, gen_module):
+        """Type is disabled by default for "components" -- with no explicit
+        config, fuel nozzles get no tag at all, same as any other
+        DEFAULT_COMPONENT_TYPE_MAPPING entry the user hasn't opted into."""
         loc = {"item_fuelnozzle_MISC_Standard_Name": "RN-7s"}
         out = gen_module.enhancements_bare_type_tags({"loc": loc, "tag_configs": {}})
+        assert out == {}
+
+    def test_tags_fuel_nozzle_when_type_enabled(self, gen_module):
+        cfg = _components_cfg_with_type(gen_module, style="short")
+        loc = {"item_fuelnozzle_MISC_Standard_Name": "RN-7s"}
+        out = gen_module.enhancements_bare_type_tags(
+            {"loc": loc, "tag_configs": {"components": cfg}}
+        )
         assert out == {"item_fuelnozzle_MISC_Standard_Name": "[FN] RN-7s"}
 
     def test_respects_users_configured_type_style(self, gen_module):
-        """A user who has actually configured the Type element (even while
-        leaving it disabled for their sized components) gets their chosen
-        abbreviation length here instead of the built-in default."""
-        comp_cfg = gen_module.DEFAULT_TAG_CONFIGS["components"]
-        custom_cfg = gen_module.TagConfig(
-            elements=[gen_module.ElementSpec("type", False, "long")],
-            separator=comp_cfg.separator,
-            enclosing=comp_cfg.enclosing,
-            placement=comp_cfg.placement,
-            class_mapping=comp_cfg.class_mapping,
-        )
+        """A user who's enabled Type gets their chosen abbreviation length
+        (short/medium/long) applied here too."""
+        cfg = _components_cfg_with_type(gen_module, style="long")
         loc = {"item_fuelnozzle_MISC_Standard_Name": "RN-7s"}
         out = gen_module.enhancements_bare_type_tags(
-            {"loc": loc, "tag_configs": {"components": custom_cfg}}
+            {"loc": loc, "tag_configs": {"components": cfg}}
         )
         assert out == {"item_fuelnozzle_MISC_Standard_Name": "[Fuel Nozzle] RN-7s"}
 
     def test_respects_append_placement(self, gen_module):
-        comp_cfg = gen_module.DEFAULT_TAG_CONFIGS["components"]
-        append_cfg = gen_module.TagConfig(
-            elements=list(comp_cfg.elements),
-            separator=comp_cfg.separator,
-            enclosing=comp_cfg.enclosing,
-            placement="append",
-            class_mapping=comp_cfg.class_mapping,
-        )
+        cfg = _components_cfg_with_type(gen_module, style="short", placement="append")
         loc = {"item_fuelnozzle_MISC_Standard_Name": "RN-7s"}
         out = gen_module.enhancements_bare_type_tags(
-            {"loc": loc, "tag_configs": {"components": append_cfg}}
+            {"loc": loc, "tag_configs": {"components": cfg}}
         )
         assert out == {"item_fuelnozzle_MISC_Standard_Name": "RN-7s [FN]"}
 
     def test_tags_short_name_variant_too(self, gen_module):
+        cfg = _components_cfg_with_type(gen_module, style="short")
         loc = {
             "item_fuelnozzle_MISC_Standard_Name": "RN-7s",
             "item_fuelnozzle_MISC_Standard_Name_short": "RN-7s",
         }
-        out = gen_module.enhancements_bare_type_tags({"loc": loc, "tag_configs": {}})
+        out = gen_module.enhancements_bare_type_tags(
+            {"loc": loc, "tag_configs": {"components": cfg}}
+        )
         assert out["item_fuelnozzle_MISC_Standard_Name"] == "[FN] RN-7s"
         assert out["item_fuelnozzle_MISC_Standard_Name_short"] == "[FN] RN-7s"
 
     def test_unrelated_keys_untouched(self, gen_module):
+        cfg = _components_cfg_with_type(gen_module, style="short")
         loc = {
             "item_fuelnozzle_MISC_Standard_Name": "RN-7s",
             "item_fuelnozzle_MISC_Standard_Desc": "Manufacturer: MISC\\nItem Type: Fuel Nozzle",
             "item_NameSHLD_ASAS_S01_Shimmer": "Shimmer",
             "some_unrelated_key": "unrelated value",
         }
-        out = gen_module.enhancements_bare_type_tags({"loc": loc, "tag_configs": {}})
+        out = gen_module.enhancements_bare_type_tags(
+            {"loc": loc, "tag_configs": {"components": cfg}}
+        )
         assert set(out) == {"item_fuelnozzle_MISC_Standard_Name"}
 
     def test_empty_loc_is_empty(self, gen_module):
-        assert gen_module.enhancements_bare_type_tags({"loc": {}, "tag_configs": {}}) == {}
+        cfg = _components_cfg_with_type(gen_module, style="short")
+        out = gen_module.enhancements_bare_type_tags(
+            {"loc": {}, "tag_configs": {"components": cfg}}
+        )
+        assert out == {}
 
     def test_missing_name_value_is_skipped(self, gen_module):
+        cfg = _components_cfg_with_type(gen_module, style="short")
         loc = {"item_fuelnozzle_MISC_Standard_Name": ""}
-        assert gen_module.enhancements_bare_type_tags({"loc": loc, "tag_configs": {}}) == {}
+        out = gen_module.enhancements_bare_type_tags(
+            {"loc": loc, "tag_configs": {"components": cfg}}
+        )
+        assert out == {}

--- a/tests/test_bare_type_tags.py
+++ b/tests/test_bare_type_tags.py
@@ -1,0 +1,98 @@
+"""Tests for ``enhancements_bare_type_tags`` (#266).
+
+Some component-adjacent items (fuel nozzles so far) carry no Size:/Grade:/
+Class: of their own -- there's nothing to hang the usual "[MIL-S1-A]" shape
+off of, and the optional "Type" element is disabled by default, so without
+this dedicated pass they'd never show any tag at all ("What is an R7?").
+Identified purely by loc-key prefix, no DataForge XML dependency -- same
+"base.ini is the only input" shape as enhancements_medical_consumables.
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture(scope="module")
+def gen_module():
+    repo_root = Path(__file__).resolve().parent.parent
+    script_path = repo_root / "scripts" / "generate_enhancements_ini.py"
+    spec = importlib.util.spec_from_file_location("generate_enhancements_ini_bare_type_test", script_path)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class TestEnhancementsBareTypeTags:
+    def test_tags_fuel_nozzle_with_default_config(self, gen_module):
+        """Default Tag Builder config: Type element is disabled but stored
+        at "short" style -- this pass forces it on regardless, producing
+        the short abbreviation ("FN"), prepended (the default placement)."""
+        loc = {"item_fuelnozzle_MISC_Standard_Name": "RN-7s"}
+        out = gen_module.enhancements_bare_type_tags({"loc": loc, "tag_configs": {}})
+        assert out == {"item_fuelnozzle_MISC_Standard_Name": "[FN] RN-7s"}
+
+    def test_respects_users_configured_type_style(self, gen_module):
+        """A user who has actually configured the Type element (even while
+        leaving it disabled for their sized components) gets their chosen
+        abbreviation length here instead of the built-in default."""
+        comp_cfg = gen_module.DEFAULT_TAG_CONFIGS["components"]
+        custom_cfg = gen_module.TagConfig(
+            elements=[gen_module.ElementSpec("type", False, "long")],
+            separator=comp_cfg.separator,
+            enclosing=comp_cfg.enclosing,
+            placement=comp_cfg.placement,
+            class_mapping=comp_cfg.class_mapping,
+        )
+        loc = {"item_fuelnozzle_MISC_Standard_Name": "RN-7s"}
+        out = gen_module.enhancements_bare_type_tags(
+            {"loc": loc, "tag_configs": {"components": custom_cfg}}
+        )
+        assert out == {"item_fuelnozzle_MISC_Standard_Name": "[Fuel Nozzle] RN-7s"}
+
+    def test_respects_append_placement(self, gen_module):
+        comp_cfg = gen_module.DEFAULT_TAG_CONFIGS["components"]
+        append_cfg = gen_module.TagConfig(
+            elements=list(comp_cfg.elements),
+            separator=comp_cfg.separator,
+            enclosing=comp_cfg.enclosing,
+            placement="append",
+            class_mapping=comp_cfg.class_mapping,
+        )
+        loc = {"item_fuelnozzle_MISC_Standard_Name": "RN-7s"}
+        out = gen_module.enhancements_bare_type_tags(
+            {"loc": loc, "tag_configs": {"components": append_cfg}}
+        )
+        assert out == {"item_fuelnozzle_MISC_Standard_Name": "RN-7s [FN]"}
+
+    def test_tags_short_name_variant_too(self, gen_module):
+        loc = {
+            "item_fuelnozzle_MISC_Standard_Name": "RN-7s",
+            "item_fuelnozzle_MISC_Standard_Name_short": "RN-7s",
+        }
+        out = gen_module.enhancements_bare_type_tags({"loc": loc, "tag_configs": {}})
+        assert out["item_fuelnozzle_MISC_Standard_Name"] == "[FN] RN-7s"
+        assert out["item_fuelnozzle_MISC_Standard_Name_short"] == "[FN] RN-7s"
+
+    def test_unrelated_keys_untouched(self, gen_module):
+        loc = {
+            "item_fuelnozzle_MISC_Standard_Name": "RN-7s",
+            "item_fuelnozzle_MISC_Standard_Desc": "Manufacturer: MISC\\nItem Type: Fuel Nozzle",
+            "item_NameSHLD_ASAS_S01_Shimmer": "Shimmer",
+            "some_unrelated_key": "unrelated value",
+        }
+        out = gen_module.enhancements_bare_type_tags({"loc": loc, "tag_configs": {}})
+        assert set(out) == {"item_fuelnozzle_MISC_Standard_Name"}
+
+    def test_empty_loc_is_empty(self, gen_module):
+        assert gen_module.enhancements_bare_type_tags({"loc": {}, "tag_configs": {}}) == {}
+
+    def test_missing_name_value_is_skipped(self, gen_module):
+        loc = {"item_fuelnozzle_MISC_Standard_Name": ""}
+        assert gen_module.enhancements_bare_type_tags({"loc": loc, "tag_configs": {}}) == {}

--- a/tests/test_bare_type_tags.py
+++ b/tests/test_bare_type_tags.py
@@ -188,3 +188,48 @@ class TestEnhancementsBareTypeTags:
             {"loc": loc, "tag_configs": {"components": cfg}}
         )
         assert out == {}
+
+
+# Real stock text (tests/fixtures/kraken_global_latest.ini) for the Abrade
+# Scraper Module -- no Size:/Grade:/Class: line, same bare shape as fuel
+# nozzles, just a different manufacturer key prefix (item_scraper_GRIN_*).
+_ABRADE_DESC = (
+    "Manufacturer: Greycat Industrial\\nItem Type: Scraper Module\\n"
+    "Extraction Speed: 0.15/0.45\\nRadius: 3.5m\\nExtraction Efficiency: 70%\\n"
+)
+
+
+class TestEnhancementsBareTypeTagsScraperModule:
+    """Scraper Module (Trawler/Cinch/Abrade) -- only ships with blueprints
+    (Adagio Industrial salvage contracts), added alongside Fuel Nozzle and
+    Mining Laser per the user's narrowed #266 scope."""
+
+    def test_tags_scraper_module_when_type_enabled(self, gen_module):
+        cfg = _components_cfg_with_type(gen_module, style="short")
+        loc = {
+            "item_scraper_GRIN_Standard_Name": "Abrade Scraper Module",
+            "item_scraper_GRIN_Standard_Desc": _ABRADE_DESC,
+        }
+        out = gen_module.enhancements_bare_type_tags(
+            {"loc": loc, "tag_configs": {"components": cfg}}
+        )
+        assert out == {"item_scraper_GRIN_Standard_Name": "[SCM] Abrade Scraper Module"}
+
+    def test_no_tag_when_type_disabled_by_default(self, gen_module):
+        loc = {
+            "item_scraper_GRIN_Standard_Name": "Abrade Scraper Module",
+            "item_scraper_GRIN_Standard_Desc": _ABRADE_DESC,
+        }
+        out = gen_module.enhancements_bare_type_tags({"loc": loc, "tag_configs": {}})
+        assert out == {}
+
+    def test_respects_users_configured_type_style(self, gen_module):
+        cfg = _components_cfg_with_type(gen_module, style="long")
+        loc = {
+            "item_scraper_GRIN_Standard_Name": "Abrade Scraper Module",
+            "item_scraper_GRIN_Standard_Desc": _ABRADE_DESC,
+        }
+        out = gen_module.enhancements_bare_type_tags(
+            {"loc": loc, "tag_configs": {"components": cfg}}
+        )
+        assert out == {"item_scraper_GRIN_Standard_Name": "[Scraper Module] Abrade Scraper Module"}

--- a/tests/test_blueprint_meta.py
+++ b/tests/test_blueprint_meta.py
@@ -304,3 +304,64 @@ class TestBareTypeKeyConventions:
         meta = build_blueprint_metadata(entries)
         assert "Abrade Scraper Module" in meta
         assert meta["Abrade Scraper Module"].tagged_name == "[SCM] Abrade Scraper Module"
+
+
+class TestBulletNameMismatches:
+    """A live mission body ("Crew Hasn't Checked In") reported bullets that
+    don't match any real item_Name value at all -- two different root
+    causes, both fixed here (#266 follow-up)."""
+
+    def test_key_slug_fallback_resolves_garbled_bullet_name(self):
+        """CIG's own bug: the bullet lists the de-slugified loc KEY instead
+        of the item's real localized name -- "Nozzle Fuelgiver Grin
+        Nozzleveryfast" for a key whose real value is "Lindstrom". This is
+        deterministic (title-case each underscore segment, drop a trailing
+        "_Name" segment first), so it's resolved generically rather than
+        via a hardcoded alias."""
+        desc = (
+            "x\\n<EM4>POTENTIAL BLUEPRINTS</EM4>"
+            "\\n- Nozzle Fuelgiver Grin Nozzleveryfast"
+        )
+        entries = [
+            _Entry("M_Desc_001", desc, "Missions"),
+            _Entry("Nozzle_FuelGiver_GRIN_NozzleVeryFast_Name", "[FN] Lindstrom", "Ship Items"),
+        ]
+        meta = build_blueprint_metadata(entries)
+        assert "Lindstrom" in meta
+        assert meta["Lindstrom"].tagged_name == "[FN] Lindstrom"
+        assert "Nozzle Fuelgiver Grin Nozzleveryfast" not in meta
+
+    def test_known_alias_resolves_helix_mismatch(self):
+        """Not every mismatch is the key-slug bug -- "Helix" bears no
+        relation to its key's slug at all, just an informal short name a
+        mission author typed. The real item is "S0 Helix"."""
+        desc = "x\\n<EM4>POTENTIAL BLUEPRINTS</EM4>\\n- Helix"
+        entries = [
+            _Entry("M_Desc_001", desc, "Missions"),
+            _Entry("item_NameMining_Head_S00_Helix_SCItem", "[Mining Laser] S0 Helix", "Ship Items"),
+        ]
+        meta = build_blueprint_metadata(entries)
+        assert "S0 Helix" in meta
+        assert meta["S0 Helix"].tagged_name == "[Mining Laser] S0 Helix"
+        assert "Helix" not in meta
+
+    def test_direct_match_is_not_overridden_by_alias_or_keyslug(self):
+        """A bullet name that already matches a real item directly must
+        win outright -- the alias/keyslug fallback only kicks in when the
+        direct match fails."""
+        desc = "x\\n<EM4>POTENTIAL BLUEPRINTS</EM4>\\n- Pitman Mining Laser"
+        entries = [
+            _Entry("M_Desc_001", desc, "Missions"),
+            _Entry("item_Mining_MiningLaser_Drake_Default_S0", "Pitman Mining Laser", "Ship Items"),
+        ]
+        meta = build_blueprint_metadata(entries)
+        assert meta["Pitman Mining Laser"].tagged_name == "Pitman Mining Laser"
+
+    def test_unresolvable_bullet_name_falls_back_to_other(self):
+        """A bullet name matching neither a real item, a known alias, nor
+        any key's slug still shows up (as an untagged "Other" entry)
+        rather than being silently dropped."""
+        desc = "x\\n<EM4>POTENTIAL BLUEPRINTS</EM4>\\n- Totally Unknown Widget"
+        meta = build_blueprint_metadata([_Entry("M_Desc_001", desc, "Missions")])
+        assert "Totally Unknown Widget" in meta
+        assert meta["Totally Unknown Widget"].type == "Other"

--- a/tests/test_blueprint_meta.py
+++ b/tests/test_blueprint_meta.py
@@ -279,3 +279,28 @@ class TestBareTypeKeyConventions:
         ]
         meta = build_blueprint_metadata(entries)
         assert meta["Lancet MH1 Mining Laser"].tagged_name == "[ML-S1] Lancet MH1 Mining Laser"
+
+    @pytest.mark.regression
+    def test_scraper_module_joins_through_reputation_tier_and_category_annotation(self):
+        """End-to-end regression for the two compounding bugs found while
+        wiring up Scraper Module: the real Adagio Industrial mission body
+        groups bullets under an "Awarded from X level variants" sub-header
+        (previously mistaken for a section boundary, so the bullet was
+        never even reached) AND appends a "(Salvage Mod)" category
+        annotation the real item_Name never carries (so even once reached,
+        the normalized names wouldn't have matched). Both must be fixed for
+        this item to ever show up tagged in the Blueprint Tracker."""
+        desc = (
+            "Adagio Holdings...\\n\\n<EM4>POTENTIAL BLUEPRINTS</EM4>"
+            "\\n<EM4>Awarded from Contractor level variants</EM4>"
+            "\\n- Trawler Scraper Module (Salvage Mod)"
+            "\\n- Abrade Scraper Module (Salvage Mod)"
+            "\\n- Cinch Scraper Module (Salvage Mod)"
+        )
+        entries = [
+            _Entry("M_Desc_001", desc, "Missions"),
+            _Entry("item_scraper_GRIN_Standard_Name", "[SCM] Abrade Scraper Module", "Ship Items"),
+        ]
+        meta = build_blueprint_metadata(entries)
+        assert "Abrade Scraper Module" in meta
+        assert meta["Abrade Scraper Module"].tagged_name == "[SCM] Abrade Scraper Module"

--- a/tests/test_blueprint_meta.py
+++ b/tests/test_blueprint_meta.py
@@ -237,3 +237,45 @@ def test_desc_without_title_yields_no_mission_but_keeps_item():
 
 def test_no_blueprint_entries_is_empty():
     assert build_blueprint_metadata([_Entry("vehicle_NameRSI_Polaris", "Polaris", "Ships")]) == {}
+
+
+class TestBareTypeKeyConventions:
+    """#266 follow-up: fuel nozzles and mining lasers don't follow the
+    item_Name<code> / vehicle_Name prefix every other component uses, so
+    Pass 1 never recognised their key as a Name entry -- tagged_name fell
+    back to the untagged bare name in the Blueprint Tracker even though
+    the enhancement generator's output (and the String Editor) showed the
+    real tag correctly. ("Tags work right in string editor but not in
+    blueprint tracker.")"""
+
+    def test_fuel_nozzle_item_fuelnozzle_prefix_gets_tagged_name(self):
+        desc = "x\\n<EM4>POTENTIAL BLUEPRINTS</EM4>\\n- RN-7s"
+        entries = [
+            _Entry("M_Desc_001", desc, "Missions"),
+            _Entry("item_fuelnozzle_MISC_Standard_Name", "[FN] RN-7s", "Ship Items"),
+        ]
+        meta = build_blueprint_metadata(entries)
+        assert meta["RN-7s"].tagged_name == "[FN] RN-7s"
+
+    def test_fuel_nozzle_nozzle_fuelgiver_prefix_gets_tagged_name(self):
+        """Regression guard: Greycat/Shubin nozzles ship under the
+        Nozzle_FuelGiver_* convention, not item_fuelnozzle_*."""
+        desc = "x\\n<EM4>POTENTIAL BLUEPRINTS</EM4>\\n- Marlin"
+        entries = [
+            _Entry("M_Desc_001", desc, "Missions"),
+            _Entry("Nozzle_FuelGiver_GRIN_NozzleSecure_Name", "[FN] Marlin", "Ship Items"),
+        ]
+        meta = build_blueprint_metadata(entries)
+        assert meta["Marlin"].tagged_name == "[FN] Marlin"
+
+    def test_mining_laser_bare_key_gets_tagged_name(self):
+        """Mining laser Name keys carry no "_Name" suffix at all -- the
+        bare key (ending in the size code) IS the Name entry."""
+        desc = "x\\n<EM4>POTENTIAL BLUEPRINTS</EM4>\\n- Lancet MH1 Mining Laser"
+        entries = [
+            _Entry("M_Desc_001", desc, "Missions"),
+            _Entry("item_Mining_MiningLaser_Greycat_1_S1",
+                   "[ML-S1] Lancet MH1 Mining Laser", "Ship Items"),
+        ]
+        meta = build_blueprint_metadata(entries)
+        assert meta["Lancet MH1 Mining Laser"].tagged_name == "[ML-S1] Lancet MH1 Mining Laser"

--- a/tests/test_blueprint_meta.py
+++ b/tests/test_blueprint_meta.py
@@ -379,6 +379,34 @@ class TestBulletNameMismatches:
         assert "Arbor" not in meta
         assert "Klein" not in meta
 
+    @pytest.mark.regression
+    def test_known_aliases_cover_the_three_fuel_nozzles_key_slug_missed(self):
+        """Most fuel nozzle variants resolve generically via _key_slug, but
+        a live Blueprint Tracker screenshot showed these three still
+        untagged/ungarbled after that fix -- their real underlying key
+        apparently doesn't follow the Nozzle_FuelGiver_<MFR>_Nozzle
+        <Variant>_Name pattern the others do, so they need explicit
+        aliases like Helix/Hofstede."""
+        desc = (
+            "x\\n<EM4>POTENTIAL BLUEPRINTS</EM4>"
+            "\\n- Nozzle Fuelgiver Grin Nozzlefast"
+            "\\n- Nozzle Fuelgiver Grin Nozzleverysecure"
+            "\\n- Nozzle Fuelgiver Misc Nozzlestandard"
+        )
+        entries = [
+            _Entry("M_Desc_001", desc, "Missions"),
+            _Entry("item_fuelnozzle_GRIN_Fast_Name", "[FN] Norfield", "Ship Items"),
+            _Entry("item_fuelnozzle_GRIN_Safe_Name", "[FN] Harkin", "Ship Items"),
+            _Entry("item_fuelnozzle_MISC_Standard_Name", "[FN] RN-7s", "Ship Items"),
+        ]
+        meta = build_blueprint_metadata(entries)
+        assert meta["Norfield"].tagged_name == "[FN] Norfield"
+        assert meta["Harkin"].tagged_name == "[FN] Harkin"
+        assert meta["RN-7s"].tagged_name == "[FN] RN-7s"
+        assert "Nozzle Fuelgiver Grin Nozzlefast" not in meta
+        assert "Nozzle Fuelgiver Grin Nozzleverysecure" not in meta
+        assert "Nozzle Fuelgiver Misc Nozzlestandard" not in meta
+
     def test_direct_match_is_not_overridden_by_alias_or_keyslug(self):
         """A bullet name that already matches a real item directly must
         win outright -- the alias/keyslug fallback only kicks in when the

--- a/tests/test_blueprint_meta.py
+++ b/tests/test_blueprint_meta.py
@@ -345,6 +345,40 @@ class TestBulletNameMismatches:
         assert meta["S0 Helix"].tagged_name == "[Mining Laser] S0 Helix"
         assert "Helix" not in meta
 
+    @pytest.mark.regression
+    def test_known_alias_resolves_hofstede_mismatch(self):
+        """Same "Mining Head" bare-name pattern as Helix, reported
+        separately in a live mission body -- confirms this isn't a
+        one-off, it's the whole item family."""
+        desc = "x\\n<EM4>POTENTIAL BLUEPRINTS</EM4>\\n- Hofstede"
+        entries = [
+            _Entry("M_Desc_001", desc, "Missions"),
+            _Entry("item_NameMining_Head_S00_Hofstede_SCItem", "[Mining Laser] S00 Hofstede", "Ship Items"),
+        ]
+        meta = build_blueprint_metadata(entries)
+        assert "S00 Hofstede" in meta
+        assert meta["S00 Hofstede"].tagged_name == "[Mining Laser] S00 Hofstede"
+        assert "Hofstede" not in meta
+
+    def test_known_aliases_cover_the_whole_mining_head_family(self):
+        """Arbor and Klein share the same key convention as Helix/Hofstede
+        (item_NameMining_Head_S00_<Name>_SCItem) -- added preemptively
+        rather than waiting for each to be reported individually."""
+        desc = (
+            "x\\n<EM4>POTENTIAL BLUEPRINTS</EM4>"
+            "\\n- Arbor\\n- Klein"
+        )
+        entries = [
+            _Entry("M_Desc_001", desc, "Missions"),
+            _Entry("item_NameMining_Head_S00_Arbor_SCItem", "[Mining Laser] S0 Arbor", "Ship Items"),
+            _Entry("item_NameMining_Head_S00_Klein_SCItem", "Lawson Mining Laser", "Ship Items"),
+        ]
+        meta = build_blueprint_metadata(entries)
+        assert meta["S0 Arbor"].tagged_name == "[Mining Laser] S0 Arbor"
+        assert meta["Lawson Mining Laser"].tagged_name == "Lawson Mining Laser"
+        assert "Arbor" not in meta
+        assert "Klein" not in meta
+
     def test_direct_match_is_not_overridden_by_alias_or_keyslug(self):
         """A bullet name that already matches a real item directly must
         win outright -- the alias/keyslug fallback only kicks in when the

--- a/tests/test_entry_filter.py
+++ b/tests/test_entry_filter.py
@@ -187,6 +187,24 @@ def test_both_bp_flags_show_titles_or_descs():
     assert result == [0, 1, 2]  # titles OR descriptions
 
 
+@pytest.mark.regression
+def test_bp_descs_only_recognises_multiple_blueprint_pools_header():
+    """CIG uses a second, entirely different header ("MULTIPLE BLUEPRINT
+    POOLS") for missions offering more than one blueprint pool (#266
+    follow-up) -- pre-fix, the "BP Descriptions" checkbox only recognised
+    "POTENTIAL BLUEPRINTS" and silently excluded these mission bodies."""
+    entries = [
+        _e("desc_pools", original_value=(
+            "POSTING...\n<EM4>MULTIPLE BLUEPRINT POOLS</EM4>"
+            "\n<EM4>Pool 1</EM4>\n- Helix I Mining Laser (Mining Laser)"
+        )),
+        _e("plain_desc", original_value="A description with no rewards section"),
+    ]
+    result = filter_entry_indices(entries, {}, _no_filters(), "All", "All", False, False, "★",
+                                  bp_descs_only=True)
+    assert result == [0]
+
+
 def test_bp_filter_reads_custom_override_when_present():
     # A user override on a title row is what's shown, so the tag must be read
     # from custom_value when set.

--- a/tests/test_owned_items.py
+++ b/tests/test_owned_items.py
@@ -12,6 +12,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
 from utils.owned_items import (  # noqa: E402
     apply_owned_to_value,
     extract_bp_item_names,
+    has_bp_section,
     normalize_item_name,
 )
 
@@ -168,6 +169,36 @@ class TestExtract:
         )
         names = extract_bp_item_names(desc)
         assert names == {"Cinch Scraper Module", "Trawler Scraper Module", "Abrade Scraper Module"}
+
+    @pytest.mark.regression
+    def test_multiple_blueprint_pools_header_recognised(self):
+        """CIG uses a second, entirely different section header ("MULTIPLE
+        BLUEPRINT POOLS") for missions offering more than one blueprint
+        pool -- confirmed via tests/fixtures/kraken_global_latest.ini: 35
+        missions use it (e.g. mining-laser purchase-order contracts that
+        award a weapon/armor Pool 1 alongside a mining-laser/radar Pool 2).
+        Pre-fix, only "POTENTIAL BLUEPRINTS" was recognised at all, so
+        these missions were never scanned -- not just untagged, their
+        items were entirely absent from the Blueprint Tracker."""
+        desc = (
+            "POSTING: Purchase Order...\\n\\n<EM4>Multiple Blueprint Pools</EM4>"
+            "\\n<EM4>Awarded from Sr. Contractor level variants</EM4>"
+            "\\n<EM4>Pool 1</EM4>"
+            "\\n- Arclight Pistol\\n- Venture Arms Base"
+            "\\n\\n<EM4>Pool 2</EM4>"
+            "\\n- Helix I Mining Laser (Mining Laser)\\n- BroadSpec (Radar)"
+        )
+        names = extract_bp_item_names(desc)
+        assert names == {
+            "Arclight Pistol", "Venture Arms Base",
+            "Helix I Mining Laser", "BroadSpec",
+        }
+
+    def test_has_bp_section_recognises_both_headers(self):
+        assert has_bp_section("x\\n<EM4>POTENTIAL BLUEPRINTS</EM4>\\n- Foo")
+        assert has_bp_section("x\\n<EM4>Multiple Blueprint Pools</EM4>\\n- Foo")
+        assert not has_bp_section("A description with no rewards section")
+        assert not has_bp_section("")
 
 
 class TestApply:

--- a/tests/test_owned_items.py
+++ b/tests/test_owned_items.py
@@ -79,6 +79,29 @@ class TestNormalize:
         assert normalize_item_name("Barbican [IND-S3-B]") == \
             normalize_item_name("[IND-S3-B] Barbican")
 
+    # ── #266 follow-up: bullet-only category annotations ──────────────────────
+    def test_strips_trailing_category_annotation(self):
+        """CIG's own POTENTIAL BLUEPRINTS bullet text appends a category
+        annotation to some items (confirmed via tests/fixtures/
+        kraken_global_latest.ini) that never appears on the item's own
+        item_Name value -- left unstripped, the bullet never matches the
+        real (tagged) item."""
+        assert normalize_item_name("Bendix (Fuel Nozzle)") == "Bendix"
+        assert normalize_item_name("Arbor MH1 Mining Laser (Mining Laser)") == "Arbor MH1 Mining Laser"
+        assert normalize_item_name("Trawler Scraper Module (Salvage Mod)") == "Trawler Scraper Module"
+        assert normalize_item_name("5CA 'Akura' (Shield)") == "5CA 'Akura'"
+
+    def test_category_annotation_matches_bare_item_name(self):
+        assert normalize_item_name("Bendix (Fuel Nozzle)") == normalize_item_name("Bendix")
+
+    def test_unrecognized_parenthetical_is_kept(self):
+        """Not every trailing parenthetical is a bullet-only annotation --
+        some are part of the item's own real distinguishing name (e.g. a
+        "(Modified)" armor variant). Only the small allow-listed category
+        words get stripped; anything else survives untouched."""
+        assert normalize_item_name("Artimex Arms (Modified)") == "Artimex Arms (Modified)"
+        assert normalize_item_name("Ballistic Gatling (x2)") == "Ballistic Gatling (x2)"
+
 
 class TestExtract:
     def test_finds_normalized_bullet_names(self):
@@ -108,6 +131,43 @@ class TestExtract:
         names = extract_bp_item_names(_DESC_WITH_FALSE_POSITIVES)
         assert {"Cryo-Star SL", "Kelvid"} <= names  # [Nyx] region
         assert {"DuraJet", "ZapJet"} <= names        # [Pyro] region
+
+    @pytest.mark.regression
+    def test_awarded_from_tier_sub_headers_not_mistaken_for_section_end(self):
+        """Reputation-tiered contracts (Adagio Industrial salvage, Bounty
+        Hunters Guild, Security, ...) group POTENTIAL BLUEPRINTS bullets
+        under an "Awarded from X level variants" sub-header *inside* the
+        section, sometimes repeated for multiple tiers in one mission body.
+        Pre-fix, the first such sub-header was mistaken for a genuine
+        section boundary (it doesn't start with "[" like a region label
+        does), truncating the span before any bullets were ever reached --
+        so items awarded this way (Scraper Modules among others) never
+        surfaced in the Blueprint Tracker at all, tag or no tag."""
+        desc = (
+            "Adagio Holdings...\\n\\n<EM4>POTENTIAL BLUEPRINTS</EM4>"
+            "\\n<EM4>Awarded from Contractor level variants</EM4>"
+            "\\n- Trawler Scraper Module (Salvage Mod)"
+            "\\n- Abrade Scraper Module (Salvage Mod)"
+            "\\n- Cinch Scraper Module (Salvage Mod)"
+        )
+        names = extract_bp_item_names(desc)
+        assert names == {"Trawler Scraper Module", "Abrade Scraper Module", "Cinch Scraper Module"}
+
+    @pytest.mark.regression
+    def test_multiple_awarded_from_tiers_in_one_body_all_included(self):
+        """Some missions list several reputation tiers, each with its own
+        sub-header + bullet group, in a single POTENTIAL BLUEPRINTS section."""
+        desc = (
+            "\\n\\n<EM4>POTENTIAL BLUEPRINTS</EM4>"
+            "\\n<EM4>Awarded from Jr. Contractor level variants</EM4>"
+            "\\n- Cinch Scraper Module (Salvage Mod)"
+            "\\n<EM4>Awarded from Contractor level variants</EM4>"
+            "\\n- Trawler Scraper Module (Salvage Mod)"
+            "\\n- Abrade Scraper Module (Salvage Mod)"
+            "\\n\\n<EM3>MISSION DETAILS</EM3>\\n<EM4>Difficulty:</EM4> 2"
+        )
+        names = extract_bp_item_names(desc)
+        assert names == {"Cinch Scraper Module", "Trawler Scraper Module", "Abrade Scraper Module"}
 
 
 class TestApply:

--- a/tests/test_scitem_lookup_bare_type_and_mining_laser.py
+++ b/tests/test_scitem_lookup_bare_type_and_mining_laser.py
@@ -1,0 +1,164 @@
+"""Regression tests for build_scitem_lookups' mission-bullet tagging of
+Fuel Nozzle / Scraper Module / ship Mining Laser entities (#266 follow-up).
+
+Before this fix, entity_name_tags (which feeds the POTENTIAL BLUEPRINTS
+bullet list a player reads in-game, via build_blueprint_pool_lookup) never
+got an entry for these three item types: Fuel Nozzle/Scraper Module have no
+Size:/Grade:/Class: so _component_name_tag always returned None for them,
+and Mining Laser lives under a "weapons" parent dir that's unconditionally
+excluded (guard added for #220's combat-weapon false positives). The item's
+OWN name still got tagged correctly (via enhancements_bare_type_tags /
+_ship_weapon_name_tag_factory), so the tag showed up in the String Editor
+and in a ship's loadout screen -- but never inside a mission's blueprint
+list, which is what a player actually reads before accepting a contract.
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+pytestmark = [pytest.mark.unit, pytest.mark.regression]
+
+
+@pytest.fixture(scope="module")
+def gen_module():
+    repo_root = Path(__file__).resolve().parent.parent
+    script_path = repo_root / "scripts" / "generate_enhancements_ini.py"
+    spec = importlib.util.spec_from_file_location(
+        "generate_enhancements_ini_scitem_bare_type_test", script_path,
+    )
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _components_cfg(gen_module, type_enabled=True, type_style="med",
+                     size_enabled=True, size_style="sn"):
+    from src.utils.tag_builder import DEFAULT_TAG_CONFIGS
+    comp_cfg = DEFAULT_TAG_CONFIGS["components"]
+    return gen_module.TagConfig(
+        elements=[
+            gen_module.ElementSpec("type", type_enabled, type_style),
+            gen_module.ElementSpec("size", size_enabled, size_style),
+        ],
+        separator=comp_cfg.separator,
+        enclosing=comp_cfg.enclosing,
+        placement=comp_cfg.placement,
+        class_mapping=comp_cfg.class_mapping,
+    )
+
+
+class TestBareTypeEntityTag:
+    """Fuel Nozzle / Scraper Module: no Size:/Grade:/Class:, tagged via
+    the _bare_type_tag_from_desc fallback when _component_name_tag can't
+    classify them."""
+
+    def _write_fuel_nozzle(self, tmp_path: Path, ref: str) -> Path:
+        subdir = tmp_path / "misc"
+        subdir.mkdir(parents=True, exist_ok=True)
+        (subdir / "nozzle_test.xml").write_text(
+            f'<EntityClassDefinition.nozzle __ref="{ref}">'
+            '<SItemComponentParams Name="@nm_nozzle" Description="@ds_nozzle"/>'
+            '</EntityClassDefinition.nozzle>',
+            encoding="utf-8",
+        )
+        return tmp_path
+
+    def test_fuel_nozzle_gets_bullet_tag_when_type_enabled(self, gen_module, tmp_path):
+        ref = "33333333-3333-3333-3333-333333333333"
+        self._write_fuel_nozzle(tmp_path, ref)
+        loc = {
+            "nm_nozzle": "RN-7s",
+            "ds_nozzle": "Manufacturer: MISC\\nItem Type: Fuel Nozzle\\nHydrogen Flow Speed: 1.65 SCU/s\\n",
+        }
+        _mag, _names, _by_file, entity_name_tags = gen_module.build_scitem_lookups(
+            tmp_path, loc=loc, tag_config=_components_cfg(gen_module),
+        )
+        assert ref in entity_name_tags
+        assert entity_name_tags[ref] == "[FNoz]"
+
+    def test_fuel_nozzle_gets_no_bullet_tag_when_type_disabled(self, gen_module, tmp_path):
+        ref = "44444444-4444-4444-4444-444444444444"
+        self._write_fuel_nozzle(tmp_path, ref)
+        loc = {
+            "nm_nozzle": "RN-7s",
+            "ds_nozzle": "Manufacturer: MISC\\nItem Type: Fuel Nozzle\\n",
+        }
+        cfg = _components_cfg(gen_module, type_enabled=False)
+        _mag, _names, _by_file, entity_name_tags = gen_module.build_scitem_lookups(
+            tmp_path, loc=loc, tag_config=cfg,
+        )
+        assert ref not in entity_name_tags
+
+
+class TestMiningLaserEntityTag:
+    """Ship-mounted Mining Laser: lives under a "weapons" parent dir
+    (normally excluded outright) but IS a real component type with a
+    real Size, so it gets a carve-out."""
+
+    def _write_mining_laser(self, tmp_path: Path, ref: str) -> Path:
+        subdir = tmp_path / "weapons"
+        subdir.mkdir(parents=True, exist_ok=True)
+        (subdir / "mininglaser_test.xml").write_text(
+            f'<EntityClassDefinition.miningLaser __ref="{ref}">'
+            '<SItemComponentParams Name="@nm_ml" Description="@ds_ml"/>'
+            '<SEntityComponentMiningLaserParams/>'
+            '</EntityClassDefinition.miningLaser>',
+            encoding="utf-8",
+        )
+        return tmp_path
+
+    def test_mining_laser_gets_bullet_type_size_tag_when_enabled(self, gen_module, tmp_path):
+        ref = "55555555-5555-5555-5555-555555555555"
+        self._write_mining_laser(tmp_path, ref)
+        loc = {
+            "nm_ml": "Helix I Mining Laser",
+            "ds_ml": "Manufacturer: Thermyte Concern\\nItem Type: Mining Laser \\nSize: 1\\n",
+        }
+        _mag, _names, _by_file, entity_name_tags = gen_module.build_scitem_lookups(
+            tmp_path, loc=loc, tag_config=_components_cfg(gen_module),
+        )
+        assert ref in entity_name_tags
+        assert entity_name_tags[ref] == "[MineL-S1]"
+
+    def test_mining_laser_gets_no_bullet_tag_when_type_disabled(self, gen_module, tmp_path):
+        ref = "66666666-6666-6666-6666-666666666666"
+        self._write_mining_laser(tmp_path, ref)
+        loc = {
+            "nm_ml": "Helix I Mining Laser",
+            "ds_ml": "Manufacturer: Thermyte Concern\\nItem Type: Mining Laser \\nSize: 1\\n",
+        }
+        cfg = _components_cfg(gen_module, type_enabled=False)
+        _mag, _names, _by_file, entity_name_tags = gen_module.build_scitem_lookups(
+            tmp_path, loc=loc, tag_config=cfg,
+        )
+        assert ref not in entity_name_tags
+
+    def test_combat_weapon_in_weapons_dir_still_excluded(self, gen_module, tmp_path):
+        """Regression guard for #220: a combat weapon (no mining-laser
+        marker) under weapons/ must still get no tag at all, even with
+        Size:/Grade:/Class: text present in its description."""
+        ref = "77777777-7777-7777-7777-777777777777"
+        subdir = tmp_path / "weapons"
+        subdir.mkdir(parents=True, exist_ok=True)
+        (subdir / "cannon_test.xml").write_text(
+            f'<EntityClassDefinition.weapon __ref="{ref}">'
+            '<SItemComponentParams Name="@nm_gun" Description="@ds_gun"/>'
+            '</EntityClassDefinition.weapon>',
+            encoding="utf-8",
+        )
+        loc = {
+            "nm_gun": "Test Cannon",
+            "ds_gun": "Size: 2 Grade: A Class: Military",
+        }
+        _mag, _names, _by_file, entity_name_tags = gen_module.build_scitem_lookups(
+            tmp_path, loc=loc, tag_config=_components_cfg(gen_module),
+        )
+        assert ref not in entity_name_tags

--- a/tests/test_ship_weapon_tag.py
+++ b/tests/test_ship_weapon_tag.py
@@ -132,7 +132,9 @@ class TestShipWeaponTagMiningLaser:
     have no ammo/damage breakdown, so the damage-required guard above
     would otherwise skip them entirely. They ARE a real component type
     with a real Size though, so #266 tags them via the component
-    Type+Size shape (``[ML-S1]`` under default styles) instead."""
+    Type+Size shape (``[ML-S1]``) instead — gated by the same
+    Components > Type toggle as every other DEFAULT_COMPONENT_TYPE_MAPPING
+    entry (Shield Generator, Cooler, ...): opt-in, not force-shown."""
 
     def _mining_laser_xml(self, name_attr: str = "Greycat_MiningLaser_Arbor"):
         xml = (
@@ -144,37 +146,66 @@ class TestShipWeaponTagMiningLaser:
         )
         return ET.fromstring(xml)
 
-    def test_mining_laser_gets_component_type_size_tag(self, gen_module):
-        desc = "Manufacturer: Greycat Industrial\\nItem Type: Mining Laser \\nSize: 1\\n"
-        tagger = gen_module._ship_weapon_name_tag_factory(ammo_lookup={})
-        assert tagger(desc, self._mining_laser_xml()) == "[ML-S1]"
-
-    def test_respects_users_configured_components_style(self, gen_module):
-        """A user who's customised the "components" Type/Size styles (even
-        while leaving Type disabled for their sized components) gets those
-        same styles applied here, matching the fuel-nozzle bare-type tag
-        behaviour (#266)."""
+    def _components_cfg(self, type_enabled, type_style="short",
+                         size_enabled=True, size_style="sn"):
         comp_cfg = DEFAULT_TAG_CONFIGS["components"]
-        custom_cfg = TagConfig(
+        return TagConfig(
             elements=[
-                ElementSpec("type", False, "long"),
-                ElementSpec("size", True, "n"),
+                ElementSpec("type", type_enabled, type_style),
+                ElementSpec("size", size_enabled, size_style),
             ],
             separator=comp_cfg.separator,
             enclosing=comp_cfg.enclosing,
             placement=comp_cfg.placement,
             class_mapping=comp_cfg.class_mapping,
         )
+
+    def test_no_tag_when_type_disabled_by_default(self, gen_module):
+        """Type is disabled by default for "components" -- with no
+        explicit config, mining lasers get no tag at all."""
+        desc = "Manufacturer: Greycat Industrial\\nItem Type: Mining Laser \\nSize: 1\\n"
+        tagger = gen_module._ship_weapon_name_tag_factory(ammo_lookup={})
+        assert tagger(desc, self._mining_laser_xml()) is None
+
+    def test_mining_laser_gets_component_type_size_tag_when_enabled(self, gen_module):
+        desc = "Manufacturer: Greycat Industrial\\nItem Type: Mining Laser \\nSize: 1\\n"
+        cfg = self._components_cfg(type_enabled=True)
+        tagger = gen_module._ship_weapon_name_tag_factory(
+            ammo_lookup={}, mining_laser_config=cfg,
+        )
+        assert tagger(desc, self._mining_laser_xml()) == "[ML-S1]"
+
+    def test_respects_users_configured_components_style(self, gen_module):
+        """A user who's enabled Type/Size with custom styles gets those
+        same styles applied here, matching the fuel-nozzle bare-type tag
+        behaviour (#266)."""
+        cfg = self._components_cfg(type_enabled=True, type_style="long",
+                                    size_enabled=True, size_style="n")
         desc = "Item Type: Mining Laser \\nSize: 1\\n"
         tagger = gen_module._ship_weapon_name_tag_factory(
-            ammo_lookup={}, mining_laser_config=custom_cfg,
+            ammo_lookup={}, mining_laser_config=cfg,
         )
         assert tagger(desc, self._mining_laser_xml()) == "[Mining Laser-1]"
+
+    def test_size_omitted_when_size_element_disabled(self, gen_module):
+        """Type enabled but Size specifically disabled -- Type-only tag,
+        no bare [S1] leaking in from a component element the user turned
+        off."""
+        cfg = self._components_cfg(type_enabled=True, size_enabled=False)
+        desc = "Item Type: Mining Laser \\nSize: 1\\n"
+        tagger = gen_module._ship_weapon_name_tag_factory(
+            ammo_lookup={}, mining_laser_config=cfg,
+        )
+        assert tagger(desc, self._mining_laser_xml()) == "[ML]"
 
     def test_mining_laser_without_marker_falls_through_to_no_tag(self, gen_module):
         """Sanity guard: only entities carrying the mining-laser marker get
         this fallback — a plain no-damage item (tractor beam etc.) is
-        untouched, per the existing damage-required guard."""
+        untouched, per the existing damage-required guard, even with Type
+        enabled."""
         beam_xml = ET.fromstring('<EntityClassDefinition Name="ARGO_TowingBeam_S3"/>')
-        tagger = gen_module._ship_weapon_name_tag_factory(ammo_lookup={})
+        cfg = self._components_cfg(type_enabled=True)
+        tagger = gen_module._ship_weapon_name_tag_factory(
+            ammo_lookup={}, mining_laser_config=cfg,
+        )
         assert tagger("Item Type: Towing Beam\\nSize: 3\\n", beam_xml) is None

--- a/tests/test_ship_weapon_tag.py
+++ b/tests/test_ship_weapon_tag.py
@@ -3,10 +3,15 @@
 Covers a 1.4.0 regression: ``_ship_weapon_name_tag_factory`` was emitting a
 size-only tag like ``[S1]`` (or ``[1]`` under a user's "Number" size style)
 for items in ``ships/weapons/`` that lacked a resolvable damage breakdown.
-EMP devices, tractor / towing beams, and mining lasers (which have their
-own enhancements_mining_laser pipeline) were the visible victims — issue
-thread reported ``item_NameMXOX_EMP_Device=[1] TroMag Burst Generator``.
-The fix requires a non-empty damage_label before any tag is emitted.
+EMP devices, tractor / towing beams, and mining lasers were the visible
+victims — issue thread reported
+``item_NameMXOX_EMP_Device=[1] TroMag Burst Generator``. The fix requires
+a non-empty damage_label before the ship-weapon damage-keyed tag is
+emitted. Mining lasers later got their own component-style Type+Size
+fallback instead of staying permanently untagged (#266) — see
+``TestShipWeaponTagMiningLaser`` below; EMP devices and tractor/towing
+beams still get no tag at all, since they aren't a recognised component
+type either.
 """
 from __future__ import annotations
 
@@ -16,6 +21,15 @@ from pathlib import Path
 
 import pytest
 from lxml import etree as ET
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+from src.utils.tag_builder import (  # noqa: E402
+    DEFAULT_TAG_CONFIGS,
+    ElementSpec,
+    TagConfig,
+)
 
 pytestmark = pytest.mark.unit
 
@@ -111,3 +125,56 @@ class TestShipWeaponTagDamageRequirement:
         if tag is None:
             pytest.skip("ammo fixture too minimal for _ammo_damage_breakdown")
         assert tag.startswith("[") and tag.endswith("]")
+
+
+class TestShipWeaponTagMiningLaser:
+    """Mining lasers live in ships/weapons/ alongside combat weapons but
+    have no ammo/damage breakdown, so the damage-required guard above
+    would otherwise skip them entirely. They ARE a real component type
+    with a real Size though, so #266 tags them via the component
+    Type+Size shape (``[ML-S1]`` under default styles) instead."""
+
+    def _mining_laser_xml(self, name_attr: str = "Greycat_MiningLaser_Arbor"):
+        xml = (
+            f'<EntityClassDefinition Name="{name_attr}">'
+            '  <Components>'
+            '    <SEntityComponentMiningLaserParams/>'
+            '  </Components>'
+            '</EntityClassDefinition>'
+        )
+        return ET.fromstring(xml)
+
+    def test_mining_laser_gets_component_type_size_tag(self, gen_module):
+        desc = "Manufacturer: Greycat Industrial\\nItem Type: Mining Laser \\nSize: 1\\n"
+        tagger = gen_module._ship_weapon_name_tag_factory(ammo_lookup={})
+        assert tagger(desc, self._mining_laser_xml()) == "[ML-S1]"
+
+    def test_respects_users_configured_components_style(self, gen_module):
+        """A user who's customised the "components" Type/Size styles (even
+        while leaving Type disabled for their sized components) gets those
+        same styles applied here, matching the fuel-nozzle bare-type tag
+        behaviour (#266)."""
+        comp_cfg = DEFAULT_TAG_CONFIGS["components"]
+        custom_cfg = TagConfig(
+            elements=[
+                ElementSpec("type", False, "long"),
+                ElementSpec("size", True, "n"),
+            ],
+            separator=comp_cfg.separator,
+            enclosing=comp_cfg.enclosing,
+            placement=comp_cfg.placement,
+            class_mapping=comp_cfg.class_mapping,
+        )
+        desc = "Item Type: Mining Laser \\nSize: 1\\n"
+        tagger = gen_module._ship_weapon_name_tag_factory(
+            ammo_lookup={}, mining_laser_config=custom_cfg,
+        )
+        assert tagger(desc, self._mining_laser_xml()) == "[Mining Laser-1]"
+
+    def test_mining_laser_without_marker_falls_through_to_no_tag(self, gen_module):
+        """Sanity guard: only entities carrying the mining-laser marker get
+        this fallback — a plain no-damage item (tractor beam etc.) is
+        untouched, per the existing damage-required guard."""
+        beam_xml = ET.fromstring('<EntityClassDefinition Name="ARGO_TowingBeam_S3"/>')
+        tagger = gen_module._ship_weapon_name_tag_factory(ammo_lookup={})
+        assert tagger("Item Type: Towing Beam\\nSize: 3\\n", beam_xml) is None


### PR DESCRIPTION
## Summary
- Adds short/medium/long Tag Builder support for three blueprint-bearing item types that previously never got tags: **Fuel Nozzle** (`FN`/`FNoz`/`Fuel Nozzle`), **Mining Laser** (`ML`/`MineL`/`Mining Laser`), and **Scraper Module** (`SCM`/`ScrMod`/`Scraper Module`). All three are gated by the existing Components → Type toggle (opt-in, off by default) and respect the user's configured abbreviation style. Closes #266.
- Fuel nozzles and scraper modules carry no `Size:`/`Grade:`/`Class:` line, so a new base.ini-only pass (`enhancements_bare_type_tags`) tags them by their description's own `Item Type:` text — robust across CIG's multiple per-manufacturer key conventions (`item_fuelnozzle_*` vs `Nozzle_FuelGiver_*`). Mining lasers live in `ships/weapons/` with no damage breakdown, so the ship-weapon tagger gained a component-style Type+Size branch for them.
- Tags now appear in **both** places a player sees the item: its own name (String Editor / loadout screens) *and* the in-game mission POTENTIAL BLUEPRINTS bullet list — the mission-bullet weaving path (`build_scitem_lookups` → `entity_name_tags`) gained the same bare-type/mining-laser support via shared helpers so the two paths can't drift.

### Blueprint-parsing bugs found and fixed along the way (all confirmed against real game data)
- **"Awarded from X level variants" reputation-tier sub-headers** were mistaken for section boundaries, truncating the blueprint scan before any bullets were read — affected dozens of missions (Adagio salvage, Bounty Hunters Guild, Security, …), whose items were entirely absent from the Blueprint Tracker.
- **"MULTIPLE BLUEPRINT POOLS"** — a second, entirely different mission header CIG uses on 35 fixture missions — wasn't recognized at all; those missions were never scanned. Also recognizes their `Pool 1`/`Pool 2` sub-labels, and the String Editor's "BP Descriptions" filter now matches them too.
- **Bullet category annotations** (`Bendix (Fuel Nozzle)`, `5CA 'Akura' (Shield)`, `(Salvage Mod)`, …) that never appear on the real item name are now stripped during normalization, so bullets join their real tagged entries instead of creating duplicate untagged "Other" rows.
- **CIG's de-slugified-key bullet bug** (`Nozzle Fuelgiver Grin Nozzleveryfast` printed instead of "Lindstrom") is reversed generically via a key-slug transform, plus a small alias table for genuine one-off mismatches (the Mining Head family: `Helix` → "S0 Helix", `Hofstede` → "S00 Hofstede", `Arbor`, `Klein`).
- Blueprint Tracker now recognizes the non-standard Name-key conventions these items use, so their `tagged_name` shows correctly there as well.

## Testing Checklist
- [x] PR is scoped to one concern (one feature + the blueprint-parsing fixes it directly required)
- [x] `pytest tests/` passes locally (1229 passed on this branch)
- [ ] App launches: `python src/main.py`
- [x] Affected user-facing flow exercised manually (extensive per-build testing on a real HOTFIX install — String Editor tags, Blueprint Tracker list, in-game mission text)
- [ ] User-facing strings, docs/HELP.md, docs/ABOUT.md, and src/gui/coach_mark.py reviewed for drift
- [x] New non-exempt code has matching test coverage in tests/ (5 new/expanded test files, ~60 new tests)
- [x] Target branch is the active release/2.3.0, not main
- [x] No direct QSettings calls, no hard-coded column indices, no QProgressBar.setValue() from workers
- [x] No new enhancement category (rides the existing components pipeline — CATEGORY_SUBTREES/DATAFORGE_KEEP_SUBPATHS unchanged by design)
- [ ] VERSION.TXT matches the active release branch

## Testing performed
Iteratively tested across multiple portable builds on a real install by the reporter: fuel nozzle tags across all 8 nozzles (both key conventions), mining laser tags, scraper module tags, Blueprint Tracker joins for previously-garbled/absent bullets, and in-game mission text after regeneration. Each report of a missed case in this thread became a regression test.

## Post-merge QA
- [ ] Regenerate + apply on a real install; confirm `[FN]`-style tags appear on fuel nozzles/mining lasers/scraper modules in both the item names and mission blueprint lists (with Components → Type enabled)
- [ ] Confirm reputation-tier and multi-pool missions (Adagio salvage, mining purchase orders) list their blueprints in the Blueprint Tracker
- [ ] Confirm no double-tagging on Shield/Cooler/PowerPlant components (bare-type allow-list is deliberately narrow)

---
🤖 PR description generated with [Claude Code](https://claude.com/claude-code) and reviewed by @Stealrull