### PR TITLE
[#281] Fix garbled fuel nozzle names in mission POTENTIAL BLUEPRINTS lists

### DIFF
--- a/scripts/generate_enhancements_ini.py
+++ b/scripts/generate_enhancements_ini.py
@@ -2991,6 +2991,28 @@ def _merge_blueprint_pool(
             existing_items.append(item)
 
 
+# Fuel nozzles hit the filename-fallback tier (#281): their entityClass UUID
+# doesn't resolve in entity_names, and entity_names_by_filename also misses
+# for reasons CIG's own data doesn't make obvious, so every fuel nozzle
+# reward fell all the way through to _name_from_blueprint_filename's
+# title-cased slug -- visible in-game as "Nozzle Fuelgiver Grin Nozzlefast"
+# etc. in a mission's POTENTIAL BLUEPRINTS list instead of the real
+# manufacturer name. Confirmed via a live "URGENT REFUEL REQUEST" mission
+# body listing all 8 variants this way. Keyed by the exact fallback string
+# this function produces (title-cased, space-separated) so it's a pure
+# post-processing correction with no effect on any other blueprint type.
+_BLUEPRINT_FILENAME_FALLBACK_ALIASES = {
+    "Nozzle Fuelgiver Grin Nozzlefast": "Norfield",
+    "Nozzle Fuelgiver Grin Nozzlesecure": "Marlin",
+    "Nozzle Fuelgiver Grin Nozzleveryfast": "Lindstrom",
+    "Nozzle Fuelgiver Grin Nozzleverysecure": "Harkin",
+    "Nozzle Fuelgiver Misc Nozzlestandard": "RN-7s",
+    "Nozzle Fuelgiver Shin Nozzleexpensivefast": "Bendix",
+    "Nozzle Fuelgiver Shin Nozzleexpensivesecure": "Torrez",
+    "Nozzle Fuelgiver Shin Nozzlemostexpensive": "Ezra",
+}
+
+
 def _name_from_blueprint_filename(bp_xml: Path) -> str:
     """Best-effort fallback display name from a blueprint XML's filename.
 
@@ -3002,7 +3024,7 @@ def _name_from_blueprint_filename(bp_xml: Path) -> str:
 
     Examples:
         bp_craft_nozzle_fuelgiver_grin_nozzlefast.xml
-            → "Nozzle Fuelgiver Grin Nozzlefast"
+            → "Norfield" (known alias — see _BLUEPRINT_FILENAME_FALLBACK_ALIASES)
         bp_craft_salvage_modifier_scraper_large.xml
             → "Salvage Modifier Scraper Large"
         bp_rewards_eckhartsecuritykillnpcboss.xml
@@ -3016,7 +3038,8 @@ def _name_from_blueprint_filename(bp_xml: Path) -> str:
             stem = stem[len(prefix):]
             break
     # Replace separators with spaces and title-case.
-    return stem.replace("_", " ").replace("-", " ").title()
+    fallback = stem.replace("_", " ").replace("-", " ").title()
+    return _BLUEPRINT_FILENAME_FALLBACK_ALIASES.get(fallback, fallback)
 
 
 def build_blueprint_pool_lookup(

--- a/tests/test_blueprint_filename_fallback.py
+++ b/tests/test_blueprint_filename_fallback.py
@@ -1,0 +1,66 @@
+"""Tests for _name_from_blueprint_filename's fuel-nozzle alias correction (#281).
+
+Fuel nozzle blueprint rewards miss both the UUID and filename entity-name
+resolution tiers in build_blueprint_pool_lookup, falling through to this
+function's title-cased-slug fallback -- confirmed live in-game via an
+"URGENT REFUEL REQUEST" mission listing all 8 variants as raw garbled text
+(e.g. "Nozzle Fuelgiver Grin Nozzlefast") instead of their real names.
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture(scope="module")
+def gen_module():
+    repo_root = Path(__file__).resolve().parent.parent
+    script_path = repo_root / "scripts" / "generate_enhancements_ini.py"
+    spec = importlib.util.spec_from_file_location(
+        "generate_enhancements_ini_bp_filename_fallback_test", script_path,
+    )
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class TestFuelNozzleFallbackAliases:
+    @pytest.mark.regression
+    @pytest.mark.parametrize("filename,expected", [
+        ("bp_craft_nozzle_fuelgiver_grin_nozzlefast.xml", "Norfield"),
+        ("bp_craft_nozzle_fuelgiver_grin_nozzlesecure.xml", "Marlin"),
+        ("bp_craft_nozzle_fuelgiver_grin_nozzleveryfast.xml", "Lindstrom"),
+        ("bp_craft_nozzle_fuelgiver_grin_nozzleverysecure.xml", "Harkin"),
+        ("bp_craft_nozzle_fuelgiver_misc_nozzlestandard.xml", "RN-7s"),
+        ("bp_craft_nozzle_fuelgiver_shin_nozzleexpensivefast.xml", "Bendix"),
+        ("bp_craft_nozzle_fuelgiver_shin_nozzleexpensivesecure.xml", "Torrez"),
+        ("bp_craft_nozzle_fuelgiver_shin_nozzlemostexpensive.xml", "Ezra"),
+    ])
+    def test_known_fuel_nozzle_fallback_resolves_to_real_name(self, gen_module, filename, expected):
+        assert gen_module._name_from_blueprint_filename(Path(filename)) == expected
+
+
+class TestUnrelatedFilenameFallbackUnaffected:
+    def test_non_nozzle_fallback_still_title_cased(self, gen_module):
+        """Regression guard: the alias correction must not touch any other
+        blueprint's filename-derived fallback name."""
+        assert (
+            gen_module._name_from_blueprint_filename(
+                Path("bp_craft_salvage_modifier_scraper_large.xml")
+            )
+            == "Salvage Modifier Scraper Large"
+        )
+
+    def test_bp_rewards_prefix_still_stripped(self, gen_module):
+        assert (
+            gen_module._name_from_blueprint_filename(
+                Path("bp_rewards_eckhartsecuritykillnpcboss.xml")
+            )
+            == "Eckhartsecuritykillnpcboss"
+        )


### PR DESCRIPTION
## Summary
- CIG bug: all 8 fuel nozzle blueprint rewards miss both the UUID and filename entity-name resolution tiers in `build_blueprint_pool_lookup` (`scripts/generate_enhancements_ini.py`), falling through to `_name_from_blueprint_filename`'s title-cased-slug fallback.
- Confirmed live in-game via an "URGENT REFUEL REQUEST: Drake Cutter" mission body listing all 8 variants as raw garbled text ("Nozzle Fuelgiver Grin Nozzlefast", etc.) instead of their real manufacturer names, in the `global.ini` that Apply to Game actually writes.
- Adds a known-alias correction keyed by the exact fallback string this function produces, scoped only to the 8 confirmed fuel nozzle variants — does not touch resolution for any other blueprint type.
- Distinct from (and a separate bug class than) the general Blueprint Tracker bullet-matching fixes in #278: that PR only affects Smart Citizen's own Blueprint Tracker tab display and never touches in-game mission text; this fix changes what's actually generated and applied to the game.

Closes #281.

## Testing Checklist
- [x] PR is scoped to one concern (single fallback-name correction)
- [x] `pytest tests/` passes locally (full suite 1270 passed, 16 skipped; new file 10/10)
- [ ] App launches: `python src/main.py`
- [ ] Affected user-facing flow exercised manually (Generate Enhancements + Apply to Game, then check a fuel-nozzle-rewarding mission's POTENTIAL BLUEPRINTS list in-game)
- [x] New non-exempt code has matching test coverage in `tests/` (previously untested function)
- [x] Target branch is `release/2.2.1`, the active patch branch, not `main`

## Testing performed
Automated: full test suite green. Manual in-game verification (re-running Generate Enhancements + Apply to Game, then re-checking the exact mission from the bug report) is still needed — flagging for the user's own testing pass.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)