### PR TITLE
[#265] Add Combat Clothing category to Blueprint Tracker's Type filter

### DIFF
--- a/src/utils/blueprint_meta.py
+++ b/src/utils/blueprint_meta.py
@@ -112,7 +112,19 @@ _ITEM_NAME_PREFIX = "item_Name"
 _TYPE_FPS_WEAPON = "FPS Weapon"
 _TYPE_SHIP_WEAPON = "Ship Weapon"
 _TYPE_ARMOR = "Armor"
+_TYPE_CLOTHING = "Combat Clothing"
 _TYPE_OTHER = "Other"
+
+# Combat Clothing (#265): a non-armor wardrobe line introduced in SC 4.9,
+# distinct from real protective Armor. Only four known blueprints today,
+# all sharing the "hdtc" line token: item_Name_m_hdtc_jacket_01_01_01,
+# ..._shirt_02_01_01, ..._pants_01_01_01, ..._shoes_01_01_01 (confirmed
+# live in-game, no older reference fixture has this category yet). None
+# of "jacket"/"shirt"/"pants"/"shoes" are armor-piece words in
+# _ARMOR_GEAR_WORDS/_ARMOR_EXTRA_WORDS, so without this they fell into
+# the catch-all "Other" bucket. Extend this tuple if CIG ships the line
+# under additional tokens later.
+_CLOTHING_KEY_TOKENS = ("_hdtc_",)
 
 # Friendly labels for the component type codes that appear right after
 # ``item_Name`` / ``item_Name_`` in a component loc key. Codes not in this map
@@ -238,9 +250,10 @@ def blueprint_type_from_key(key: str):
     """Coarse type bucket for a blueprint item from its matched name key.
 
     A recognized ship-component code wins (Shield / Quantum Drive / ...), then
-    FPS weapon and armor by key tokens. Returns ``None`` for anything else, so
-    the caller can fold it into the "Other" bucket. ``None`` key (the bullet
-    name matched no loaded name entry) is also ``None`` -> "Other".
+    FPS weapon, Combat Clothing, and armor by key tokens. Returns ``None`` for
+    anything else, so the caller can fold it into the "Other" bucket. ``None``
+    key (the bullet name matched no loaded name entry) is also ``None`` ->
+    "Other".
     """
     if not key:
         return None
@@ -250,6 +263,8 @@ def blueprint_type_from_key(key: str):
     kl = key.lower()
     if any(w in kl for w in _FPS_WEAPON_WORDS):
         return _TYPE_FPS_WEAPON
+    if any(w in kl for w in _CLOTHING_KEY_TOKENS):
+        return _TYPE_CLOTHING
     if any(w in kl for w in _ARMOR_GEAR_WORDS) or any(w in kl for w in _ARMOR_EXTRA_WORDS):
         return _TYPE_ARMOR
     # Ship weapons (#212): an uppercase-manufacturer ship item (item_Name<UPPER>…)

--- a/tests/test_blueprint_meta.py
+++ b/tests/test_blueprint_meta.py
@@ -165,6 +165,21 @@ def test_blueprint_type_gys_jacket_and_pants():
     assert blueprint_type_from_key("item_Desc_DMC_Pants_01_01_01") is None
 
 
+def test_blueprint_type_combat_clothing():
+    """SC 4.9 introduced a non-armor "Combat Clothing" wardrobe line
+    (#265) -- confirmed live in-game, the only four blueprints today all
+    share the "hdtc" line token. None of jacket/shirt/pants/shoes are
+    armor-piece words, so without this they fell into "Other"."""
+    assert blueprint_type_from_key("item_Name_m_hdtc_jacket_01_01_01") == "Combat Clothing"
+    assert blueprint_type_from_key("item_Name_m_hdtc_shirt_02_01_01") == "Combat Clothing"
+    assert blueprint_type_from_key("item_Name_m_hdtc_pants_01_01_01") == "Combat Clothing"
+    assert blueprint_type_from_key("item_Name_m_hdtc_shoes_01_01_01") == "Combat Clothing"
+    # Scoped to the "hdtc" line token specifically — bare jacket/pants
+    # words from unrelated manufacturers must not be swept in.
+    assert blueprint_type_from_key("item_Name_987_jacket_01_01_01") is None
+    assert blueprint_type_from_key("item_Name_DMC_pants_01_01_01") is None
+
+
 def test_clean_mission_title_strips_reward_tags():
     raw = ("Salvager Needed (Lrg. Special Order) "
            "<EM4>[BP]</EM4> <EM4>[150 REP]</EM4>")


### PR DESCRIPTION
## Summary
- Adds a "Combat Clothing" bucket to the Blueprint Tracker's Type filter for the non-armor wardrobe line introduced in SC 4.9. Closes #265.
- The Type dropdown is fully dynamic (populated from whatever distinct values `blueprint_type_from_key()` returns), so this is a classification-only change in `src/utils/blueprint_meta.py` — no GUI code touched, same pattern as the earlier Ammo bucket (#249).
- Detection is scoped to the `_hdtc_` line token shared by all four known blueprints (`item_Name_m_hdtc_jacket/shirt/pants/shoes_*`, confirmed live in-game) rather than bare `jacket`/`pants` words, which would sweep in hundreds of unrelated civilian wardrobe items.

## Testing Checklist
- [x] PR is scoped to one concern (single feature)
- [x] `pytest tests/` passes locally (1188 passed on this branch)
- [ ] App launches: `python src/main.py`
- [ ] Affected user-facing flow exercised manually: Blueprint Tracker → Type dropdown shows "Combat Clothing" and filters the four hdtc items
- [ ] User-facing strings, docs/HELP.md, docs/ABOUT.md, and src/gui/coach_mark.py reviewed for drift (HELP.md's filter description is a non-exhaustive example list; no update needed)
- [x] New non-exempt code has matching test coverage in tests/ (test_blueprint_type_combat_clothing, incl. negative controls)
- [x] Target branch is the active release/2.3.0, not main
- [x] No direct QSettings calls, no hard-coded column indices, no QProgressBar.setValue() from workers
- [x] Not an enhancement category — CATEGORY_SUBTREES/DATAFORGE_KEEP_SUBPATHS not applicable
- [ ] VERSION.TXT matches the active release branch

## Testing performed
Unit tests cover all four real item keys plus negative controls proving unrelated `jacket`/`pants` keys from other manufacturers stay out of the bucket. Included in the reporter's cumulative portable test builds.

## Post-merge QA
- [ ] On a real install, confirm the four SC 4.9 combat clothing blueprints appear under Type → Combat Clothing instead of Other
- [ ] Confirm existing Armor items did not move buckets

---
🤖 PR description generated with [Claude Code](https://claude.com/claude-code) and reviewed by @Stealrull