### PR TITLE
Fix crash: tr() kwarg named 'key' collides with its own first parameter

### DIFF
--- a/languages/english/ui.json
+++ b/languages/english/ui.json
@@ -1055,7 +1055,7 @@
       "at": ""
     },
     "custom_value_prompt": {
-      "ht": "Enter custom value for key:\n{key}",
+      "ht": "Enter custom value for key:\n{loc_key}",
       "at": ""
     },
     "auto_add_summary": {

--- a/languages/french/ui.json
+++ b/languages/french/ui.json
@@ -1029,8 +1029,8 @@
       "at": "Valeur personnalisée"
     },
     "custom_value_prompt": {
-      "ht": "Entrez une valeur personnalisée pour la clé :\n{key}",
-      "at": "Entrez une valeur personnalisée pour la clé :\n{key}"
+      "ht": "Entrez une valeur personnalisée pour la clé :\n{loc_key}",
+      "at": "Entrez une valeur personnalisée pour la clé :\n{loc_key}"
     },
     "auto_add_summary": {
       "ht": "{count} clés seront ajoutées automatiquement.",

--- a/languages/portuguese_br/ui.json
+++ b/languages/portuguese_br/ui.json
@@ -1029,8 +1029,8 @@
       "at": "Valor Personalizado"
     },
     "custom_value_prompt": {
-      "ht": "Insira um valor personalizado para a chave:\n{key}",
-      "at": "Insira um valor personalizado para a chave:\n{key}"
+      "ht": "Insira um valor personalizado para a chave:\n{loc_key}",
+      "at": "Insira um valor personalizado para a chave:\n{loc_key}"
     },
     "auto_add_summary": {
       "ht": "{count} chaves serão adicionadas automaticamente.",

--- a/languages/spanish/ui.json
+++ b/languages/spanish/ui.json
@@ -1029,7 +1029,7 @@
       "at": ""
     },
     "custom_value_prompt": {
-      "ht": "Introduce un valor personalizado para la clave:\n{key}",
+      "ht": "Introduce un valor personalizado para la clave:\n{loc_key}",
       "at": ""
     },
     "auto_add_summary": {

--- a/src/gui/import_dialog.py
+++ b/src/gui/import_dialog.py
@@ -149,7 +149,7 @@ class ImportConflictDialog(QDialog):
             initial = self._custom_values.get(key, imported_val)
             text, ok = QInputDialog.getText(
                 self, tr("import_dialog.custom_value_title"),
-                tr("import_dialog.custom_value_prompt", key=key),
+                tr("import_dialog.custom_value_prompt", loc_key=key),
                 text=initial)
             if ok:
                 self._custom_values[key] = text

--- a/src/utils/i18n.py
+++ b/src/utils/i18n.py
@@ -116,13 +116,20 @@ def set_language(lang: str) -> None:
     logger.debug(f"i18n: UI language set to {lang!r}")
 
 
-def tr(key: str, **kwargs) -> str:
-    """Return the translated string for *key*.
+def tr(i18n_key: str, **kwargs) -> str:
+    """Return the translated string for *i18n_key*.
 
     Supports dot-separated paths: ``tr("toolbar.apply_btn")``.
     Interpolates *kwargs* using str.format — e.g.
     ``tr("config.p4k_status_found_with_base", date="2025-01-01")``.
-    Returns the bare *key* if not found anywhere so callers never crash.
+    Returns the bare *i18n_key* if not found anywhere so callers never crash.
+
+    Named ``i18n_key`` rather than the more natural ``key`` so a caller
+    interpolating a loc key into the message text (a very natural thing to
+    show in a UI string) can freely pass ``key=...`` as a kwarg without
+    colliding with this function's own first parameter (crashed as
+    ``TypeError: tr() got multiple values for argument 'key'`` — see
+    import_dialog.py's custom_value_prompt call).
     """
     global _strings
     if not _strings:
@@ -130,22 +137,22 @@ def tr(key: str, **kwargs) -> str:
         # by tests, CLI-adjacent utils) get English instead of bare keys.
         set_language(_current_lang)
     node = _strings
-    for part in key.split("."):
+    for part in i18n_key.split("."):
         if not isinstance(node, dict) or _is_leaf(node):
             node = None
             break
         node = node.get(part)
 
     if node is None:
-        logger.debug(f"i18n: missing key {key!r} (lang={_current_lang!r})")
-        return key
+        logger.debug(f"i18n: missing key {i18n_key!r} (lang={_current_lang!r})")
+        return i18n_key
 
     # Leaf -> ht (preferred) or at (fallback); legacy plain string -> itself.
     # A non-leaf section dict resolves to "" and falls through to the bare key.
     val = _leaf_value(node)
     if val == "":
-        logger.debug(f"i18n: empty/blank key {key!r} (lang={_current_lang!r})")
-        return key
+        logger.debug(f"i18n: empty/blank key {i18n_key!r} (lang={_current_lang!r})")
+        return i18n_key
 
     if kwargs:
         try:

--- a/tests/test_i18n.py
+++ b/tests/test_i18n.py
@@ -71,6 +71,18 @@ class TestTr:
         i18n.set_language("english")
         assert i18n.tr("toolbar.apply_btn.deeper") == "toolbar.apply_btn.deeper"
 
+    def test_kwarg_named_key_does_not_collide(self, lang_root):
+        """Crash report: tr()'s own first parameter used to be named "key",
+        so a caller passing the dot-path positionally and also interpolating
+        a loc key into the message text via key=... (a very natural thing to
+        show in a UI string, e.g. import_dialog.py's custom_value_prompt)
+        raised TypeError: tr() got multiple values for argument 'key' before
+        the function body ever ran. Renamed to i18n_key so "key" is free."""
+        i18n.set_language("english")
+        assert (
+            i18n.tr("toolbar.apply_btn", key="some.loc.key") == "Apply to Game"
+        )
+
     def test_kwargs_interpolation(self, lang_root):
         i18n.set_language("english")
         assert (


### PR DESCRIPTION
## Summary
- Crash report: opening the "Custom..." resolution in Import INI and entering a value raises `TypeError: tr() got multiple values for argument 'key'`. `import_dialog.py`'s `custom_value_prompt` call already exists on `release/2.2.1` as `tr("import_dialog.custom_value_prompt", key=key)` — passing a loc key as an interpolation variable is natural, but `tr(key: str, **kwargs)` has its own first parameter also named `key`, so Python rejects the call before the function body ever runs.
- Renames `tr()`'s own parameter to `i18n_key` so `key` is free for any caller, and fixes the one existing crashing call site plus its `{key}` → `{loc_key}` placeholder across all four locale files.
- Scoped narrowly to this one pre-existing crash. A second, unrelated `tr()`-with-`key=` collision in `main_window.py`'s "Copy Key" action only exists once the #247 hardcoded-string sweep converts that line from a plain f-string to a `tr()` call — that lands alongside the sweep itself in a separate PR, not here.

## Testing Checklist
- [x] PR is scoped to one concern (single crash fix)
- [x] `pytest tests/` passes locally (full suite 1205 passed, 16 skipped)
- [ ] App launches: `python src/main.py`
- [ ] Affected user-facing flow exercised manually (Import INI > Custom... resolution)
- [x] New non-exempt code has matching test coverage in `tests/`
- [x] Target branch is `release/2.2.1`, the active patch branch, not `main`

## Testing performed
Automated: full test suite green. Manual verification of the Import INI Custom... flow is still needed — flagging for the user's own testing pass.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)